### PR TITLE
Feat/382 create bluegreen environments

### DIFF
--- a/.github/workflows/switch_ensnode_environment.yml
+++ b/.github/workflows/switch_ensnode_environment.yml
@@ -25,7 +25,11 @@ jobs:
       - name: Print switch target
         run: | 
             echo "Switching to: $TARGET_ENVIRONMENT"
-      
+
+      - name: Install redis-cli
+        run: | 
+            sudo apt install redis-tools
+
       - name: Switch Traefik routers
         run: |
             # SEPOLIA

--- a/.github/workflows/switch_ensnode_environment.yml
+++ b/.github/workflows/switch_ensnode_environment.yml
@@ -15,7 +15,7 @@ on:
         - feat/382-create-bluegreen-environments
 
 jobs:
-  deploy:
+  switch-environment:
     runs-on: ubuntu-latest
     env:
       TARGET_ENVIRONMENT: "green"
@@ -33,19 +33,19 @@ jobs:
       - name: Switch Traefik routers
         run: |
             # SEPOLIA
-            redis-cli -u $REDIS_URL SET traefik/http/routers/sepolia-api-router/service "${TARGET_ENVRIONMENT}-sepolia-api"
-            redis-cli -u $REDIS_URL SET traefik/http/routers/sepolia-indexer-router/service "${TARGET_ENVRIONMENT}-sepolia-indexer"
+            redis-cli -u $REDIS_URL SET traefik/http/routers/sepolia-api-router/service "${TARGET_ENVIRONMENT}-sepolia-api"
+            redis-cli -u $REDIS_URL SET traefik/http/routers/sepolia-indexer-router/service "${TARGET_ENVIRONMENT}-sepolia-indexer"
 
             # ALPHA
-            redis-cli -u $REDIS_URL SET traefik/http/routers/alpha-api-router/service "${TARGET_ENVRIONMENT}-alpha-api"
-            redis-cli -u $REDIS_URL SET traefik/http/routers/alpha-indexer-router/service "${TARGET_ENVRIONMENT}-alpha-indexer"
+            redis-cli -u $REDIS_URL SET traefik/http/routers/alpha-api-router/service "${TARGET_ENVIRONMENT}-alpha-api"
+            redis-cli -u $REDIS_URL SET traefik/http/routers/alpha-indexer-router/service "${TARGET_ENVIRONMENT}-alpha-indexer"
 
             # MAINNET
-            redis-cli -u $REDIS_URL SET traefik/http/routers/mainnet-api-router/service "${TARGET_ENVRIONMENT}-mainnet-api"
-            redis-cli -u $REDIS_URL SET traefik/http/routers/mainnet-indexer-router/service "${TARGET_ENVRIONMENT}-mainnet-indexer"
+            redis-cli -u $REDIS_URL SET traefik/http/routers/mainnet-api-router/service "${TARGET_ENVIRONMENT}-mainnet-api"
+            redis-cli -u $REDIS_URL SET traefik/http/routers/mainnet-indexer-router/service "${TARGET_ENVIRONMENT}-mainnet-indexer"
 
             # HOLESKY
-            redis-cli -u $REDIS_URL SET traefik/http/routers/holesky-api-router/service "${TARGET_ENVRIONMENT}-holesky-api"
-            redis-cli -u $REDIS_URL SET traefik/http/routers/holesky-indexer-router/service "${TARGET_ENVRIONMENT}-holesky-indexer"
+            redis-cli -u $REDIS_URL SET traefik/http/routers/holesky-api-router/service "${TARGET_ENVIRONMENT}-holesky-api"
+            redis-cli -u $REDIS_URL SET traefik/http/routers/holesky-indexer-router/service "${TARGET_ENVIRONMENT}-holesky-indexer"
 
           

--- a/.github/workflows/switch_ensnode_environment.yml
+++ b/.github/workflows/switch_ensnode_environment.yml
@@ -1,0 +1,47 @@
+name: Switch ENSNode main environment
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'New main environment (green or blue)'
+        required: true
+        type: choice
+        options:
+          - green
+          - blue
+  push:
+    branches:
+        - feat/382-create-bluegreen-environments
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      TARGET_ENVIRONMENT: "green"
+      REDIS_URL: ${{ secrets.TRAEFIK_REDIS_URL }}
+    
+    steps:
+      - name: Print switch target
+        run: | 
+            echo "Switching to: $TARGET_ENVIRONMENT"
+      
+      - name: Switch Traefik routers
+        run: |
+            # SEPOLIA
+            redis-cli -u $REDIS_URL SET traefik/http/routers/sepolia-api-router/service "${TARGET_ENVRIONMENT}-sepolia-api"
+            redis-cli -u $REDIS_URL SET traefik/http/routers/sepolia-indexer-router/service "${TARGET_ENVRIONMENT}-sepolia-indexer"
+
+            # ALPHA
+            redis-cli -u $REDIS_URL SET traefik/http/routers/alpha-api-router/service "${TARGET_ENVRIONMENT}-alpha-api"
+            redis-cli -u $REDIS_URL SET traefik/http/routers/alpha-indexer-router/service "${TARGET_ENVRIONMENT}-alpha-indexer"
+
+            # MAINNET
+            redis-cli -u $REDIS_URL SET traefik/http/routers/mainnet-api-router/service "${TARGET_ENVRIONMENT}-mainnet-api"
+            redis-cli -u $REDIS_URL SET traefik/http/routers/mainnet-indexer-router/service "${TARGET_ENVRIONMENT}-mainnet-indexer"
+
+            # HOLESKY
+            redis-cli -u $REDIS_URL SET traefik/http/routers/holesky-api-router/service "${TARGET_ENVRIONMENT}-holesky-api"
+            redis-cli -u $REDIS_URL SET traefik/http/routers/holesky-indexer-router/service "${TARGET_ENVRIONMENT}-holesky-indexer"
+
+          

--- a/.github/workflows/switch_ensnode_environment.yml
+++ b/.github/workflows/switch_ensnode_environment.yml
@@ -18,7 +18,7 @@ jobs:
   switch-environment:
     runs-on: ubuntu-latest
     env:
-      TARGET_ENVIRONMENT: "green"
+      TARGET_ENVIRONMENT: "blue"
       REDIS_URL: ${{ secrets.TRAEFIK_REDIS_URL }}
     
     steps:

--- a/.github/workflows/switch_ensnode_environment.yml
+++ b/.github/workflows/switch_ensnode_environment.yml
@@ -10,15 +10,12 @@ on:
         options:
           - green
           - blue
-  push:
-    branches:
-        - feat/382-create-bluegreen-environments
 
 jobs:
   switch-environment:
     runs-on: ubuntu-latest
     env:
-      TARGET_ENVIRONMENT: "green"
+      TARGET_ENVIRONMENT: ${{ inputs.target }}
       REDIS_URL: ${{ secrets.TRAEFIK_REDIS_URL }}
     
     steps:

--- a/.github/workflows/switch_ensnode_environment.yml
+++ b/.github/workflows/switch_ensnode_environment.yml
@@ -18,7 +18,7 @@ jobs:
   switch-environment:
     runs-on: ubuntu-latest
     env:
-      TARGET_ENVIRONMENT: "blue"
+      TARGET_ENVIRONMENT: "green"
       REDIS_URL: ${{ secrets.TRAEFIK_REDIS_URL }}
     
     steps:


### PR DESCRIPTION
Related to: https://github.com/namehash/ensnode/issues/382
Workflow for changing main environments: blue/green
PR is adding a manual workflow to trigger the Traefik environment "switch" inside GitHub Actions. Depending on workflow input flag green or blue environment will be set as "active" in Railway.