### PR TITLE
fix: ensure new domain created for initial transfer

### DIFF
--- a/src/handlers/Registry.ts
+++ b/src/handlers/Registry.ts
@@ -30,7 +30,8 @@ import { ROOT_NODE, makeSubnodeNamehash } from "../lib/subname-helpers";
  * execution will be: `linea`, `ethereum`, `base`.
  */
 export async function setupRootNode({ context }: { context: Context }) {
-  // ensure we have an account for the zeroAddress
+  // Each domain must reference an account of its owner,
+  // so we ensure the account exists before inserting the domain
   await upsertAccount(context, zeroAddress);
 
   // initialize the ENS root to be owned by the zeroAddress and not migrated
@@ -86,7 +87,8 @@ export async function handleTransfer({
 }) {
   const { node, owner } = event.args;
 
-  // ensure owner account
+  // Each domain must reference an account of its owner,
+  // so we ensure the account exists before inserting the domain
   await upsertAccount(context, owner);
 
   // ensure domain & update owner
@@ -119,7 +121,8 @@ export const handleNewOwner =
 
     const subnode = makeSubnodeNamehash(node, label);
 
-    // ensure owner
+    // Each domain must reference an account of its owner,
+    // so we ensure the account exists before inserting the domain
     await upsertAccount(context, owner);
 
     // note that we set isMigrated so that if this domain is being interacted with on the new registry, its migration status is set here

--- a/src/plugins/base.eth/handlers/Registrar.ts
+++ b/src/plugins/base.eth/handlers/Registrar.ts
@@ -17,26 +17,10 @@ const {
 
 export default function () {
   // support NameRegisteredWithRecord for BaseRegistrar as it used by Base's RegistrarControllers
-  ponder.on(pluginNamespace("BaseRegistrar:NameRegisteredWithRecord"), async ({ context, event }) =>
-    handleNameRegistered({ context, event }),
-  );
+  ponder.on(pluginNamespace("BaseRegistrar:NameRegisteredWithRecord"), handleNameRegistered);
 
-  ponder.on(pluginNamespace("BaseRegistrar:NameRegistered"), async ({ context, event }) => {
-    await upsertAccount(context, event.args.owner);
-    // Base has 'preminted' names via Registrar#registerOnly, which explicitly
-    // does not update the Registry. This breaks a subgraph assumption, as it
-    // expects a domain to exist (via Registry:NewOwner) before any
-    // Registrar:NameRegistered events. We insert the domain entity here,
-    // allowing the base indexer to progress.
-    await context.db.insert(schema.domain).values({
-      id: makeSubnodeNamehash(ownedSubnameNode, tokenIdToLabel(event.args.id)),
-      ownerId: event.args.owner,
-      createdAt: event.block.timestamp,
-    });
+  ponder.on(pluginNamespace("BaseRegistrar:NameRegistered"), handleNameRegistered);
 
-    // after ensuring the domain exists, continue with the standard handler
-    return handleNameRegistered({ context, event });
-  });
   ponder.on(pluginNamespace("BaseRegistrar:NameRenewed"), handleNameRenewed);
 
   ponder.on(pluginNamespace("BaseRegistrar:Transfer"), async ({ context, event }) => {
@@ -44,6 +28,8 @@ export default function () {
     const { id: tokenId, from, to } = event.args;
 
     if (event.args.from === zeroAddress) {
+      // ensure owner account
+      await upsertAccount(context, to);
       // The ens-subgraph `handleNameTransferred` handler implementation
       // assumes an indexed record for the domain already exists. However,
       // when an NFT token is minted (transferred from `0x0` address),

--- a/src/plugins/base.eth/handlers/Registrar.ts
+++ b/src/plugins/base.eth/handlers/Registrar.ts
@@ -28,7 +28,8 @@ export default function () {
     const { id: tokenId, from, to } = event.args;
 
     if (event.args.from === zeroAddress) {
-      // ensure owner account
+      // Each domain must reference an account of its owner,
+      // so we ensure the account exists before inserting the domain
       await upsertAccount(context, to);
       // The ens-subgraph `handleNameTransferred` handler implementation
       // assumes an indexed record for the domain already exists. However,

--- a/src/plugins/linea.eth/handlers/EthRegistrar.ts
+++ b/src/plugins/linea.eth/handlers/EthRegistrar.ts
@@ -2,6 +2,7 @@ import { ponder } from "ponder:registry";
 import schema from "ponder:schema";
 import { zeroAddress } from "viem";
 import { makeRegistrarHandlers } from "../../../handlers/Registrar";
+import { upsertAccount } from "../../../lib/db-helpers";
 import { makeSubnodeNamehash, tokenIdToLabel } from "../../../lib/subname-helpers";
 import { ownedName, pluginNamespace } from "../ponder.config";
 
@@ -22,6 +23,8 @@ export default function () {
     const { tokenId, from, to } = event.args;
 
     if (event.args.from === zeroAddress) {
+      // ensure owner account
+      await upsertAccount(context, to);
       // The ens-subgraph `handleNameTransferred` handler implementation
       // assumes an indexed record for the domain already exists. However,
       // when an NFT token is minted (transferred from `0x0` address),

--- a/src/plugins/linea.eth/handlers/EthRegistrar.ts
+++ b/src/plugins/linea.eth/handlers/EthRegistrar.ts
@@ -23,7 +23,8 @@ export default function () {
     const { tokenId, from, to } = event.args;
 
     if (event.args.from === zeroAddress) {
-      // ensure owner account
+      // Each domain must reference an account of its owner,
+      // so we ensure the account exists before inserting the domain
       await upsertAccount(context, to);
       // The ens-subgraph `handleNameTransferred` handler implementation
       // assumes an indexed record for the domain already exists. However,


### PR DESCRIPTION
base.eth & linea.eth plugins need to make sure that the initial Transfer event emitted by a respective registar contract results in creating a new domain entity in indexer's database.