### PR TITLE
fix: correctly implement dns packet decoding from subgraph

### DIFF
--- a/apps/ensnode/src/handlers/NameWrapper.ts
+++ b/apps/ensnode/src/handlers/NameWrapper.ts
@@ -20,9 +20,7 @@ const tokenIdToNode = (tokenId: bigint): Node => uint256ToHex32(tokenId);
 
 // if the wrappedDomain has PCC set in fuses, set domain's expiryDate to the greatest of the two
 async function materializeDomainExpiryDate(context: Context, node: Node) {
-  const wrappedDomain = await context.db.find(schema.wrappedDomain, {
-    id: node,
-  });
+  const wrappedDomain = await context.db.find(schema.wrappedDomain, { id: node });
   if (!wrappedDomain) throw new Error(`Expected WrappedDomain(${node})`);
 
   // NOTE: the subgraph has a helper function called [checkPccBurned](https://github.com/ensdomains/ens-subgraph/blob/master/src/nameWrapper.ts#L63)

--- a/packages/ensnode-utils/src/subname-helpers.spec.ts
+++ b/packages/ensnode-utils/src/subname-helpers.spec.ts
@@ -1,4 +1,4 @@
-import { IntegerOutOfRangeError, labelhash, namehash, toBytes, zeroHash } from "viem";
+import { IntegerOutOfRangeError, hexToBytes, labelhash, namehash, toBytes, zeroHash } from "viem";
 import { describe, expect, it } from "vitest";
 import {
   decodeDNSPacketBytes,
@@ -42,6 +42,14 @@ describe("decodeDNSPacketBytes", () => {
     // TODO: based on the definition of `isLabelIndexable` the empty label ("")
     // is not indexable, however this test case returns ["", ""] instead of [null, null]
     // expect(decodeDNSPacketBytes(toBytes(""))).toEqual([null, null]);
+  });
+
+  it("should handle previously bugged name", () => {
+    // this `name` from tx 0x2138cdf5fbaeabc9cc2cd65b0a30e4aea47b3961f176d4775869350c702bd401
+    expect(decodeDNSPacketBytes(hexToBytes("0x0831323333333232310365746800"))).toEqual([
+      "12333221",
+      "12333221.eth",
+    ]);
   });
 });
 


### PR DESCRIPTION
this fixes one of the issues in #79 regarding `WrappedDomain.name` being null — my original re-implementation of the dns packet decoding helper was subtly incorrect. this version goes line-by-line and mirrors the subgraph implementation more closely. i've included a test case to verify against the specific instance that surfaced this issue.

https://github.com/ensdomains/ens-subgraph/blob/master/src/nameWrapper.ts#L30