### PR TITLE
fix(ensnode): apply conflict resolution for event DB records

### DIFF
--- a/apps/ensnode/src/handlers/NameWrapper.ts
+++ b/apps/ensnode/src/handlers/NameWrapper.ts
@@ -20,7 +20,9 @@ const tokenIdToNode = (tokenId: bigint): Node => uint256ToHex32(tokenId);
 
 // if the wrappedDomain has PCC set in fuses, set domain's expiryDate to the greatest of the two
 async function materializeDomainExpiryDate(context: Context, node: Node) {
-  const wrappedDomain = await context.db.find(schema.wrappedDomain, { id: node });
+  const wrappedDomain = await context.db.find(schema.wrappedDomain, {
+    id: node,
+  });
   if (!wrappedDomain) throw new Error(`Expected WrappedDomain(${node})`);
 
   // NOTE: the subgraph has a helper function called [checkPccBurned](https://github.com/ensdomains/ens-subgraph/blob/master/src/nameWrapper.ts#L63)
@@ -76,12 +78,15 @@ export const makeNameWrapperHandlers = (ownedName: OwnedName) => {
       });
 
     // log DomainEvent
-    await context.db.insert(schema.wrappedTransfer).values({
-      ...sharedEventValues(event),
-      id: eventId, // NOTE: override the shared id in this case, to account for TransferBatch
-      domainId: node,
-      ownerId: to,
-    });
+    await context.db
+      .insert(schema.wrappedTransfer)
+      .values({
+        ...sharedEventValues(event),
+        id: eventId, // NOTE: override the shared id in this case, to account for TransferBatch
+        domainId: node,
+        ownerId: to,
+      })
+      .onConflictDoNothing();
   }
 
   return {
@@ -124,14 +129,17 @@ export const makeNameWrapperHandlers = (ownedName: OwnedName) => {
       await materializeDomainExpiryDate(context, node);
 
       // log DomainEvent
-      await context.db.insert(schema.nameWrapped).values({
-        ...sharedEventValues(event),
-        domainId: node,
-        name,
-        fuses,
-        ownerId: owner,
-        expiryDate: expiry,
-      });
+      await context.db
+        .insert(schema.nameWrapped)
+        .values({
+          ...sharedEventValues(event),
+          domainId: node,
+          name,
+          fuses,
+          ownerId: owner,
+          expiryDate: expiry,
+        })
+        .onConflictDoNothing();
     },
 
     async handleNameUnwrapped({
@@ -156,11 +164,14 @@ export const makeNameWrapperHandlers = (ownedName: OwnedName) => {
       await context.db.delete(schema.wrappedDomain, { id: node });
 
       // log DomainEvent
-      await context.db.insert(schema.nameUnwrapped).values({
-        ...sharedEventValues(event),
-        domainId: node,
-        ownerId: owner,
-      });
+      await context.db
+        .insert(schema.nameUnwrapped)
+        .values({
+          ...sharedEventValues(event),
+          domainId: node,
+          ownerId: owner,
+        })
+        .onConflictDoNothing();
     },
 
     async handleFusesSet({
@@ -186,11 +197,14 @@ export const makeNameWrapperHandlers = (ownedName: OwnedName) => {
       }
 
       // log DomainEvent
-      await context.db.insert(schema.fusesSet).values({
-        ...sharedEventValues(event),
-        domainId: node,
-        fuses,
-      });
+      await context.db
+        .insert(schema.fusesSet)
+        .values({
+          ...sharedEventValues(event),
+          domainId: node,
+          fuses,
+        })
+        .onConflictDoNothing();
     },
     async handleExpiryExtended({
       context,
@@ -215,11 +229,14 @@ export const makeNameWrapperHandlers = (ownedName: OwnedName) => {
       }
 
       // log DomainEvent
-      await context.db.insert(schema.expiryExtended).values({
-        ...sharedEventValues(event),
-        domainId: node,
-        expiryDate: expiry,
-      });
+      await context.db
+        .insert(schema.expiryExtended)
+        .values({
+          ...sharedEventValues(event),
+          domainId: node,
+          expiryDate: expiry,
+        })
+        .onConflictDoNothing();
     },
     async handleTransferSingle({
       context,

--- a/apps/ensnode/src/handlers/Registrar.ts
+++ b/apps/ensnode/src/handlers/Registrar.ts
@@ -97,12 +97,15 @@ export const makeRegistrarHandlers = (ownedName: OwnedName) => {
       });
 
       // log RegistrationEvent
-      await context.db.insert(schema.nameRegistered).values({
-        ...sharedEventValues(event),
-        registrationId: id,
-        registrantId: owner,
-        expiryDate: expires,
-      });
+      await context.db
+        .insert(schema.nameRegistered)
+        .values({
+          ...sharedEventValues(event),
+          registrationId: id,
+          registrantId: owner,
+          expiryDate: expires,
+        })
+        .onConflictDoNothing();
     },
 
     async handleNameRegisteredByController({
@@ -151,11 +154,14 @@ export const makeRegistrarHandlers = (ownedName: OwnedName) => {
 
       // log RegistrationEvent
 
-      await context.db.insert(schema.nameRenewed).values({
-        ...sharedEventValues(event),
-        registrationId: id,
-        expiryDate: expires,
-      });
+      await context.db
+        .insert(schema.nameRenewed)
+        .values({
+          ...sharedEventValues(event),
+          registrationId: id,
+          expiryDate: expires,
+        })
+        .onConflictDoNothing();
     },
 
     async handleNameTransferred({
@@ -178,11 +184,14 @@ export const makeRegistrarHandlers = (ownedName: OwnedName) => {
       await context.db.update(schema.domain, { id: node }).set({ registrantId: to });
 
       // log RegistrationEvent
-      await context.db.insert(schema.nameTransferred).values({
-        ...sharedEventValues(event),
-        registrationId: id,
-        newOwnerId: to,
-      });
+      await context.db
+        .insert(schema.nameTransferred)
+        .values({
+          ...sharedEventValues(event),
+          registrationId: id,
+          newOwnerId: to,
+        })
+        .onConflictDoNothing();
     },
   };
 };

--- a/apps/ensnode/src/handlers/Registry.ts
+++ b/apps/ensnode/src/handlers/Registry.ts
@@ -140,13 +140,16 @@ export const makeRegistryHandlers = (ownedName: OwnedName) => {
         }
 
         // log DomainEvent
-        await context.db.insert(schema.newOwner).values({
-          ...sharedEventValues(event),
+        await context.db
+          .insert(schema.newOwner)
+          .values({
+            ...sharedEventValues(event),
 
-          parentDomainId: node,
-          domainId: subnode,
-          ownerId: owner,
-        });
+            parentDomainId: node,
+            domainId: subnode,
+            ownerId: owner,
+          })
+          .onConflictDoNothing();
       },
     async handleTransfer({
       context,
@@ -173,11 +176,14 @@ export const makeRegistryHandlers = (ownedName: OwnedName) => {
       }
 
       // log DomainEvent
-      await context.db.insert(schema.transfer).values({
-        ...sharedEventValues(event),
-        domainId: node,
-        ownerId: owner,
-      });
+      await context.db
+        .insert(schema.transfer)
+        .values({
+          ...sharedEventValues(event),
+          domainId: node,
+          ownerId: owner,
+        })
+        .onConflictDoNothing();
     },
 
     async handleNewTTL({
@@ -195,11 +201,14 @@ export const makeRegistryHandlers = (ownedName: OwnedName) => {
       await context.db.update(schema.domain, { id: node }).set({ ttl });
 
       // log DomainEvent
-      await context.db.insert(schema.newTTL).values({
-        ...sharedEventValues(event),
-        domainId: node,
-        ttl,
-      });
+      await context.db
+        .insert(schema.newTTL)
+        .values({
+          ...sharedEventValues(event),
+          domainId: node,
+          ttl,
+        })
+        .onConflictDoNothing();
     },
 
     async handleNewResolver({
@@ -239,17 +248,20 @@ export const makeRegistryHandlers = (ownedName: OwnedName) => {
       }
 
       // log DomainEvent
-      await context.db.insert(schema.newResolver).values({
-        ...sharedEventValues(event),
-        domainId: node,
-        // NOTE: this actually produces a bug in the subgraph's graphql layer — `resolver` is not nullable
-        // but there is never a resolver record created for the zeroAddress. so if you query the
-        // `resolver { id }` of a NewResolver event that set the resolver to zeroAddress
-        // ex: newResolver(id: "3745840-2") { id resolver {id} }
-        // you will receive a GraphQL type error. for subgraph compatibility we re-implement this
-        // behavior here, but it should be entirely avoided in a v2 restructuring of the schema.
-        resolverId: resolverAddress === zeroAddress ? zeroAddress : resolverId,
-      });
+      await context.db
+        .insert(schema.newResolver)
+        .values({
+          ...sharedEventValues(event),
+          domainId: node,
+          // NOTE: this actually produces a bug in the subgraph's graphql layer — `resolver` is not nullable
+          // but there is never a resolver record created for the zeroAddress. so if you query the
+          // `resolver { id }` of a NewResolver event that set the resolver to zeroAddress
+          // ex: newResolver(id: "3745840-2") { id resolver {id} }
+          // you will receive a GraphQL type error. for subgraph compatibility we re-implement this
+          // behavior here, but it should be entirely avoided in a v2 restructuring of the schema.
+          resolverId: resolverAddress === zeroAddress ? zeroAddress : resolverId,
+        })
+        .onConflictDoNothing();
     },
   };
 };

--- a/apps/ensnode/src/handlers/Resolver.ts
+++ b/apps/ensnode/src/handlers/Resolver.ts
@@ -43,11 +43,14 @@ export const makeResolverHandlers = (ownedName: OwnedName) => {
       }
 
       // log ResolverEvent
-      await context.db.insert(schema.addrChanged).values({
-        ...sharedEventValues(event),
-        resolverId: id,
-        addrId: address,
-      });
+      await context.db
+        .insert(schema.addrChanged)
+        .values({
+          ...sharedEventValues(event),
+          resolverId: id,
+          addrId: address,
+        })
+        .onConflictDoNothing();
     },
 
     async handleAddressChanged({
@@ -72,12 +75,15 @@ export const makeResolverHandlers = (ownedName: OwnedName) => {
         .set({ coinTypes: uniq([...(resolver.coinTypes ?? []), coinType]) });
 
       // log ResolverEvent
-      await context.db.insert(schema.multicoinAddrChanged).values({
-        ...sharedEventValues(event),
-        resolverId: id,
-        coinType,
-        addr: newAddress,
-      });
+      await context.db
+        .insert(schema.multicoinAddrChanged)
+        .values({
+          ...sharedEventValues(event),
+          resolverId: id,
+          coinType,
+          addr: newAddress,
+        })
+        .onConflictDoNothing();
     },
 
     async handleNameChanged({
@@ -98,11 +104,14 @@ export const makeResolverHandlers = (ownedName: OwnedName) => {
       });
 
       // log ResolverEvent
-      await context.db.insert(schema.nameChanged).values({
-        ...sharedEventValues(event),
-        resolverId: id,
-        name,
-      });
+      await context.db
+        .insert(schema.nameChanged)
+        .values({
+          ...sharedEventValues(event),
+          resolverId: id,
+          name,
+        })
+        .onConflictDoNothing();
     },
 
     async handleABIChanged({
@@ -123,11 +132,14 @@ export const makeResolverHandlers = (ownedName: OwnedName) => {
       });
 
       // log ResolverEvent
-      await context.db.insert(schema.abiChanged).values({
-        ...sharedEventValues(event),
-        resolverId: id,
-        contentType,
-      });
+      await context.db
+        .insert(schema.abiChanged)
+        .values({
+          ...sharedEventValues(event),
+          resolverId: id,
+          contentType,
+        })
+        .onConflictDoNothing();
     },
 
     async handlePubkeyChanged({
@@ -148,12 +160,15 @@ export const makeResolverHandlers = (ownedName: OwnedName) => {
       });
 
       // log ResolverEvent
-      await context.db.insert(schema.pubkeyChanged).values({
-        ...sharedEventValues(event),
-        resolverId: id,
-        x,
-        y,
-      });
+      await context.db
+        .insert(schema.pubkeyChanged)
+        .values({
+          ...sharedEventValues(event),
+          resolverId: id,
+          x,
+          y,
+        })
+        .onConflictDoNothing();
     },
 
     async handleTextChanged({
@@ -182,16 +197,19 @@ export const makeResolverHandlers = (ownedName: OwnedName) => {
         .set({ texts: uniq([...(resolver.texts ?? []), key]) });
 
       // log ResolverEvent
-      await context.db.insert(schema.textChanged).values({
-        ...sharedEventValues(event),
-        resolverId: id,
-        key,
-        // ponder's (viem's) event parsing produces empty string for some TextChange events
-        // (which is correct) but the subgraph records null for these instances, so we coalesce
-        // falsy strings to null for compatibility
-        // ex: last TextChanged in 0x7fac4f1802c9b1969311be0412e6f900d531c59155421ff8ce1fda78b87956d0
-        value: value || null,
-      });
+      await context.db
+        .insert(schema.textChanged)
+        .values({
+          ...sharedEventValues(event),
+          resolverId: id,
+          key,
+          // ponder's (viem's) event parsing produces empty string for some TextChange events
+          // (which is correct) but the subgraph records null for these instances, so we coalesce
+          // falsy strings to null for compatibility
+          // ex: last TextChanged in 0x7fac4f1802c9b1969311be0412e6f900d531c59155421ff8ce1fda78b87956d0
+          value: value || null,
+        })
+        .onConflictDoNothing();
     },
 
     async handleContenthashChanged({
@@ -211,11 +229,14 @@ export const makeResolverHandlers = (ownedName: OwnedName) => {
       });
 
       // log ResolverEvent
-      await context.db.insert(schema.contenthashChanged).values({
-        ...sharedEventValues(event),
-        resolverId: id,
-        hash,
-      });
+      await context.db
+        .insert(schema.contenthashChanged)
+        .values({
+          ...sharedEventValues(event),
+          resolverId: id,
+          hash,
+        })
+        .onConflictDoNothing();
     },
 
     async handleInterfaceChanged({
@@ -234,12 +255,15 @@ export const makeResolverHandlers = (ownedName: OwnedName) => {
       });
 
       // log ResolverEvent
-      await context.db.insert(schema.interfaceChanged).values({
-        ...sharedEventValues(event),
-        resolverId: id,
-        interfaceID,
-        implementer,
-      });
+      await context.db
+        .insert(schema.interfaceChanged)
+        .values({
+          ...sharedEventValues(event),
+          resolverId: id,
+          interfaceID,
+          implementer,
+        })
+        .onConflictDoNothing();
     },
 
     async handleAuthorisationChanged({
@@ -263,14 +287,17 @@ export const makeResolverHandlers = (ownedName: OwnedName) => {
       });
 
       // log ResolverEvent
-      await context.db.insert(schema.authorisationChanged).values({
-        ...sharedEventValues(event),
-        resolverId: id,
-        owner,
-        target,
-        // NOTE: the spelling difference is kept for subgraph backwards-compatibility
-        isAuthorized: isAuthorised,
-      });
+      await context.db
+        .insert(schema.authorisationChanged)
+        .values({
+          ...sharedEventValues(event),
+          resolverId: id,
+          owner,
+          target,
+          // NOTE: the spelling difference is kept for subgraph backwards-compatibility
+          isAuthorized: isAuthorised,
+        })
+        .onConflictDoNothing();
     },
 
     async handleVersionChanged({
@@ -303,11 +330,14 @@ export const makeResolverHandlers = (ownedName: OwnedName) => {
       });
 
       // log ResolverEvent
-      await context.db.insert(schema.versionChanged).values({
-        ...sharedEventValues(event),
-        resolverId: id,
-        version: newVersion,
-      });
+      await context.db
+        .insert(schema.versionChanged)
+        .values({
+          ...sharedEventValues(event),
+          resolverId: id,
+          version: newVersion,
+        })
+        .onConflictDoNothing();
     },
 
     async handleDNSRecordChanged({


### PR DESCRIPTION
All events have to be recorded just once, with a unique primary key. None of recorded events will ever need to be updated.

Resolves:
- #183 
- #185 
- #197