### PR TITLE
fix: default to 100 for plurals without limit specified

### DIFF
--- a/packages/ponder-subgraph-api/src/graphql.ts
+++ b/packages/ponder-subgraph-api/src/graphql.ts
@@ -117,7 +117,8 @@ type PluralArgs = {
   orderDirection?: "asc" | "desc";
 };
 
-const DEFAULT_LIMIT = 50 as const;
+// NOTE: subgraph defaults to 100 entities in a plural
+const DEFAULT_LIMIT = 100 as const;
 const MAX_LIMIT = 1000 as const;
 
 const OrderDirectionEnum = new GraphQLEnumType({


### PR DESCRIPTION
self explanatory, fixes an issue tracked in #79 