### PR TITLE
fix: stop upserting addresses in multicoinaddresschanged

### DIFF
--- a/apps/ensnode/src/handlers/Resolver.ts
+++ b/apps/ensnode/src/handlers/Resolver.ts
@@ -58,7 +58,6 @@ export const makeResolverHandlers = (ownedName: OwnedName) => {
       event: EventWithArgs<{ node: Node; coinType: bigint; newAddress: Hex }>;
     }) {
       const { node, coinType, newAddress } = event.args;
-      await upsertAccount(context, newAddress);
 
       const id = makeResolverId(event.log.address, node);
       const resolver = await upsertResolver(context, {


### PR DESCRIPTION
probably some merge conflict when we wrapped `makeResolverHandlers` but the bugfix in #105 got overwritten so this is that again