### PR TITLE
fix(apps): use pnpm version arg with every app

### DIFF
--- a/apps/ensadmin/Dockerfile
+++ b/apps/ensadmin/Dockerfile
@@ -1,7 +1,8 @@
 # Base working stage
 FROM node:18-slim AS builder
+ARG PNPM_VERSION=9.12.0
 RUN apt-get update && \
-    npm install -g pnpm 
+    npm install -g pnpm@${PNPM_VERSION}
 WORKDIR /app
 
 # Define the environment variables during the build process

--- a/apps/ensindexer/Dockerfile
+++ b/apps/ensindexer/Dockerfile
@@ -1,7 +1,8 @@
 # Base working stage
 FROM node:18-slim
+ARG PNPM_VERSION=9.12.0
 RUN apt-get update && \
-    npm install -g pnpm
+    npm install -g pnpm@${PNPM_VERSION}
 WORKDIR /app
 
 # Copy pnpm workspace configuration files from the root directory


### PR DESCRIPTION
This allows using `--frozen-lockfile` option when installing dependencies for which lockfile was generated with specifying pnpm version.

Related to:
- #315 