### PR TITLE
fix: streamling dockerfiles further

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,7 @@
 **/.git
 **/Dockerfile
 .dockerignore
+
+# ignore ensrainbow artifacts on host machine
+ens_names.sql.gz*
+apps/ensrainbow/data/

--- a/apps/ensrainbow/.dockerignore
+++ b/apps/ensrainbow/.dockerignore
@@ -1,2 +1,0 @@
-ens_names.sql.gz*
-data/

--- a/apps/ensrainbow/Dockerfile
+++ b/apps/ensrainbow/Dockerfile
@@ -29,9 +29,6 @@ WORKDIR /app/apps/ensrainbow
 
 # copy data dir from ensrainbow-data
 COPY --from=ensrainbow-data /app/apps/ensrainbow/data ./data
-# Copy built files and dependencies
-COPY --from=app-deps /app/apps/ensrainbow/package*.json .
-COPY --from=app-deps /app/apps/ensrainbow/node_modules node_modules
 
 # Set environment variables
 ENV NODE_ENV=production

--- a/apps/ensrainbow/Dockerfile
+++ b/apps/ensrainbow/Dockerfile
@@ -28,7 +28,7 @@ FROM app-deps AS app
 WORKDIR /app/apps/ensrainbow
 
 # copy data dir from ensrainbow-data
-COPY --from=ensrainbow-data /app/apps/ensrainbow/data ./data
+COPY --from=ensrainbow-data /data ./data
 
 # Set environment variables
 ENV NODE_ENV=production

--- a/apps/ensrainbow/Dockerfile
+++ b/apps/ensrainbow/Dockerfile
@@ -28,7 +28,7 @@ FROM app-deps AS app
 WORKDIR /app/apps/ensrainbow
 
 # copy data dir from ensrainbow-data
-COPY --from=ensrainbow-data /data ./data
+COPY --from=ensrainbow-data /app/apps/ensrainbow/data ./data
 
 # Set environment variables
 ENV NODE_ENV=production

--- a/apps/ensrainbow/Dockerfile.data
+++ b/apps/ensrainbow/Dockerfile.data
@@ -38,5 +38,8 @@ WORKDIR /app/apps/ensrainbow
 COPY --from=db-data /app/ens_names.sql.gz .
 COPY --from=db-data /app/THE_GRAPH_LICENSE.txt .
 
-# produce the data dir artifact & cleanup
-RUN pnpm run ingest && rm ens_names.sql.gz
+# produce the data dir artifact
+RUN pnpm run ingest
+
+# cleanup input file to reduce image size
+RUN rm ens_names.sql.gz

--- a/apps/ensrainbow/Dockerfile.data
+++ b/apps/ensrainbow/Dockerfile.data
@@ -1,12 +1,11 @@
 # Base working stage
 FROM node:18-slim AS base
 RUN apt-get update && \
-    apt-get install -y wget && \
     npm install -g pnpm
 WORKDIR /app
 
 ###################
-## Data Stage — heavily cached remote data
+## Data Stage — download ens_name.sql archive & checksum
 ###################
 
 FROM base AS db-data
@@ -16,30 +15,20 @@ ADD "https://bucket.ensrainbow.io/THE_GRAPH_LICENSE.txt" ./THE_GRAPH_LICENSE.txt
 RUN sha256sum -c ens_names.sql.gz.sha256sum
 
 ###################
-## Ingest Dependencies Stage — minimal deps for ingest script
+## Dependencies Stage — standard monorepo pnpm install from base
 ###################
 
 FROM base AS ingest-deps
 
-# copy pnpm files from the root directory
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY pnpm-workspace.yaml ./
+COPY package.json pnpm-lock.yaml ./
+COPY packages ./packages
+COPY apps ./apps
 
-# copy just the dependent packages (sync with package.json)
-# TODO: this could be even more minimal
-COPY packages/ensrainbow-sdk ./packages/ensrainbow-sdk
-COPY packages/ensnode-utils ./packages/ensnode-utils
-
-# cwd to ensrainbow
-WORKDIR /app/apps/ensrainbow
-# copy ensrainbow package.json & src directory only
-COPY apps/ensrainbow/package*.json ./
-COPY apps/ensrainbow/src ./src
-
-# install
 RUN pnpm install --frozen-lockfile
 
 ###################
-## Ingest Runtime Stage — produces data dir artifact
+## Runtime Stage — produces data dir artifact
 ###################
 
 FROM ingest-deps AS ingest
@@ -51,16 +40,3 @@ COPY --from=db-data /app/THE_GRAPH_LICENSE.txt .
 
 # produce the data dir artifact & cleanup
 RUN pnpm run ingest && rm ens_names.sql.gz
-
-###################
-## Output image
-###################
-
-FROM app-deps AS app
-
-# cwd to ensrainbow
-WORKDIR /app/apps/ensrainbow
-
-# copy data dir from ingest
-COPY --from=ingest /app/apps/ensrainbow/data ./data
-COPY --from=ingest /app/apps/ensrainbow/THE_GRAPH_LICENSE.txt ./data

--- a/apps/ensrainbow/Dockerfile.data
+++ b/apps/ensrainbow/Dockerfile.data
@@ -48,6 +48,6 @@ RUN rm ens_names.sql.gz
 ## Output Image — just the data dir
 ###################
 
-FROM base
+FROM base AS ensrainbow-data
 
 COPY --from=ingest /app/apps/ensrainbow/data ./data

--- a/apps/ensrainbow/Dockerfile.data
+++ b/apps/ensrainbow/Dockerfile.data
@@ -28,7 +28,7 @@ COPY apps ./apps
 RUN pnpm install --frozen-lockfile
 
 ###################
-## Runtime Stage — produces data dir artifact
+## Runtime Stage — ingest to produce data dir artifact
 ###################
 
 FROM ingest-deps AS ingest

--- a/apps/ensrainbow/Dockerfile.data
+++ b/apps/ensrainbow/Dockerfile.data
@@ -43,3 +43,11 @@ RUN pnpm run ingest
 
 # cleanup input file to reduce image size
 RUN rm ens_names.sql.gz
+
+###################
+## Output Image — just the data dir
+###################
+
+FROM base
+
+COPY --from=ingest /app/apps/ensrainbow/data ./data

--- a/apps/ensrainbow/Dockerfile.data
+++ b/apps/ensrainbow/Dockerfile.data
@@ -5,7 +5,7 @@ RUN apt-get update && \
 WORKDIR /app
 
 ###################
-## Data Stage — download ens_name.sql archive & checksum
+## Data Stage — download ENS Subgraph rainbow table archive & checksum
 ###################
 
 FROM base AS db-data


### PR DESCRIPTION
- ignore host artifacts so builds will work even if user has these files on local machine (also helps with out of space issues)
- no need to copy node modules from app-deps if we're inheriting from app-deps stage
  - and there's no build step so the efficiency of splitting into multiple stages any only copying over deps + built app isn't important, we can just inherit from the deps stage directly.
- simplifies ingest significantly now that we're manually building