### PR TITLE
chore: ENSRainbow - landing page fixes - 1st batch

### DIFF
--- a/docs/ensrainbow/package.json
+++ b/docs/ensrainbow/package.json
@@ -25,6 +25,7 @@
     "classcat": "5.0.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-wrap-balancer": "^1.1.1",
     "tailwindcss": "3.4.13"
   }
 }

--- a/docs/ensrainbow/src/components/organisms/AboutRainbowSections.tsx
+++ b/docs/ensrainbow/src/components/organisms/AboutRainbowSections.tsx
@@ -47,22 +47,22 @@ const rainbowSections: AboutRainbowProps[] = [
           variant="underline"
           size="large"
         >
-            Example 1<span className="text-sm align-text-top">&#129133;</span>
+          Example 1<span className="text-sm align-text-top">&#129133;</span>
         </Link>{" "}
         and{" "}
-          <Link
-              href="https://app.ens.domains/[4283f2583432677d3dac6d2c021cdd7ef6855349ea584813ad5811c0e497eb0b].makoto.eth"
-              target="_blank"
-              className="!text-black"
-              variant="underline"
-              size="large"
-          >
-              Example 2<span className="text-sm align-text-top">&#129133;</span>
-          </Link>
+        <Link
+          href="https://app.ens.domains/[4283f2583432677d3dac6d2c021cdd7ef6855349ea584813ad5811c0e497eb0b].makoto.eth"
+          target="_blank"
+          className="!text-black"
+          variant="underline"
+          size="large"
+        >
+          Example 2<span className="text-sm align-text-top">&#129133;</span>
+        </Link>
       </>
     ),
-      sectionBackgroundName: "",
-      isTextOnTheLeft: true,
+    sectionBackgroundName: "",
+    isTextOnTheLeft: true,
     mobileImageOnTop: false,
     svgImage: <ENSProfile styles="relative z-10 w-full h-full" />,
     designatedMobileImage: (

--- a/docs/ensrainbow/src/components/organisms/AboutRainbowSections.tsx
+++ b/docs/ensrainbow/src/components/organisms/AboutRainbowSections.tsx
@@ -39,10 +39,7 @@ const rainbowSections: AboutRainbowProps[] = [
       <>
         These are encoded labelhashes used to represent an unknown label in an ENS name. Without
         name healing, millions of names in the ENS manager app (and other ENS apps) don’t appear
-        properly.
-        <br />
-        See the problem for yourself:
-        <br />
+        properly. See the problem for yourself:{" "}
         <Link
           href="https://app.ens.domains/0xfFD1Ac3e8818AdCbe5C597ea076E8D3210B45df5"
           target="_blank"
@@ -50,22 +47,22 @@ const rainbowSections: AboutRainbowProps[] = [
           variant="underline"
           size="large"
         >
-          Example 1↗
+            Example 1<span className="text-sm align-text-top">&#129133;</span>
         </Link>{" "}
         and{" "}
-        <Link
-          href="https://app.ens.domains/[4283f2583432677d3dac6d2c021cdd7ef6855349ea584813ad5811c0e497eb0b].makoto.eth"
-          target="_blank"
-          className="!text-black"
-          variant="underline"
-          size="large"
-        >
-          Example 2↗
-        </Link>
+          <Link
+              href="https://app.ens.domains/[4283f2583432677d3dac6d2c021cdd7ef6855349ea584813ad5811c0e497eb0b].makoto.eth"
+              target="_blank"
+              className="!text-black"
+              variant="underline"
+              size="large"
+          >
+              Example 2<span className="text-sm align-text-top">&#129133;</span>
+          </Link>
       </>
     ),
-    sectionBackgroundName: "",
-    isTextOnTheLeft: true,
+      sectionBackgroundName: "",
+      isTextOnTheLeft: true,
     mobileImageOnTop: false,
     svgImage: <ENSProfile styles="relative z-10 w-full h-full" />,
     designatedMobileImage: (

--- a/docs/ensrainbow/src/components/organisms/Footer.tsx
+++ b/docs/ensrainbow/src/components/organisms/Footer.tsx
@@ -10,7 +10,7 @@ import { NameHashLabsLogo } from "../atoms/logos/NameHashLabsLogo.tsx";
 const footerProducts = [
   {
     name: "ENSNode",
-    href: "https://www.ensnode.io/",
+    href: "https://ensnode.io/",
   },
   {
     name: "NameAI",

--- a/docs/ensrainbow/src/components/organisms/ForDevelopers.tsx
+++ b/docs/ensrainbow/src/components/organisms/ForDevelopers.tsx
@@ -10,11 +10,12 @@ import { NpmIcon } from "../atoms/icons/NpmIcon.tsx";
 import { RailwayIcon } from "../atoms/icons/RailwayIcon.tsx";
 import { TelegramIcon } from "../atoms/icons/TelegramIcon.tsx";
 import { DeveloperResourceItem } from "../molecules/DeveloperResourceItem.tsx";
+import { Balancer } from 'react-wrap-balancer'
 
 export default function DevelopersSection() {
   return (
     <section className="box-border w-full h-fit flex flex-col py-[60px] px-5 lg:py-[100px] items-center justify-center self-stretch gap-8 xl:gap-12 bg-gradient-to-b to-white from-[#F9FAFB] xl:max-h-screen">
-      <div className="flex flex-col justify-center items-center gap-5 max-w-[608px]">
+      <div className="flex flex-col justify-center items-center gap-5 max-w-[720px]">
         <div className="inline-flex px-4 py-2 bg-[rgba(0,0,0,0.05)] rounded-3xl gap-2 justify-center items-center z-10">
           <GithubIconSmall />
           <span className="text-black text-center text-sm leading-5 not-italic font-medium z-10">
@@ -24,9 +25,9 @@ export default function DevelopersSection() {
         <h1 className="text-black text-center not-italic z-10 text-2xl leading-8 font-bold md:text-4xl md:leading-10">
           ENSRainbow for Devs
         </h1>
-        <p className="text-center not-italic text-gray-500 text-lg leading-7 sm:font-normal font-light">
+        <Balancer className="text-center not-italic text-gray-500 text-lg leading-7 sm:font-normal font-light">
           All resources are open sourced and MIT licensed for the ENS community.
-        </p>
+        </Balancer>
       </div>
       <div className="w-fit h-fit flex flex-col md:flex-row md:flex-wrap max-w-[1220px] items-center justify-center xl:justify-start content-between gap-4">
         {devElements.map((elem, idx) => {
@@ -73,7 +74,7 @@ const devElements: ListSectionElement[] = [
         <FileOutlineIcon />
       </div>
     ),
-    link: "https://www.ensnode.io/ensrainbow/",
+    link: "https://ensnode.io/ensrainbow/",
   },
   {
     header: (

--- a/docs/ensrainbow/src/components/organisms/ForDevelopers.tsx
+++ b/docs/ensrainbow/src/components/organisms/ForDevelopers.tsx
@@ -1,4 +1,5 @@
 import { Fragment } from "react";
+import { Balancer } from "react-wrap-balancer";
 import { ListSectionElement } from "../../types/listSectionTypes.ts";
 import { ListSectionBadge } from "../atoms/ListSectionBadge.tsx";
 import { CloudOutlineIcon } from "../atoms/icons/CloudOutlineIcon.tsx";
@@ -10,7 +11,6 @@ import { NpmIcon } from "../atoms/icons/NpmIcon.tsx";
 import { RailwayIcon } from "../atoms/icons/RailwayIcon.tsx";
 import { TelegramIcon } from "../atoms/icons/TelegramIcon.tsx";
 import { DeveloperResourceItem } from "../molecules/DeveloperResourceItem.tsx";
-import { Balancer } from 'react-wrap-balancer'
 
 export default function DevelopersSection() {
   return (

--- a/docs/ensrainbow/src/components/organisms/FullRainbow.tsx
+++ b/docs/ensrainbow/src/components/organisms/FullRainbow.tsx
@@ -28,7 +28,7 @@ export default function FullRainbow() {
           ),
           value: 90,
           color:
-            "linear-gradient(90deg, #EA2F86 0%, #CA01FD 0.5%, #0B10FE 18.5%, #1EFDFF 36.5%, #93E223 53%, #FAE000 72.5%, #F09C0A 87.5%, #EA2F86 105%)",
+            "linear-gradient(90deg, #EA2F86 0%, #CA01FD 0.5%, #0B10FE 18.5%, #1EFDFF 36.5%, #93E223 53%, #FAE000 71%, #F09C0A 87.5%, #EA2F86 105%)",
         },
         {
           label: (

--- a/docs/ensrainbow/src/components/organisms/FullRainbow.tsx
+++ b/docs/ensrainbow/src/components/organisms/FullRainbow.tsx
@@ -18,7 +18,7 @@ export default function FullRainbow() {
         {
           label: <>ENS Subgraph</>,
           value: 20,
-          color: "linear-gradient(270deg, #DBE10B 0%, #FAE000 17.5%, #F09C0A 54.5%, #EA2F86 100%)",
+          color: "linear-gradient(90deg, #EA2F86 0%, #CA01FD 0.5%, #0B10FE 80%)",
         },
         {
           label: (
@@ -28,7 +28,7 @@ export default function FullRainbow() {
           ),
           value: 90,
           color:
-            "linear-gradient(270deg, #CA01FD -30.44%, #0B10FE -7.38%, #1EFDFF 16.33%, #93E223 38.07%, #FAE000 59.16%, #F09C0A 79.58%, #EA2F86 100%)",
+            "linear-gradient(90deg, #EA2F86 0%, #CA01FD 0.5%, #0B10FE 18.5%, #1EFDFF 36.5%, #93E223 53%, #FAE000 72.5%, #F09C0A 87.5%, #EA2F86 105%)",
         },
         {
           label: (
@@ -38,7 +38,7 @@ export default function FullRainbow() {
           ),
           value: 95,
           color:
-            "linear-gradient(270deg, #EA2F86 0%, #CA01FD 1%, #0B10FE 18.5%, #1EFDFF 36.5%, #93E223 53%, #FAE000 69%, #F09C0A 84.5%, #EA2F86 100%)",
+            "linear-gradient(90deg, #EA2F86 0%, #CA01FD 0.5%, #0B10FE 18.5%, #1EFDFF 36.5%, #93E223 53%, #FAE000 69%, #F09C0A 84.5%, #EA2F86 100%)",
         },
       ]}
       title="Name Healing Coverage"

--- a/docs/ensrainbow/src/components/organisms/Header.tsx
+++ b/docs/ensrainbow/src/components/organisms/Header.tsx
@@ -20,7 +20,7 @@ export default function Header() {
         </div>
         <div className="hidden sm:flex items-center justify-center gap-1">
           <Button variant="ghost" asChild>
-            <Link href="https://www.ensnode.io/ensrainbow/">Docs</Link>
+            <Link href="https://ensnode.io/ensrainbow/">Docs</Link>
           </Button>
 
           <Button variant="ghost" asChild>
@@ -38,7 +38,7 @@ export default function Header() {
         <div className="sm:hidden flex items-center justify-center gap-1">
           <IconButton asChild variant="ghost">
             <Link
-              href="https://www.ensnode.io/ensrainbow/"
+              href="https://ensnode.io/ensrainbow/"
               target="_blank"
               size="small"
               className="hover:no-underline nk-underline-none"

--- a/docs/ensrainbow/src/components/organisms/Hero.tsx
+++ b/docs/ensrainbow/src/components/organisms/Hero.tsx
@@ -44,12 +44,12 @@ export default function Hero() {
 
           <div className="block relative z-10 pt-3 lg:hidden">
             <Button asChild>
-              <Link href="https://www.ensnode.io/ensrainbow/">View the docs</Link>
+              <Link href="https://ensnode.io/ensrainbow/">View the docs</Link>
             </Button>
           </div>
           <div className="hidden lg:block relative z-10">
             <Button variant="primary" size="large" asChild>
-              <Link href="https://www.ensnode.io/ensrainbow/">View the docs</Link>
+              <Link href="https://ensnode.io/ensrainbow/">View the docs</Link>
             </Button>
           </div>
         </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -470,6 +470,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-wrap-balancer:
+        specifier: ^1.1.1
+        version: 1.1.1(react@18.3.1)
       tailwindcss:
         specifier: 3.4.13
         version: 3.4.13
@@ -835,10 +838,6 @@ packages:
 
   '@babel/types@7.26.10':
     resolution: {integrity: sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.26.7':
-    resolution: {integrity: sha512-t8kDRGrKXyp6+tjUh7hw2RLyclsW4TRoRvRHtSyAX9Bb5ldlFh+90YAYY6awRXrlB4G5G2izNeGySpATlFzmOg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.26.9':
@@ -5485,6 +5484,11 @@ packages:
       '@types/react':
         optional: true
 
+  react-wrap-balancer@1.1.1:
+    resolution: {integrity: sha512-AB+l7FPRWl6uZ28VcJ8skkwLn2+UC62bjiw8tQUrZPlEWDVnR9MG0lghyn7EyxuJSsFEpht4G+yh2WikEqQ/5Q==}
+    peerDependencies:
+      react: '>=16.8.0 || ^17.0.0 || ^18'
+
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -7250,11 +7254,6 @@ snapshots:
       - supports-color
 
   '@babel/types@7.26.10':
-    dependencies:
-      '@babel/helper-string-parser': 7.25.9
-      '@babel/helper-validator-identifier': 7.25.9
-
-  '@babel/types@7.26.7':
     dependencies:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
@@ -12896,6 +12895,10 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 18.3.18
+
+  react-wrap-balancer@1.1.1(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   react@18.3.1:
     dependencies:


### PR DESCRIPTION
Fixes and changes to ENSRainbow LP, including:
- [x] Horizontal flip and improved alignment of the gradients in bar chart in **FullRainbow** component
- [x] Introduction of `react-wrap-balancer` to **ForDevelopers** section description.
- [x] Removed line breaking and replaced arrows for **What the heck is [428...]?** section
- [x] Unification of links to [ensnode.io](ensnode.io) (now all without "www")