### PR TITLE
fix: use jsonb for texts to fix malformed string serialization bug

### DIFF
--- a/packages/ponder-schema/src/ponder.schema.ts
+++ b/packages/ponder-schema/src/ponder.schema.ts
@@ -100,12 +100,16 @@ export const resolver = onchainTable("resolvers", (t) => ({
   contentHash: t.text("content_hash"),
   // The set of observed text record keys for this resolver
   // NOTE: we avoid .notNull.default([]) to match subgraph behavior
-  texts: t.text().array(),
+  // NOTE: due to a serialization bug (likely in drizzle), we temporarily use a jsonb column here
+  // https://github.com/ponder-sh/ponder/issues/1484
+  // TODO: revert back to t.text().array(),
+  texts: t.jsonb().$type<string[]>(),
   // The set of observed SLIP-44 coin types for this resolver
   // NOTE: we avoid .notNull.default([]) to match subgraph behavior
   // NOTE: we store coinTypes as a [String!], to avoid loss of precision due to drizzle parsing bug
   // https://github.com/ponder-sh/ponder/issues/1475
   // https://github.com/ponder-sh/ponder/pull/1482
+  // TODO: revert back to t.bigint().array()
   coinTypes: t.text("coin_types").array(),
 }));
 


### PR DESCRIPTION
a workaround for the malformed `//U_W_U\\` text key identified in #79 

the issue is being tracked with ponder team in https://github.com/ponder-sh/ponder/issues/1484 but this workaround is acceptable for now. it produces the incorrect graphql type, similar to the bigint array stopgap, but the json data response itself continues to be subgraph-compatible