### PR TITLE
fix(ensrainbow): TS output path during Docker build

### DIFF
--- a/apps/ensrainbow/package.json
+++ b/apps/ensrainbow/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@hono/node-server": "^1.4.1",
     "classic-level": "^1.4.1",
+    "ensnode-utils": "workspace:*",
     "hono": "catalog:",
     "progress": "^2.0.3",
     "tsx": "^4.7.1",

--- a/apps/ensrainbow/package.json
+++ b/apps/ensrainbow/package.json
@@ -23,7 +23,10 @@
     "docker:push": "docker push ensnode/ensrainbow",
     "test": "DATA_DIR=test-data vitest run",
     "test:watch": "DATA_DIR=test-data vitest",
-    "test:coverage": "DATA_DIR=test-data vitest run --coverage"
+    "test:coverage": "DATA_DIR=test-data vitest run --coverage",
+    "lint": "biome check --write .",
+    "lint:ci": "biome ci",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@hono/node-server": "^1.4.1",

--- a/apps/ensrainbow/src/count-keys.ts
+++ b/apps/ensrainbow/src/count-keys.ts
@@ -1,8 +1,8 @@
 import { join } from "path";
 import { ClassicLevel } from "classic-level";
-import { LABELHASH_COUNT_KEY } from "./utils/constants";
 import { ByteArray } from "viem";
 import { byteArraysEqual } from "./utils/byte-utils";
+import { LABELHASH_COUNT_KEY } from "./utils/constants";
 
 const DATA_DIR = process.env.DATA_DIR || join(process.cwd(), "data");
 
@@ -18,15 +18,15 @@ async function countKeys(): Promise<void> {
     const existingCount = await db.get(LABELHASH_COUNT_KEY);
     console.log(`Existing count in database: ${existingCount}`);
   } catch (error: any) {
-    if (error.code !== 'LEVEL_NOT_FOUND') {
-      console.error('Error reading existing count:', error);
+    if (error.code !== "LEVEL_NOT_FOUND") {
+      console.error("Error reading existing count:", error);
     } else {
-      console.log('No existing count found in database');
+      console.log("No existing count found in database");
     }
   }
 
   console.log("Counting keys in database...");
-  
+
   let count = 0;
   for await (const [key] of db.iterator()) {
     // Don't count the count key itself
@@ -37,7 +37,7 @@ async function countKeys(): Promise<void> {
 
   // Store the count
   await db.put(LABELHASH_COUNT_KEY, count.toString());
-  
+
   console.log(`Total number of keys (excluding count key): ${count}`);
   console.log(`Updated count in database under LABELHASH_COUNT_KEY`);
 
@@ -49,4 +49,4 @@ if (import.meta.url === `file://${process.argv[1]}`) {
   countKeys()
     .then(() => console.log("Done!"))
     .catch(console.error);
-} 
+}

--- a/apps/ensrainbow/src/count-keys.ts
+++ b/apps/ensrainbow/src/count-keys.ts
@@ -1,8 +1,8 @@
 import { join } from "path";
 import { ClassicLevel } from "classic-level";
 import { ByteArray } from "viem";
-import { byteArraysEqual } from "./utils/byte-utils";
-import { LABELHASH_COUNT_KEY } from "./utils/constants";
+import { byteArraysEqual } from "./utils/byte-utils.js";
+import { LABELHASH_COUNT_KEY } from "./utils/constants.js";
 
 const DATA_DIR = process.env.DATA_DIR || join(process.cwd(), "data");
 

--- a/apps/ensrainbow/src/index.test.ts
+++ b/apps/ensrainbow/src/index.test.ts
@@ -2,11 +2,11 @@ import { serve } from "@hono/node-server";
 import { labelhash } from "viem";
 /// <reference types="vitest" />
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { labelHashToBytes } from "./utils/label-utils";
 import { app, db } from "./index";
+import { LABELHASH_COUNT_KEY } from "./utils/constants";
+import { labelHashToBytes } from "./utils/label-utils";
 import type { CountResponse, HealError, HealResponse, HealSuccess } from "./utils/response-types";
 import { ErrorCode, StatusCode } from "./utils/response-types";
-import { LABELHASH_COUNT_KEY } from "./utils/constants";
 
 describe("ENS Rainbow API", () => {
   let server: ReturnType<typeof serve>;

--- a/apps/ensrainbow/src/index.ts
+++ b/apps/ensrainbow/src/index.ts
@@ -4,11 +4,9 @@ import { ClassicLevel } from "classic-level";
 import { Hono } from "hono";
 import type { Context as HonoContext } from "hono";
 import { ByteArray } from "viem";
-import type { ENSRainbowContext } from "./operations";
-import { countLabels, heal } from "./operations";
-import { LABELHASH_COUNT_KEY } from "./utils/constants";
-import { labelHashToBytes } from "./utils/label-utils";
-import type { HealthResponse } from "./utils/response-types";
+import type { ENSRainbowContext } from "./operations.js";
+import { countLabels, heal } from "./operations.js";
+import type { HealthResponse } from "./utils/response-types.js";
 
 export const app = new Hono();
 export const DATA_DIR = process.env.VITEST

--- a/apps/ensrainbow/src/index.ts
+++ b/apps/ensrainbow/src/index.ts
@@ -2,12 +2,12 @@ import { join } from "path";
 import { serve } from "@hono/node-server";
 import { ClassicLevel } from "classic-level";
 import { Hono } from "hono";
-import { ByteArray } from 'viem'
-import { labelHashToBytes } from "./utils/label-utils";
-import { LABELHASH_COUNT_KEY } from "./utils/constants";
 import type { Context as HonoContext } from "hono";
+import { ByteArray } from "viem";
 import type { ENSRainbowContext } from "./operations";
 import { countLabels, heal } from "./operations";
+import { LABELHASH_COUNT_KEY } from "./utils/constants";
+import { labelHashToBytes } from "./utils/label-utils";
 import type { HealthResponse } from "./utils/response-types";
 
 export const app = new Hono();
@@ -30,7 +30,6 @@ try {
   console.error(`Please ensure the directory ${DATA_DIR} exists and is writable`);
   process.exit(1);
 }
-
 
 const rainbow: ENSRainbowContext = { db };
 

--- a/apps/ensrainbow/src/ingest.ts
+++ b/apps/ensrainbow/src/ingest.ts
@@ -15,7 +15,7 @@ const INPUT_FILE = process.env.INPUT_FILE || join(process.cwd(), "ens_names.sql.
 // as of January 30, 2024 from the Graph Protocol's ENS rainbow tables
 // Source file: ens_names.sql.gz
 // SHA256: a6316b1e7770b1f3142f1f21d4248b849a5c6eb998e3e66336912c9750c41f31
-// Note: The input file contains one known invalid record at line 10878 
+// Note: The input file contains one known invalid record at line 10878
 // where the labelhash value is literally "hash". This record is skipped
 // during ingestion since it would be unreachable through the ENS Subgraph anyway.
 // See: https://github.com/namehash/ensnode/issues/140
@@ -78,7 +78,9 @@ async function loadEnsNamesToLevelDB(): Promise<void> {
       record = buildRainbowRecord(line);
     } catch (e) {
       if (e instanceof Error) {
-        console.warn(`Skipping invalid record: ${e.message} - this record would be unreachable via ENS Subgraph`);
+        console.warn(
+          `Skipping invalid record: ${e.message} - this record would be unreachable via ENS Subgraph`,
+        );
       } else {
         console.warn(`Unknown error processing record - skipping`);
       }

--- a/apps/ensrainbow/src/ingest.ts
+++ b/apps/ensrainbow/src/ingest.ts
@@ -5,7 +5,7 @@ import { createGunzip } from "zlib";
 import { ClassicLevel } from "classic-level";
 import ProgressBar from "progress";
 import { ByteArray } from "viem";
-import { buildRainbowRecord } from "./utils/rainbow-record";
+import { buildRainbowRecord } from "./utils/rainbow-record.js";
 
 const DATA_DIR = process.env.DATA_DIR || join(process.cwd(), "data");
 const INPUT_FILE = process.env.INPUT_FILE || join(process.cwd(), "ens_names.sql.gz");

--- a/apps/ensrainbow/src/operations.ts
+++ b/apps/ensrainbow/src/operations.ts
@@ -1,7 +1,7 @@
 import { ClassicLevel } from "classic-level";
 import { ByteArray } from "viem";
-import { LABELHASH_COUNT_KEY } from "./utils/constants";
-import { labelHashToBytes } from "./utils/label-utils";
+import { LABELHASH_COUNT_KEY } from "./utils/constants.js";
+import { labelHashToBytes } from "./utils/label-utils.js";
 import type {
   CountError,
   CountResponse,
@@ -9,8 +9,8 @@ import type {
   HealError,
   HealResponse,
   HealSuccess,
-} from "./utils/response-types";
-import { ErrorCode, StatusCode } from "./utils/response-types";
+} from "./utils/response-types.js";
+import { ErrorCode, StatusCode } from "./utils/response-types.js";
 
 export interface ENSRainbowContext {
   db: ClassicLevel<ByteArray, string>;

--- a/apps/ensrainbow/src/operations.ts
+++ b/apps/ensrainbow/src/operations.ts
@@ -1,4 +1,6 @@
 import { ClassicLevel } from "classic-level";
+import { ByteArray } from "viem";
+import { LABELHASH_COUNT_KEY } from "./utils/constants";
 import { labelHashToBytes } from "./utils/label-utils";
 import type {
   CountError,
@@ -9,8 +11,6 @@ import type {
   HealSuccess,
 } from "./utils/response-types";
 import { ErrorCode, StatusCode } from "./utils/response-types";
-import { ByteArray } from "viem";
-import { LABELHASH_COUNT_KEY } from "./utils/constants";
 
 export interface ENSRainbowContext {
   db: ClassicLevel<ByteArray, string>;

--- a/apps/ensrainbow/src/utils/byte-utils.ts
+++ b/apps/ensrainbow/src/utils/byte-utils.ts
@@ -1,5 +1,5 @@
 import { ByteArray } from "viem";
 
 export function byteArraysEqual(a: ByteArray, b: ByteArray): boolean {
-    return a.length === b.length && a.every((val, i) => val === b[i]);
-} 
+  return a.length === b.length && a.every((val, i) => val === b[i]);
+}

--- a/apps/ensrainbow/src/utils/constants.ts
+++ b/apps/ensrainbow/src/utils/constants.ts
@@ -1,3 +1,3 @@
 import { ByteArray } from "viem";
 
-export const LABELHASH_COUNT_KEY = new Uint8Array([0xFF, 0xFF, 0xFF, 0xFF]) as ByteArray;
+export const LABELHASH_COUNT_KEY = new Uint8Array([0xff, 0xff, 0xff, 0xff]) as ByteArray;

--- a/apps/ensrainbow/src/utils/label-utils.test.ts
+++ b/apps/ensrainbow/src/utils/label-utils.test.ts
@@ -1,50 +1,60 @@
-import { describe, it, expect } from 'vitest';
-import { labelHashToBytes } from './label-utils';
-import { Labelhash } from '../../../../packages/ensnode-utils/src/types';
+import { describe, expect, it } from "vitest";
+import { Labelhash } from "../../../../packages/ensnode-utils/src/types";
+import { labelHashToBytes } from "./label-utils";
 
-describe('labelHashToBytes', () => {
+describe("labelHashToBytes", () => {
   // Valid case for reference
-  it('should convert a valid 32-byte hex string', () => {
-    const validHash = '0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef' as Labelhash;
+  it("should convert a valid 32-byte hex string", () => {
+    const validHash =
+      "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" as Labelhash;
     expect(() => labelHashToBytes(validHash)).not.toThrow();
   });
 
   // Test case: labelhash without 0x prefix
-  it('should throw error when labelhash does not begin with 0x', () => {
-    const noPrefix = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+  it("should throw error when labelhash does not begin with 0x", () => {
+    const noPrefix = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
     // @ts-expect-error - Testing invalid input
-    expect(() => labelHashToBytes(noPrefix)).toThrow('Invalid labelhash length 64 characters (expected 66)');
+    expect(() => labelHashToBytes(noPrefix)).toThrow(
+      "Invalid labelhash length 64 characters (expected 66)",
+    );
   });
 
   // Test case: labelhash with 1x prefix
-  it('should throw error when labelhash begins with 1x', () => {
-    const onePrefix = '1x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+  it("should throw error when labelhash begins with 1x", () => {
+    const onePrefix = "1x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
     // @ts-expect-error - Testing invalid input
-    expect(() => labelHashToBytes(onePrefix)).toThrow('Labelhash must be 0x-prefixed');
+    expect(() => labelHashToBytes(onePrefix)).toThrow("Labelhash must be 0x-prefixed");
   });
 
   // Test case: mixed-case labelhash characters
-  it('should throw error when labelhash contains mixed case characters', () => {
-    const mixedCase = '0x0123456789aBcDeF0123456789abcdef0123456789abcdef0123456789abcdef' as Labelhash;
-    expect(() => labelHashToBytes(mixedCase)).toThrow('Labelhash must be in lowercase');
+  it("should throw error when labelhash contains mixed case characters", () => {
+    const mixedCase =
+      "0x0123456789aBcDeF0123456789abcdef0123456789abcdef0123456789abcdef" as Labelhash;
+    expect(() => labelHashToBytes(mixedCase)).toThrow("Labelhash must be in lowercase");
   });
 
   // Test case: 63 hex digits
-  it('should throw error when hash is 63 hex digits', () => {
-    const hash63 = '0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcde' as Labelhash;
-    expect(() => labelHashToBytes(hash63)).toThrow('Invalid labelhash length 65 characters (expected 66)');
+  it("should throw error when hash is 63 hex digits", () => {
+    const hash63 = "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcde" as Labelhash;
+    expect(() => labelHashToBytes(hash63)).toThrow(
+      "Invalid labelhash length 65 characters (expected 66)",
+    );
   });
 
   // Test case: 62 hex digits
-  it('should throw error when labelhash is 62 hex digits', () => {
-    const hash62 = '0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd' as Labelhash;
-    expect(() => labelHashToBytes(hash62)).toThrow('Invalid labelhash length 64 characters (expected 66)');
+  it("should throw error when labelhash is 62 hex digits", () => {
+    const hash62 = "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd" as Labelhash;
+    expect(() => labelHashToBytes(hash62)).toThrow(
+      "Invalid labelhash length 64 characters (expected 66)",
+    );
   });
 
   // Test case: 65 hex digits
-  it('should throw error when labelhash is 65 hex digits', () => {
-    const hash65 = '0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdefa' as Labelhash;
-    expect(() => labelHashToBytes(hash65)).toThrow('Invalid labelhash length 67 characters (expected 66)');
+  it("should throw error when labelhash is 65 hex digits", () => {
+    const hash65 =
+      "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdefa" as Labelhash;
+    expect(() => labelHashToBytes(hash65)).toThrow(
+      "Invalid labelhash length 67 characters (expected 66)",
+    );
   });
-}); 
-
+});

--- a/apps/ensrainbow/src/utils/label-utils.test.ts
+++ b/apps/ensrainbow/src/utils/label-utils.test.ts
@@ -1,5 +1,5 @@
+import type { Labelhash } from "ensnode-utils/types";
 import { describe, expect, it } from "vitest";
-import { Labelhash } from "../../../../packages/ensnode-utils/src/types";
 import { labelHashToBytes } from "./label-utils";
 
 describe("labelHashToBytes", () => {

--- a/apps/ensrainbow/src/utils/label-utils.test.ts
+++ b/apps/ensrainbow/src/utils/label-utils.test.ts
@@ -13,8 +13,8 @@ describe("labelHashToBytes", () => {
   // Test case: labelhash without 0x prefix
   it("should throw error when labelhash does not begin with 0x", () => {
     const noPrefix = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
-    // @ts-expect-error - Testing invalid input
-    expect(() => labelHashToBytes(noPrefix)).toThrow(
+    // Testing invalid input
+    expect(() => labelHashToBytes(noPrefix as Labelhash)).toThrow(
       "Invalid labelhash length 64 characters (expected 66)",
     );
   });
@@ -22,8 +22,8 @@ describe("labelHashToBytes", () => {
   // Test case: labelhash with 1x prefix
   it("should throw error when labelhash begins with 1x", () => {
     const onePrefix = "1x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
-    // @ts-expect-error - Testing invalid input
-    expect(() => labelHashToBytes(onePrefix)).toThrow("Labelhash must be 0x-prefixed");
+    // Testing invalid input
+    expect(() => labelHashToBytes(onePrefix as Labelhash)).toThrow("Labelhash must be 0x-prefixed");
   });
 
   // Test case: mixed-case labelhash characters

--- a/apps/ensrainbow/src/utils/label-utils.ts
+++ b/apps/ensrainbow/src/utils/label-utils.ts
@@ -1,5 +1,5 @@
+import type { Labelhash } from "ensnode-utils/types";
 import { ByteArray, hexToBytes } from "viem";
-import { Labelhash } from "../../../../packages/ensnode-utils/src/types";
 
 /**
  * Converts a Labelhash to bytes, with validation

--- a/apps/ensrainbow/src/utils/label-utils.ts
+++ b/apps/ensrainbow/src/utils/label-utils.ts
@@ -1,5 +1,5 @@
-import { hexToBytes, ByteArray } from 'viem';
-import { Labelhash } from '../../../../packages/ensnode-utils/src/types';
+import { ByteArray, hexToBytes } from "viem";
+import { Labelhash } from "../../../../packages/ensnode-utils/src/types";
 
 /**
  * Converts a Labelhash to bytes, with validation
@@ -13,13 +13,14 @@ export function labelHashToBytes(labelHash: Labelhash): ByteArray {
       throw new Error(`Invalid labelhash length ${labelHash.length} characters (expected 66)`);
     }
     if (labelHash !== labelHash.toLowerCase()) {
-      throw new Error('Labelhash must be in lowercase');
+      throw new Error("Labelhash must be in lowercase");
     }
-    if (!labelHash.startsWith('0x')) {
-      throw new Error('Labelhash must be 0x-prefixed');
+    if (!labelHash.startsWith("0x")) {
+      throw new Error("Labelhash must be 0x-prefixed");
     }
     const bytes = hexToBytes(labelHash);
-    if (bytes.length !== 32) { // should be redundant but keeping it for the principle of defensive programming
+    if (bytes.length !== 32) {
+      // should be redundant but keeping it for the principle of defensive programming
       throw new Error(`Invalid labelhash length ${bytes.length} bytes (expected 32)`);
     }
     return bytes;
@@ -27,6 +28,6 @@ export function labelHashToBytes(labelHash: Labelhash): ByteArray {
     if (e instanceof Error) {
       throw e;
     }
-    throw new Error('Invalid hex format');
+    throw new Error("Invalid hex format");
   }
-} 
+}

--- a/apps/ensrainbow/src/utils/rainbow-record.test.ts
+++ b/apps/ensrainbow/src/utils/rainbow-record.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect } from 'vitest';
-import { labelhash } from 'viem';
-import { buildRainbowRecord } from './rainbow-record';
-import { labelHashToBytes } from './label-utils';
-import { Labelhash } from '../../../../packages/ensnode-utils/src/types';
+import { labelhash } from "viem";
+import { describe, expect, it } from "vitest";
+import { Labelhash } from "../../../../packages/ensnode-utils/src/types";
+import { labelHashToBytes } from "./label-utils";
+import { buildRainbowRecord } from "./rainbow-record";
 
-describe('buildRainbowRecord', () => {
-  it('should parse a valid line', () => {
-    const label = 'test-label';
+describe("buildRainbowRecord", () => {
+  it("should parse a valid line", () => {
+    const label = "test-label";
     const validLabelhash = labelhash(label);
     const line = `${validLabelhash}\t${label}`;
 
@@ -15,8 +15,8 @@ describe('buildRainbowRecord', () => {
     expect(record.labelHash).toEqual(labelHashToBytes(validLabelhash as Labelhash));
   });
 
-  it('should handle labels with special characters', () => {
-    const label = 'test🚀label';
+  it("should handle labels with special characters", () => {
+    const label = "test🚀label";
     const validLabelhash = labelhash(label);
     const line = `${validLabelhash}\t${label}`;
 
@@ -25,19 +25,19 @@ describe('buildRainbowRecord', () => {
     expect(record.labelHash).toEqual(labelHashToBytes(validLabelhash as Labelhash));
   });
 
-  it('should throw on invalid line format', () => {
-    const invalidLine = 'just-one-column';
-    expect(() => buildRainbowRecord(invalidLine)).toThrow('Invalid line format');
+  it("should throw on invalid line format", () => {
+    const invalidLine = "just-one-column";
+    expect(() => buildRainbowRecord(invalidLine)).toThrow("Invalid line format");
   });
 
-  it('should throw on invalid labelhash format', () => {
-    const invalidLine = 'not-a-hash\tsome-label';
-    expect(() => buildRainbowRecord(invalidLine)).toThrow('Invalid labelhash length');
+  it("should throw on invalid labelhash format", () => {
+    const invalidLine = "not-a-hash\tsome-label";
+    expect(() => buildRainbowRecord(invalidLine)).toThrow("Invalid labelhash length");
   });
 
-  describe('with validation enabled', () => {
-    it('should accept valid labelhash', () => {
-      const label = 'test-label';
+  describe("with validation enabled", () => {
+    it("should accept valid labelhash", () => {
+      const label = "test-label";
       const validLabelhash = labelhash(label);
       const line = `${validLabelhash}\t${label}`;
 
@@ -46,13 +46,14 @@ describe('buildRainbowRecord', () => {
       expect(record.labelHash).toEqual(labelHashToBytes(validLabelhash as Labelhash));
     });
 
-    it('should throw on mismatched labelhash', () => {
-      const label = 'test-label';
-      const wrongLabelhash = '0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+    it("should throw on mismatched labelhash", () => {
+      const label = "test-label";
+      const wrongLabelhash = "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
       const line = `${wrongLabelhash}\t${label}`;
 
-      expect(() => buildRainbowRecord(line, { validateLabelHash: true }))
-        .toThrow('Labelhash validation failed: computed hash does not match provided hash');
+      expect(() => buildRainbowRecord(line, { validateLabelHash: true })).toThrow(
+        "Labelhash validation failed: computed hash does not match provided hash",
+      );
     });
   });
-}); 
+});

--- a/apps/ensrainbow/src/utils/rainbow-record.test.ts
+++ b/apps/ensrainbow/src/utils/rainbow-record.test.ts
@@ -1,6 +1,6 @@
+import type { Labelhash } from "ensnode-utils/types";
 import { labelhash } from "viem";
 import { describe, expect, it } from "vitest";
-import { Labelhash } from "../../../../packages/ensnode-utils/src/types";
 import { labelHashToBytes } from "./label-utils";
 import { buildRainbowRecord } from "./rainbow-record";
 

--- a/apps/ensrainbow/src/utils/rainbow-record.ts
+++ b/apps/ensrainbow/src/utils/rainbow-record.ts
@@ -1,5 +1,5 @@
+import type { Labelhash } from "ensnode-utils/types";
 import { ByteArray, labelhash } from "viem";
-import { Labelhash } from "../../../../packages/ensnode-utils/src/types";
 import { byteArraysEqual } from "./byte-utils";
 import { labelHashToBytes } from "./label-utils";
 

--- a/apps/ensrainbow/src/utils/rainbow-record.ts
+++ b/apps/ensrainbow/src/utils/rainbow-record.ts
@@ -1,7 +1,7 @@
-import { ByteArray, labelhash } from 'viem';
-import { Labelhash } from '../../../../packages/ensnode-utils/src/types';
-import { labelHashToBytes } from './label-utils';
-import { byteArraysEqual } from './byte-utils';
+import { ByteArray, labelhash } from "viem";
+import { Labelhash } from "../../../../packages/ensnode-utils/src/types";
+import { byteArraysEqual } from "./byte-utils";
+import { labelHashToBytes } from "./label-utils";
 
 export interface RainbowRecord {
   labelHash: ByteArray;
@@ -19,16 +19,21 @@ export interface RainbowRecordOptions {
 
 /**
  * Parses a line from the rainbow table SQL dump into a RainbowRecord.
- * 
+ *
  * @param line A line from the rainbow table SQL dump in the format "labelhash\tlabel"
  * @param options Optional configuration for parsing behavior
  * @returns A RainbowRecord containing the parsed labelhash and label
  * @throws Error if the line format is invalid or if validation fails
  */
-export function buildRainbowRecord(line: string, options: RainbowRecordOptions = {}): RainbowRecord {
+export function buildRainbowRecord(
+  line: string,
+  options: RainbowRecordOptions = {},
+): RainbowRecord {
   const parts = line.trim().split("\t");
   if (parts.length !== 2) {
-    throw new Error(`Invalid line format - expected 2 columns but got ${parts.length}: "${line.slice(0, 100)}"`);
+    throw new Error(
+      `Invalid line format - expected 2 columns but got ${parts.length}: "${line.slice(0, 100)}"`,
+    );
   }
 
   const [maybeLabelHash, label] = parts;
@@ -38,12 +43,12 @@ export function buildRainbowRecord(line: string, options: RainbowRecordOptions =
     const computedLabelHash = labelHashToBytes(labelhash(label) as Labelhash);
 
     if (!byteArraysEqual(labelHash, computedLabelHash)) {
-        throw new Error(`Labelhash validation failed: computed hash does not match provided hash`);
-     }
+      throw new Error(`Labelhash validation failed: computed hash does not match provided hash`);
+    }
   }
 
   return {
     labelHash,
-    label
+    label,
   };
-} 
+}

--- a/apps/ensrainbow/src/utils/rainbow-record.ts
+++ b/apps/ensrainbow/src/utils/rainbow-record.ts
@@ -1,7 +1,7 @@
 import type { Labelhash } from "ensnode-utils/types";
 import { ByteArray, labelhash } from "viem";
-import { byteArraysEqual } from "./byte-utils";
-import { labelHashToBytes } from "./label-utils";
+import { byteArraysEqual } from "./byte-utils.js";
+import { labelHashToBytes } from "./label-utils.js";
 
 export interface RainbowRecord {
   labelHash: ByteArray;

--- a/apps/ensrainbow/tsconfig.json
+++ b/apps/ensrainbow/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "@namehash/shared-configs/tsconfig.lib.json",
-  "include": ["src/**/**/*.ts"],
+  "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "**/*.test.ts"],
   "compilerOptions": {
     "allowImportingTsExtensions": false,

--- a/apps/ensrainbow/tsconfig.json
+++ b/apps/ensrainbow/tsconfig.json
@@ -1,10 +1,11 @@
 {
   "extends": "@namehash/shared-configs/tsconfig.lib.json",
-  "include": ["src/**/*"],
+  "include": ["src/**/**/*.ts"],
   "exclude": ["node_modules", "**/*.test.ts"],
   "compilerOptions": {
     "allowImportingTsExtensions": false,
     "noEmit": false,
+    "rootDir": "src",
     "outDir": "dist"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       classic-level:
         specifier: ^1.4.1
         version: 1.4.1
+      ensnode-utils:
+        specifier: workspace:*
+        version: link:../../packages/ensnode-utils
       hono:
         specifier: 'catalog:'
         version: 4.6.17


### PR DESCRIPTION
This PR aims to fix the issue that causes Docker to fail image build process for ENSRainbow codebase.

Feel free to review commit by commit.

Key changes:
- update TS config file to target Node.js runtime (resolves docker build error),
- link to `ensnode-utils` package via pnpm workspace (resolves #154),
- replace ts-expect-error with type-casting to allow testing invalid inputs (resolves #155).


Other changes:
- include ENSRainbow in static analysis CI checks (enables more checks on CI for ENSRainbow).

### Context

Example failed CI run: https://github.com/namehash/ensnode/actions/runs/13103011295/job/36553617832#step:3:273

<details isOpen="false">
  <summary>Error log</summary>
  
```
#26 [ingestor 3/3] RUN node dist/ingest.js
#26 0.151 node:internal/modules/cjs/loader:1228
#26 0.151   throw err;
#26 0.151   ^
#26 0.151 
#26 0.151 Error: Cannot find module '/app/apps/ensrainbow/dist/ingest.js'
#26 0.151     at Module._resolveFilename (node:internal/modules/cjs/loader:1225:15)
#26 0.151     at Module._load (node:internal/modules/cjs/loader:1051:27)
#26 0.151     at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:173:12)
#26 0.151     at node:internal/main/run_main_module:28:49 {
#26 0.151   code: 'MODULE_NOT_FOUND',
#26 0.151   requireStack: []
#26 0.151 }
#26 0.151 
#26 0.151 Node.js v20.18.2
#26 ERROR: process "/bin/sh -c node dist/ingest.js" did not complete successfully: exit code: 1
------
 > [ingestor 3/3] RUN node dist/ingest.js:
0.151 Error: Cannot find module '/app/apps/ensrainbow/dist/ingest.js'
0.151     at Module._resolveFilename (node:internal/modules/cjs/loader:1225:15)
0.151     at Module._load (node:internal/modules/cjs/loader:1051:27)
0.151     at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:173:12)
0.151     at node:internal/main/run_main_module:28:49 {
0.151   code: 'MODULE_NOT_FOUND',
0.151   requireStack: []
0.151 }
0.151 
0.151 Node.js v20.18.2
------
Dockerfile:47
```
</details>