### PR TITLE
fix(ponder-build): move tests out the `src/` dir

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -35,3 +35,6 @@ jobs:
 
       - name: Run TypeScript type checks
         run: pnpm run typecheck
+
+      - name: Run Ponder build checks
+        run: pnpm codegen

--- a/src/plugins/eth/ponder.config.ts
+++ b/src/plugins/eth/ponder.config.ts
@@ -21,7 +21,7 @@ export const pluginNamespace = createPluginNamespace(ownedName);
 // constrain indexing between the following start/end blocks
 // https://ponder.sh/0_6/docs/contracts-and-networks#block-range
 const START_BLOCK: ContractConfig["startBlock"] = undefined;
-const END_BLOCK: ContractConfig["endBlock"] = 21_000_000;
+const END_BLOCK: ContractConfig["endBlock"] = undefined;
 
 const REGISTRY_OLD_ADDRESS = "0x314159265dd8dbb310642f98f50c066173c1259b";
 const REGISTRY_ADDRESS = "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e";

--- a/test/helpers.spec.ts
+++ b/test/helpers.spec.ts
@@ -8,7 +8,7 @@ import {
   parseRpcEndpointUrl,
   parseRpcMaxRequestsPerSecond,
   uniq,
-} from "./helpers";
+} from "../src/lib/helpers";
 
 describe("helpers", () => {
   describe("uniq", () => {

--- a/test/plugin-helpers.spec.ts
+++ b/test/plugin-helpers.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createPluginNamespace } from "./plugin-helpers";
+import { createPluginNamespace } from "../src/lib/plugin-helpers";
 
 describe("createPluginNamespace", () => {
   it("should return a function that creates namespaced contract names", () => {

--- a/test/subname-helpers.spec.ts
+++ b/test/subname-helpers.spec.ts
@@ -5,7 +5,7 @@ import {
   isLabelIndexable,
   makeSubnodeNamehash,
   tokenIdToLabel,
-} from "./subname-helpers";
+} from "../src/lib/subname-helpers";
 
 describe("isLabelIndexable", () => {
   it("should return false for labels containing unindexable characters", () => {


### PR DESCRIPTION
This is needed to avoid issues with ponder build process. If tests are included in the `src/` directory, ponder won't be able to start indexing:

<img width="1251" alt="image" src="https://github.com/user-attachments/assets/70b47524-b49d-4c42-8348-e616a061578b" />

Also, this PR drops the end block limit on the `eth` plugin and adds new check to static analysis task on CI.
