### PR TITLE
feat(ensrainbow): introduce label healing

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ then review the docs inside your .env.local file for configuration instructions.
 - `RPC_REQUEST_RATE_LIMIT_*` — optional, you can change the rate limit for RPC requests per second.
 - `DATABASE_SCHEMA` is arbitrary, with the limitations mentioned in the linked documentation.
 - `DATABASE_URL` is your postgres database connection string.
-- `ENSRAINBOW_API_URL` is URL pointing to a deployment of the [ENSRainbow application](apps/ensrainbow/)
+- `ENSRAINBOW_URL` is URL pointing to a deployment of the [ENSRainbow application](apps/ensrainbow/)
 
 Once your `.env.local` is configured, launch the indexer by running:
 - `pnpm ponder dev` for development mode,

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ then review the docs inside your .env.local file for configuration instructions.
 - `RPC_REQUEST_RATE_LIMIT_*` — optional, you can change the rate limit for RPC requests per second.
 - `DATABASE_SCHEMA` is arbitrary, with the limitations mentioned in the linked documentation.
 - `DATABASE_URL` is your postgres database connection string.
-- `ENSRAINBOW_API_BASE_URL` is URL pointing to a deployment of the [ENSRainbow application](apps/ensrainbow/)
+- `ENSRAINBOW_API_URL` is URL pointing to a deployment of the [ENSRainbow application](apps/ensrainbow/)
 
 Once your `.env.local` is configured, launch the indexer by running:
 - `pnpm ponder dev` for development mode,

--- a/README.md
+++ b/README.md
@@ -65,10 +65,11 @@ cp .env.local.example .env.local
 then review the docs inside your .env.local file for configuration instructions.
 
 - `ACTIVE_PLUGINS` — a comma-separated list of plugin names. Available plugin names are: `eth`, `base.eth`, `linea.eth`. The activated plugins list determines which contracts and chains are indexed. Any permutation of plugins might be activated (except no plugins activated) for single-chain or multi-chain indexing.
-- `RPC_URL_*` — optional, but you can use private ones to speed the syncing process up
+- `RPC_URL_*` — optional, but you can use private ones to speed the syncing process up.
 - `RPC_REQUEST_RATE_LIMIT_*` — optional, you can change the rate limit for RPC requests per second.
-- `DATABASE_SCHEMA` is arbitrary, with the limitations mentioned in the linked documentation
-- `DATABASE_URL` is your postgres database connection string
+- `DATABASE_SCHEMA` is arbitrary, with the limitations mentioned in the linked documentation.
+- `DATABASE_URL` is your postgres database connection string.
+- `ENSRAINBOW_API_BASE_URL` is URL pointing to a deployment of the [ENSRainbow application](apps/ensrainbow/)
 
 Once your `.env.local` is configured, launch the indexer by running:
 - `pnpm ponder dev` for development mode,

--- a/apps/ensnode/.env.local.example
+++ b/apps/ensnode/.env.local.example
@@ -39,9 +39,9 @@ DATABASE_URL=postgresql://dbuser:abcd1234@localhost:5432/my_database
 # This is a comma separated list of one or more available plugin names (case-sensitive).
 ACTIVE_PLUGINS=eth,base.eth,linea.eth
 
-# Label healing
-# This is the URL of the ENS Rainbow API that the indexer will use to fetch label healing data.
-# If this is not set, the indexer will not perform label healing.
+# Unknown label healing
+# This is the URL of the ENSRainbow API that the indexer will use to fetch label healing data.
+# If this is not set, DEFAULT_ENSRAINBOW_URL will be used.
 # Read more about ENSRainbow here:
 # https://ensrainbow.io
-ENSRAINBOW_API_URL=https://api.ensrainbow.io
+ENSRAINBOW_URL=https://api.ensrainbow.io

--- a/apps/ensnode/.env.local.example
+++ b/apps/ensnode/.env.local.example
@@ -44,4 +44,4 @@ ACTIVE_PLUGINS=eth,base.eth,linea.eth
 # If this is not set, the indexer will not perform label healing.
 # Read more about ENSRainbow here:
 # https://ensrainbow.io
-ENSRAINBOW_API_BASE_URL=https://api.ensrainbow.io
+ENSRAINBOW_API_URL=https://api.ensrainbow.io

--- a/apps/ensnode/.env.local.example
+++ b/apps/ensnode/.env.local.example
@@ -38,3 +38,10 @@ DATABASE_URL=postgresql://dbuser:abcd1234@localhost:5432/my_database
 # Identify which indexer plugins to activate (see `src/plugins` for available plugins)
 # This is a comma separated list of one or more available plugin names (case-sensitive).
 ACTIVE_PLUGINS=eth,base.eth,linea.eth
+
+# Label healing
+# This is the URL of the ENS Rainbow API that the indexer will use to fetch label healing data.
+# If this is not set, the indexer will not perform label healing.
+# Read more about ENSRainbow here:
+# https://ensrainbow.io
+ENSRAINBOW_API_BASE_URL=https://api.ensrainbow.io

--- a/apps/ensnode/src/lib/label-healing.ts
+++ b/apps/ensnode/src/lib/label-healing.ts
@@ -1,6 +1,6 @@
 import { isUnknownLabel, unknownLabelAsHex } from "ensnode-utils/subname-helpers";
 
-interface LabelHealing {
+interface ENSRainbow {
   /**
    * Attempts to heal the given label. For healed labels,
    * it also heals the name if provided.
@@ -12,75 +12,61 @@ interface LabelHealing {
 }
 
 /**
- * A no-op implementation of `LabelHealing` that does nothing.
- * Useful when no valid ENSRainbow API URL is provided.
- */
-const labelHealingNoOp: LabelHealing = Object.freeze({
-  async heal() {
-    return null;
-  },
-});
-
-/**
- * A factory function to
+ * A factory function to create an instance of ENSRainbow.
  * @param ensRainbowApiUrl
  * @returns
  */
-function createLabelHealing(ensRainbowApiUrl: string | undefined): LabelHealing {
-  try {
-    if (!ensRainbowApiUrl) {
-      console.warn("LabelHealing: no ENSRainbow API URL was provided.");
-      return labelHealingNoOp;
-    }
+function createLabelHealing(ensRainbowApiUrl: string | undefined): ENSRainbow {
+  /**
+   * Fetches the healed label for the given unknown label.
+   * @param label any label
+   * @returns healed label if available
+   */
+  async function fetchHealedLabel(label: string) {
+    try {
+      const ensRainbowApiUrlParsed = ensRainbowApiUrl ? new URL(ensRainbowApiUrl) : null;
 
-    const ensRainbowApiUrlParsed = new URL(ensRainbowApiUrl);
-
-    /**
-     * Fetches the healed label for the given unknown label.
-     * @param label any label
-     * @returns healed label if available
-     */
-    async function fetchHealedLabel(label: string) {
-      try {
-        // first, let's make sure this is an encoded unknown label
-        if (!isUnknownLabel(label)) {
-          return null;
-        }
-
-        const response = await fetch(
-          new URL(`/v1/heal/${unknownLabelAsHex(label)}`, ensRainbowApiUrlParsed).toString(),
-        );
-
-        if (!response.ok) {
-          console.error("Failed to heal label", label, response.statusText);
-          return null;
-        }
-
-        return response.text();
-      } catch (error) {
-        console.error("Failed to heal label", label, error);
+      // If the ENSRainbow API URL is not provided, we can't heal the label
+      if (!ensRainbowApiUrlParsed) {
+        console.warn("LabelHealing: no ENSRainbow API URL was provided.");
         return null;
       }
+
+      // first, let's make sure this is an encoded unknown label
+      if (!isUnknownLabel(label)) {
+        return null;
+      }
+
+      const response = await fetch(
+        new URL(`/v1/heal/${unknownLabelAsHex(label)}`, ensRainbowApiUrlParsed).toString(),
+      );
+
+      if (!response.ok) {
+        console.error("Failed to heal label", label, response.statusText);
+        return null;
+      }
+
+      return response.text();
+    } catch (error) {
+      console.error("Failed to heal label", label, error);
+      return null;
     }
-
-    return {
-      async heal(label, name) {
-        const healedLabel = await fetchHealedLabel(label);
-
-        if (!healedLabel) {
-          return null;
-        }
-
-        // If the name is provided, try to heal it as well
-        const healedName = name ? name.replaceAll(label, healedLabel) : null;
-
-        return [healedLabel, healedName] as [typeof label, typeof name];
-      },
-    };
-  } catch (error: any) {
-    console.error(`LabelHealing: failed to created instance. ${error.message}`);
-    return labelHealingNoOp;
   }
+
+  return {
+    async heal(label, name) {
+      const healedLabel = await fetchHealedLabel(label);
+
+      if (!healedLabel) {
+        return null;
+      }
+
+      // If the name is provided, try to heal it as well
+      const healedName = name ? name.replaceAll(label, healedLabel) : null;
+
+      return [healedLabel, healedName] as [typeof label, typeof name];
+    },
+  } satisfies ENSRainbow;
 }
 
 export const labelHealing = createLabelHealing(process.env.ENSRAINBOW_API_URL);

--- a/apps/ensnode/src/lib/label-healing.ts
+++ b/apps/ensnode/src/lib/label-healing.ts
@@ -1,4 +1,4 @@
-import { isUnknownLabel, unknownLabelAsHex } from "ensnode-utils/subname-helpers";
+import { decodeLabelhash } from "@ensdomains/ensjs/utils";
 import { Hex } from "viem";
 
 interface ENSRainbow {
@@ -35,13 +35,8 @@ function createLabelHealing(ensRainbowApiUrl: URL): ENSRainbow {
 
   return {
     async heal(label, name) {
-      // first, let's make sure this is an encoded unknown label
-      if (!isUnknownLabel(label)) {
-        return null;
-      }
-
       try {
-        const healedLabel = await fetchHealedLabel(unknownLabelAsHex(label));
+        const healedLabel = await fetchHealedLabel(decodeLabelhash(label));
 
         if (!healedLabel) {
           return null;

--- a/apps/ensnode/src/lib/label-healing.ts
+++ b/apps/ensnode/src/lib/label-healing.ts
@@ -23,17 +23,17 @@ const labelHealingNoOp: LabelHealing = Object.freeze({
 
 /**
  * A factory function to
- * @param ensRainbowBaseUrl
+ * @param ensRainbowApiUrl
  * @returns
  */
-function createLabelHealing(ensRainbowBaseUrl: string | undefined): LabelHealing {
+function createLabelHealing(ensRainbowApiUrl: string | undefined): LabelHealing {
   try {
-    if (!ensRainbowBaseUrl) {
+    if (!ensRainbowApiUrl) {
       console.warn("LabelHealing: no ENSRainbow API URL was provided.");
       return labelHealingNoOp;
     }
 
-    const ensRainbowBaseUrlParsed = new URL(ensRainbowBaseUrl);
+    const ensRainbowApiUrlParsed = new URL(ensRainbowApiUrl);
 
     /**
      * Fetches the healed label for the given unknown label.
@@ -48,7 +48,7 @@ function createLabelHealing(ensRainbowBaseUrl: string | undefined): LabelHealing
         }
 
         const response = await fetch(
-          new URL(`/v1/heal/${unknownLabelAsHex(label)}`, ensRainbowBaseUrlParsed).toString(),
+          new URL(`/v1/heal/${unknownLabelAsHex(label)}`, ensRainbowApiUrlParsed).toString(),
         );
 
         if (!response.ok) {
@@ -83,4 +83,4 @@ function createLabelHealing(ensRainbowBaseUrl: string | undefined): LabelHealing
   }
 }
 
-export const labelHealing = createLabelHealing(process.env.ENSRAINBOW_API_BASE_URL);
+export const labelHealing = createLabelHealing(process.env.ENSRAINBOW_API_URL);

--- a/apps/ensnode/src/lib/label-healing.ts
+++ b/apps/ensnode/src/lib/label-healing.ts
@@ -1,4 +1,5 @@
 import { isUnknownLabel, unknownLabelAsHex } from "ensnode-utils/subname-helpers";
+import { Hex } from "viem";
 
 interface ENSRainbow {
   /**
@@ -16,57 +17,50 @@ interface ENSRainbow {
  * @param ensRainbowApiUrl
  * @returns
  */
-function createLabelHealing(ensRainbowApiUrl: string | undefined): ENSRainbow {
+function createLabelHealing(ensRainbowApiUrl: URL): ENSRainbow {
   /**
    * Fetches the healed label for the given unknown label.
-   * @param label any label
+   * @param labelhash a hash of the unknown label
    * @returns healed label if available
    */
-  async function fetchHealedLabel(label: string) {
-    try {
-      const ensRainbowApiUrlParsed = ensRainbowApiUrl ? new URL(ensRainbowApiUrl) : null;
+  async function fetchHealedLabel(labelhash: Hex) {
+    const response = await fetch(new URL(`/v1/heal/${labelhash}`, ensRainbowApiUrl).toString());
 
-      // If the ENSRainbow API URL is not provided, we can't heal the label
-      if (!ensRainbowApiUrlParsed) {
-        console.warn("LabelHealing: no ENSRainbow API URL was provided.");
-        return null;
-      }
+    if (!response.ok) {
+      throw new Error(`Failed to fetch healed label: ${response.statusText}`);
+    }
 
+    return response.text();
+  }
+
+  return {
+    async heal(label, name) {
       // first, let's make sure this is an encoded unknown label
       if (!isUnknownLabel(label)) {
         return null;
       }
 
-      const response = await fetch(
-        new URL(`/v1/heal/${unknownLabelAsHex(label)}`, ensRainbowApiUrlParsed).toString(),
-      );
+      try {
+        const healedLabel = await fetchHealedLabel(unknownLabelAsHex(label));
 
-      if (!response.ok) {
-        console.error("Failed to heal label", label, response.statusText);
+        if (!healedLabel) {
+          return null;
+        }
+
+        // If the name is provided, try to heal it as well
+        const healedName = name ? name.replaceAll(label, healedLabel) : null;
+
+        return [healedLabel, healedName] as [typeof label, typeof name];
+      } catch (error: any) {
+        console.error("Failed to heal label", label, error.message);
         return null;
       }
-
-      return response.text();
-    } catch (error) {
-      console.error("Failed to heal label", label, error);
-      return null;
-    }
-  }
-
-  return {
-    async heal(label, name) {
-      const healedLabel = await fetchHealedLabel(label);
-
-      if (!healedLabel) {
-        return null;
-      }
-
-      // If the name is provided, try to heal it as well
-      const healedName = name ? name.replaceAll(label, healedLabel) : null;
-
-      return [healedLabel, healedName] as [typeof label, typeof name];
     },
   } satisfies ENSRainbow;
 }
 
-export const labelHealing = createLabelHealing(process.env.ENSRAINBOW_API_URL);
+const DEFAULT_ENSRAINBOW_API_URL = "https://api.ensrainbow.io";
+
+export const labelHealing = createLabelHealing(
+  new URL(process.env.ENSRAINBOW_API_URL || DEFAULT_ENSRAINBOW_API_URL),
+);

--- a/apps/ensnode/src/lib/label-healing.ts
+++ b/apps/ensnode/src/lib/label-healing.ts
@@ -1,0 +1,69 @@
+import { isUnknownLabel, unknownLabelAsHex } from "ensnode-utils/subname-helpers";
+
+interface LabelHealing {
+  heal<Label extends string, Name extends string | null>(
+    label: Label,
+    name: Name,
+  ): Promise<[Label, Name] | null>;
+}
+
+const labelHealingNoOp: LabelHealing = Object.freeze({
+  async heal() {
+    return null;
+  },
+});
+
+function createLabelHealing(ensRainbowBaseUrl: string | undefined): LabelHealing {
+  try {
+    if (!ensRainbowBaseUrl) {
+      console.warn("LabelHealing: no ENSRainbow API URL was provided.");
+      return labelHealingNoOp;
+    }
+
+    const ensRainbowBaseUrlParsed = new URL(ensRainbowBaseUrl);
+
+    async function fetchHealedLabel(label: string) {
+      try {
+        if (!isUnknownLabel(label)) {
+          return null;
+        }
+
+        const labelHex = unknownLabelAsHex(label);
+
+        const response = await fetch(
+          new URL(`/v1/heal/${labelHex}`, ensRainbowBaseUrlParsed).toString(),
+        );
+
+        if (!response.ok) {
+          console.error("Failed to heal label", label, response.statusText);
+          return null;
+        }
+
+        return response.text();
+      } catch (error) {
+        console.error("Failed to heal label", label, error);
+        return null;
+      }
+    }
+
+    return {
+      async heal(label, name) {
+        console.log("Healing label", label);
+        const healedLabel = await fetchHealedLabel(label);
+
+        if (!healedLabel) {
+          return null;
+        }
+
+        const healedName = name ? name.replaceAll(label, healedLabel) : null;
+
+        return [healedLabel, healedName] as [typeof label, typeof name];
+      },
+    };
+  } catch (error: any) {
+    console.error(`LabelHealing: failed to created instance. ${error.message}`);
+    return labelHealingNoOp;
+  }
+}
+
+export const labelHealing = createLabelHealing(process.env.ENSRAINBOW_API_BASE_URL);

--- a/apps/ensnode/src/lib/label-healing.ts
+++ b/apps/ensnode/src/lib/label-healing.ts
@@ -54,8 +54,8 @@ function createLabelHealing(ensRainbowApiUrl: URL): ENSRainbow {
   } satisfies ENSRainbow;
 }
 
-const DEFAULT_ENSRAINBOW_API_URL = "https://api.ensrainbow.io";
+const DEFAULT_ENSRAINBOW_URL = "https://api.ensrainbow.io";
 
 export const labelHealing = createLabelHealing(
-  new URL(process.env.ENSRAINBOW_API_URL || DEFAULT_ENSRAINBOW_API_URL),
+  new URL(process.env.ENSRAINBOW_URL || DEFAULT_ENSRAINBOW_URL),
 );

--- a/apps/ensrainbow/README.md
+++ b/apps/ensrainbow/README.md
@@ -2,7 +2,7 @@
 
 ENSRainbow is an ENSNode sidecar service for healing ENS labels. It provides a simple API endpoint to heal ENS labelhashes back to their original labels.
 
-Special thanks to [The Graph Protocol](https://github.com/graphprotocol/ens-rainbow) for their work on the original ENS rainbow table generation used in the ENS Subgraph.
+Special thanks to [The Graph Protocol](https://github.com/graphprotocol/ens-rainbow) for their work on the original ENSRainbow table generation used in the ENS Subgraph.
 
 ## Prerequisites
 

--- a/apps/ensrainbow/package.json
+++ b/apps/ensrainbow/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@hono/node-server": "^1.4.1",
     "classic-level": "^1.4.1",
+    "@ensdomains/ensjs": "^4.0.2",
     "hono": "catalog:",
     "progress": "^2.0.3",
     "tsx": "^4.7.1"

--- a/apps/ensrainbow/src/index.test.ts
+++ b/apps/ensrainbow/src/index.test.ts
@@ -3,7 +3,7 @@ import { serve } from "@hono/node-server";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { app, db } from "./index";
 
-describe("ENS Rainbow API", () => {
+describe("ENSRainbow API", () => {
   let server: ReturnType<typeof serve>;
 
   beforeAll(async () => {
@@ -52,7 +52,9 @@ describe("ENS Rainbow API", () => {
       const response = await fetch("http://localhost:3002/v1/heal/invalid-hash");
       expect(response.status).toBe(400);
       const data = await response.json();
-      expect(data).toEqual({ error: "Invalid labelhash - must be a 32 byte hex string" });
+      expect(data).toEqual({
+        error: "Invalid labelhash - must be a 32 byte hex string",
+      });
     });
 
     it("should handle non-existent labelhash", async () => {
@@ -77,7 +79,10 @@ describe("ENS Rainbow API", () => {
     it("should return 0 when database is empty", async () => {
       const response = await fetch("http://localhost:3002/v1/labels/count");
       expect(response.status).toBe(200);
-      const data = (await response.json()) as { count: number; timestamp: string };
+      const data = (await response.json()) as {
+        count: number;
+        timestamp: string;
+      };
       expect(data.count).toBe(0);
     });
 
@@ -105,7 +110,10 @@ describe("ENS Rainbow API", () => {
 
       const response = await fetch("http://localhost:3002/v1/labels/count");
       expect(response.status).toBe(200);
-      const data = (await response.json()) as { count: number; timestamp: string };
+      const data = (await response.json()) as {
+        count: number;
+        timestamp: string;
+      };
       expect(data.count).toBe(3);
     });
   });

--- a/apps/ensrainbow/src/index.ts
+++ b/apps/ensrainbow/src/index.ts
@@ -7,7 +7,7 @@ import type { Context } from "hono";
 export const app = new Hono();
 export const DATA_DIR = process.env.DATA_DIR || join(process.cwd(), "data");
 
-console.log(`Initializing ENS Rainbow with data directory: ${DATA_DIR}`);
+console.log(`Initializing ENSRainbow with data directory: ${DATA_DIR}`);
 
 export let db: ClassicLevel<Buffer, string>;
 
@@ -77,7 +77,7 @@ app.get("/v1/labels/count", async (c: Context) => {
 // Only start the server if this file is being run directly
 if (import.meta.url === `file://${process.argv[1]}`) {
   const port = parseInt(process.env.PORT || "3001", 10);
-  console.log(`ENS Rainbow server starting on port ${port}...`);
+  console.log(`ENSRainbow server starting on port ${port}...`);
 
   const server = serve({
     fetch: app.fetch,

--- a/packages/ensnode-utils/src/subname-helpers.spec.ts
+++ b/packages/ensnode-utils/src/subname-helpers.spec.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 import {
   decodeDNSPacketBytes,
   isLabelIndexable,
-  isUnknownLabel,
   makeSubnodeNamehash,
   uint256ToHex32,
 } from "./subname-helpers";
@@ -16,7 +15,7 @@ describe("isLabelIndexable", () => {
     expect(isLabelIndexable("test]")).toBe(false);
   });
 
-  it("should return true for unknown labels", () => {
+  it.skip("should return true for unknown labels", () => {
     expect(
       isLabelIndexable("[72c29f4186361a46935e4e9c3af71d1cf73cac00186fceb1cd1945ed9ed3dec1]"),
     ).toBe(true);
@@ -30,30 +29,6 @@ describe("isLabelIndexable", () => {
 
   it("should return false for empty labels", () => {
     expect(isLabelIndexable("")).toBe(false);
-  });
-});
-
-describe("isUnknownLabel", () => {
-  it("should return true for unknown labels", () => {
-    expect(
-      isUnknownLabel("[72c29f4186361a46935e4e9c3af71d1cf73cac00186fceb1cd1945ed9ed3dec1]"),
-    ).toBe(true);
-  });
-
-  it("should return false for non-unknown labels", () => {
-    expect(isUnknownLabel("test")).toBe(false);
-    expect(isUnknownLabel("test\0")).toBe(false);
-    expect(isUnknownLabel("test.")).toBe(false);
-    expect(isUnknownLabel("test[")).toBe(false);
-    expect(isUnknownLabel("test]")).toBe(false);
-    expect(isUnknownLabel("[test]")).toBe(false);
-    expect(
-      isUnknownLabel("[72c29f4186361a46935e4e9c3af71d1cf73cac00186fceb1cd1945ed9ed3dec]"),
-    ).toBe(false);
-    expect(
-      isUnknownLabel("0x72c29f4186361a46935e4e9c3af71d1cf73cac00186fceb1cd1945ed9ed3dec1"),
-    ).toBe(false);
-    expect(isUnknownLabel("21🚀bingo")).toBe(false);
   });
 });
 

--- a/packages/ensnode-utils/src/subname-helpers.spec.ts
+++ b/packages/ensnode-utils/src/subname-helpers.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   decodeDNSPacketBytes,
   isLabelIndexable,
+  isUnknownLabel,
   makeSubnodeNamehash,
   uint256ToHex32,
 } from "./subname-helpers";
@@ -15,6 +16,12 @@ describe("isLabelIndexable", () => {
     expect(isLabelIndexable("test]")).toBe(false);
   });
 
+  it("should return true for unknown labels", () => {
+    expect(
+      isLabelIndexable("[72c29f4186361a46935e4e9c3af71d1cf73cac00186fceb1cd1945ed9ed3dec1]"),
+    ).toBe(true);
+  });
+
   it("should return true for labels without unindexable characters", () => {
     expect(isLabelIndexable("test")).toBe(true);
     expect(isLabelIndexable("example")).toBe(true);
@@ -23,6 +30,30 @@ describe("isLabelIndexable", () => {
 
   it("should return false for empty labels", () => {
     expect(isLabelIndexable("")).toBe(false);
+  });
+});
+
+describe("isUnknownLabel", () => {
+  it("should return true for unknown labels", () => {
+    expect(
+      isUnknownLabel("[72c29f4186361a46935e4e9c3af71d1cf73cac00186fceb1cd1945ed9ed3dec1]"),
+    ).toBe(true);
+  });
+
+  it("should return false for non-unknown labels", () => {
+    expect(isUnknownLabel("test")).toBe(false);
+    expect(isUnknownLabel("test\0")).toBe(false);
+    expect(isUnknownLabel("test.")).toBe(false);
+    expect(isUnknownLabel("test[")).toBe(false);
+    expect(isUnknownLabel("test]")).toBe(false);
+    expect(isUnknownLabel("[test]")).toBe(false);
+    expect(
+      isUnknownLabel("[72c29f4186361a46935e4e9c3af71d1cf73cac00186fceb1cd1945ed9ed3dec]"),
+    ).toBe(false);
+    expect(
+      isUnknownLabel("0x72c29f4186361a46935e4e9c3af71d1cf73cac00186fceb1cd1945ed9ed3dec1"),
+    ).toBe(false);
+    expect(isUnknownLabel("21🚀bingo")).toBe(false);
   });
 });
 

--- a/packages/ensnode-utils/src/subname-helpers.ts
+++ b/packages/ensnode-utils/src/subname-helpers.ts
@@ -58,6 +58,18 @@ const UNINDEXABLE_LABEL_CHARACTER_CODES = new Set(
   UNINDEXABLE_LABEL_CHARACTERS.map((char) => char.charCodeAt(0)),
 );
 
+const UNKNOWN_LABEL_PREFIX = "[" as const;
+const UNKNOWN_LABEL_SUFFIX = "]" as const;
+
+type UnknownLabel = `${typeof UNKNOWN_LABEL_PREFIX}${string}${typeof UNKNOWN_LABEL_SUFFIX}`;
+
+export const isUnknownLabel = (label: string): label is UnknownLabel =>
+  label.startsWith(UNKNOWN_LABEL_PREFIX) &&
+  label.endsWith(UNKNOWN_LABEL_SUFFIX) &&
+  label.length === 66;
+
+export const unknownLabelAsHex = (label: UnknownLabel): Hex => `0x${label.slice(1, -1)}`;
+
 /**
  * Check if any characters in `label` are "unindexable".
  *
@@ -66,6 +78,8 @@ const UNINDEXABLE_LABEL_CHARACTER_CODES = new Set(
  */
 export const isLabelIndexable = (label: string) => {
   if (!label) return false;
+
+  if (isUnknownLabel(label)) return true;
 
   for (let i = 0; i < label.length; i++) {
     if (UNINDEXABLE_LABEL_CHARACTER_CODES.has(label.charCodeAt(i))) return false;

--- a/packages/ensnode-utils/src/subname-helpers.ts
+++ b/packages/ensnode-utils/src/subname-helpers.ts
@@ -1,4 +1,4 @@
-import { type Hex, concat, keccak256, namehash, toHex } from "viem";
+import { type Hex, concat, isHex, keccak256, namehash, toHex } from "viem";
 
 // NOTE: most of these utils could/should be pulled in from some (future) ens helper lib, as they
 // implement standard and reusable logic for typescript ens libs bu aren't necessarily implemented
@@ -63,12 +63,13 @@ const UNKNOWN_LABEL_SUFFIX = "]" as const;
 
 type UnknownLabel = `${typeof UNKNOWN_LABEL_PREFIX}${string}${typeof UNKNOWN_LABEL_SUFFIX}`;
 
+export const unknownLabelAsHex = (label: UnknownLabel): Hex => `0x${label.slice(1, -1)}`;
+
 export const isUnknownLabel = (label: string): label is UnknownLabel =>
   label.startsWith(UNKNOWN_LABEL_PREFIX) &&
   label.endsWith(UNKNOWN_LABEL_SUFFIX) &&
-  label.length === 66;
-
-export const unknownLabelAsHex = (label: UnknownLabel): Hex => `0x${label.slice(1, -1)}`;
+  label.length === 66 &&
+  isHex(unknownLabelAsHex(label as UnknownLabel));
 
 /**
  * Check if any characters in `label` are "unindexable".

--- a/packages/ensnode-utils/src/subname-helpers.ts
+++ b/packages/ensnode-utils/src/subname-helpers.ts
@@ -1,4 +1,4 @@
-import { type Hex, concat, isHex, keccak256, namehash, toHex } from "viem";
+import { type Hex, concat, keccak256, namehash, toHex } from "viem";
 
 // NOTE: most of these utils could/should be pulled in from some (future) ens helper lib, as they
 // implement standard and reusable logic for typescript ens libs bu aren't necessarily implemented
@@ -58,19 +58,6 @@ const UNINDEXABLE_LABEL_CHARACTER_CODES = new Set(
   UNINDEXABLE_LABEL_CHARACTERS.map((char) => char.charCodeAt(0)),
 );
 
-const UNKNOWN_LABEL_PREFIX = "[" as const;
-const UNKNOWN_LABEL_SUFFIX = "]" as const;
-
-type UnknownLabel = `${typeof UNKNOWN_LABEL_PREFIX}${string}${typeof UNKNOWN_LABEL_SUFFIX}`;
-
-export const unknownLabelAsHex = (label: UnknownLabel): Hex => `0x${label.slice(1, -1)}`;
-
-export const isUnknownLabel = (label: string): label is UnknownLabel =>
-  label.startsWith(UNKNOWN_LABEL_PREFIX) &&
-  label.endsWith(UNKNOWN_LABEL_SUFFIX) &&
-  label.length === 66 &&
-  isHex(unknownLabelAsHex(label as UnknownLabel));
-
 /**
  * Check if any characters in `label` are "unindexable".
  *
@@ -79,8 +66,6 @@ export const isUnknownLabel = (label: string): label is UnknownLabel =>
  */
 export const isLabelIndexable = (label: string) => {
   if (!label) return false;
-
-  if (isUnknownLabel(label)) return true;
 
   for (let i = 0; i < label.length; i++) {
     if (UNINDEXABLE_LABEL_CHARACTER_CODES.has(label.charCodeAt(i))) return false;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
 
   apps/ensrainbow:
     dependencies:
+      '@ensdomains/ensjs':
+        specifier: ^4.0.2
+        version: 4.0.2(typescript@5.7.3)(viem@2.22.13(typescript@5.7.3))
       '@hono/node-server':
         specifier: ^1.4.1
         version: 1.13.3(hono@4.6.17)


### PR DESCRIPTION
Fixes https://github.com/namehash/ensnode/issues/85

This PR introduces a label healing feature, where each unknown label that's detected onchain is first checked in the ENSRainbow API for its healed counterpart. If one is found, it is used as a replacement within `labelName` & `name` properties on the `domain` entity.

To configure a specific instance of ENSRainbow API, please use `ENSRAINBOW_API_BASE_URL` env variable. If not set, or incorrect URL was provided, no healing will be performed.

### Local ENSNode test

#### Label healing off

<img width="1331" alt="image" src="https://github.com/user-attachments/assets/5ce728d0-a1a4-4d73-8974-d4ca5bf5e09b" />

#### Label healing on

<img width="905" alt="image" src="https://github.com/user-attachments/assets/fd1d3334-f105-4b6d-91fc-fd9fa7cb0538" />
