### PR TITLE
fix(plugins): lazy-loaded config

### DIFF
--- a/src/plugins/base.eth/ponder.config.ts
+++ b/src/plugins/base.eth/ponder.config.ts
@@ -2,11 +2,7 @@ import { type ContractConfig, createConfig, factory } from "ponder";
 import { http } from "viem";
 import { base } from "viem/chains";
 
-import {
-  blockConfig,
-  rpcEndpointUrl,
-  rpcMaxRequestsPerSecond,
-} from "../../lib/helpers";
+import { blockConfig, rpcEndpointUrl, rpcMaxRequestsPerSecond } from "../../lib/helpers";
 import { createPluginNamespace } from "../../lib/plugin-helpers";
 import { BaseRegistrar } from "./abis/BaseRegistrar";
 import { EarlyAccessRegistrarController } from "./abis/EARegistrarController";

--- a/src/plugins/base.eth/ponder.config.ts
+++ b/src/plugins/base.eth/ponder.config.ts
@@ -2,7 +2,11 @@ import { type ContractConfig, createConfig, factory } from "ponder";
 import { http } from "viem";
 import { base } from "viem/chains";
 
-import { blockConfig, rpcEndpointUrl, rpcMaxRequestsPerSecond } from "../../lib/helpers";
+import {
+  blockConfig,
+  rpcEndpointUrl,
+  rpcMaxRequestsPerSecond,
+} from "../../lib/helpers";
 import { createPluginNamespace } from "../../lib/plugin-helpers";
 import { BaseRegistrar } from "./abis/BaseRegistrar";
 import { EarlyAccessRegistrarController } from "./abis/EARegistrarController";
@@ -21,10 +25,12 @@ const END_BLOCK: ContractConfig["endBlock"] = undefined;
 
 export const config = createConfig({
   networks: {
-    base: {
-      chainId: base.id,
-      transport: http(rpcEndpointUrl(base.id)),
-      maxRequestsPerSecond: rpcMaxRequestsPerSecond(base.id),
+    get base() {
+      return {
+        chainId: base.id,
+        transport: http(rpcEndpointUrl(base.id)),
+        maxRequestsPerSecond: rpcMaxRequestsPerSecond(base.id),
+      };
     },
   },
   contracts: {

--- a/src/plugins/eth/ponder.config.ts
+++ b/src/plugins/eth/ponder.config.ts
@@ -2,7 +2,11 @@ import { ContractConfig, createConfig, mergeAbis } from "ponder";
 import { http } from "viem";
 
 import { mainnet } from "viem/chains";
-import { blockConfig, rpcEndpointUrl, rpcMaxRequestsPerSecond } from "../../lib/helpers";
+import {
+  blockConfig,
+  rpcEndpointUrl,
+  rpcMaxRequestsPerSecond,
+} from "../../lib/helpers";
 import { createPluginNamespace } from "../../lib/plugin-helpers";
 import { BaseRegistrar } from "./abis/BaseRegistrar";
 import { EthRegistrarController } from "./abis/EthRegistrarController";
@@ -28,10 +32,12 @@ const REGISTRY_ADDRESS = "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e";
 
 export const config = createConfig({
   networks: {
-    mainnet: {
-      chainId: mainnet.id,
-      transport: http(rpcEndpointUrl(mainnet.id)),
-      maxRequestsPerSecond: rpcMaxRequestsPerSecond(mainnet.id),
+    get mainnet() {
+      return {
+        chainId: mainnet.id,
+        transport: http(rpcEndpointUrl(mainnet.id)),
+        maxRequestsPerSecond: rpcMaxRequestsPerSecond(mainnet.id),
+      };
     },
   },
   contracts: {

--- a/src/plugins/eth/ponder.config.ts
+++ b/src/plugins/eth/ponder.config.ts
@@ -2,11 +2,7 @@ import { ContractConfig, createConfig, mergeAbis } from "ponder";
 import { http } from "viem";
 
 import { mainnet } from "viem/chains";
-import {
-  blockConfig,
-  rpcEndpointUrl,
-  rpcMaxRequestsPerSecond,
-} from "../../lib/helpers";
+import { blockConfig, rpcEndpointUrl, rpcMaxRequestsPerSecond } from "../../lib/helpers";
 import { createPluginNamespace } from "../../lib/plugin-helpers";
 import { BaseRegistrar } from "./abis/BaseRegistrar";
 import { EthRegistrarController } from "./abis/EthRegistrarController";

--- a/src/plugins/linea.eth/ponder.config.ts
+++ b/src/plugins/linea.eth/ponder.config.ts
@@ -21,10 +21,12 @@ const END_BLOCK: ContractConfig["endBlock"] = undefined;
 
 export const config = createConfig({
   networks: {
-    linea: {
+    get linea() {
+      return {
       chainId: linea.id,
       transport: http(rpcEndpointUrl(linea.id)),
       maxRequestsPerSecond: rpcMaxRequestsPerSecond(linea.id),
+      };
     },
   },
   contracts: {

--- a/src/plugins/linea.eth/ponder.config.ts
+++ b/src/plugins/linea.eth/ponder.config.ts
@@ -23,9 +23,9 @@ export const config = createConfig({
   networks: {
     get linea() {
       return {
-      chainId: linea.id,
-      transport: http(rpcEndpointUrl(linea.id)),
-      maxRequestsPerSecond: rpcMaxRequestsPerSecond(linea.id),
+        chainId: linea.id,
+        transport: http(rpcEndpointUrl(linea.id)),
+        maxRequestsPerSecond: rpcMaxRequestsPerSecond(linea.id),
       };
     },
   },


### PR DESCRIPTION
Defer executing the networks config object for each plugin, so that the env vars validation could become optional and only done for the activated plugins.

Resolves #37