### PR TITLE
fix(ci): merge docker build & push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Run unit tests
         run: pnpm -r test
 
-  ensrainbow-docker-build:
+  ensrainbow-docker-build-and-push:
     runs-on: ubuntu-latest
     needs: [static-analysis, unit-tests]
     # we only build the docker image after a push to the branch
@@ -95,37 +95,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Build Docker image for ENSRainbow app
+      - name: Build & Push Docker image for ENSRainbow app
         env:
           IMAGE_NAME: ghcr.io/${{ github.repository }}/ensrainbow
           TAG: ${{ github.ref == 'refs/heads/main' && 'latest' || github.ref == 'refs/heads/alpha' && 'alpha' || github.ref == 'refs/heads/subgraph' && 'subgraph' }}
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
           docker build -f apps/ensrainbow/Dockerfile -t $IMAGE_NAME:$TAG -t $IMAGE_NAME:${{ github.sha }} .
-          docker save $IMAGE_NAME:$TAG $IMAGE_NAME:${{ github.sha }} > image.tar
-
-      - name: Upload Docker image artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ensrainbow-docker-image
-          path: ensrainbow-docker-image.tar
-
-  ensrainbow-docker-push:
-    runs-on: ubuntu-latest
-    needs: [ensrainbow-docker-build]
-    
-    steps:
-      - name: Download Docker image artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ensrainbow-docker-image
-          
-      - name: Push Docker image for ENSRainbow app to GitHub Container Registry
-        env:
-          IMAGE_NAME: ghcr.io/${{ github.repository }}/ensrainbow
-          TAG: latest
-        run: |
-          docker load < ensrainbow-docker-image.tar
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
           docker push $IMAGE_NAME:$TAG
           docker push $IMAGE_NAME:${{ github.sha }}


### PR DESCRIPTION
This one allows saving a lot of space on the GitHub Action runtime and avoid "no space left on the device" error. Before this change, there would be separate steps for building Docker image, and for pushing it to container registry. It would require a temp file to be saved and shared between those files. This temp file was too large to fit on the available storage space.

Error:
- https://github.com/namehash/ensnode/actions/runs/13061577337/job/36445589428#step:3:316