### PR TITLE
fix: temporarily store coinTypes as string array to avoid parsing bugs

### DIFF
--- a/apps/ensnode/src/handlers/Resolver.ts
+++ b/apps/ensnode/src/handlers/Resolver.ts
@@ -70,7 +70,7 @@ export const makeResolverHandlers = (ownedName: OwnedName) => {
       // upsert the new coinType
       await context.db
         .update(schema.resolver, { id })
-        .set({ coinTypes: uniq([...(resolver.coinTypes ?? []), coinType]) });
+        .set({ coinTypes: uniq([...(resolver.coinTypes ?? []), coinType.toString()]) });
 
       // log ResolverEvent
       await context.db.insert(schema.multicoinAddrChanged).values({

--- a/packages/ponder-schema/src/ponder.schema.ts
+++ b/packages/ponder-schema/src/ponder.schema.ts
@@ -103,7 +103,10 @@ export const resolver = onchainTable("resolvers", (t) => ({
   texts: t.text().array(),
   // The set of observed SLIP-44 coin types for this resolver
   // NOTE: we avoid .notNull.default([]) to match subgraph behavior
-  coinTypes: t.bigint("coin_types").array(),
+  // NOTE: we store coinTypes as a [String!], to avoid loss of precision due to drizzle parsing bug
+  // https://github.com/ponder-sh/ponder/issues/1475
+  // https://github.com/ponder-sh/ponder/pull/1482
+  coinTypes: t.text("coin_types").array(),
 }));
 
 export const resolverRelations = relations(resolver, ({ one, many }) => ({


### PR DESCRIPTION
this provides incorrect graphql typings but correct graphql responses (since bigints are represented as string in json anyway). so it's effectively subgraph compatible. when the bugs are fixed we can revert to correct behavior