### PR TITLE
fix: dont upsertAccount for multicoin address newAddress

### DIFF
--- a/apps/ensnode/src/handlers/Resolver.ts
+++ b/apps/ensnode/src/handlers/Resolver.ts
@@ -53,7 +53,6 @@ export async function handleAddressChanged({
   event: EventWithArgs<{ node: Node; coinType: bigint; newAddress: Hex }>;
 }) {
   const { node, coinType, newAddress } = event.args;
-  await upsertAccount(context, newAddress);
 
   const id = makeResolverId(event.log.address, node);
   const resolver = await upsertResolver(context, {


### PR DESCRIPTION
fixes #39 

i naively called `upsertAccount` for account values in MulticoinAddrChanged events, but that is both incorrect and unnecessary.

note the lack of Account access in this handler: https://github.com/ensdomains/ens-subgraph/blob/c8447914e8743671fb4b20cffe5a0a97020b3cee/src/resolver.ts#L59