### PR TITLE
fix: correctly parse args where null bytes values may be encountered

### DIFF
--- a/apps/ensindexer/src/handlers/Registrar.ts
+++ b/apps/ensindexer/src/handlers/Registrar.ts
@@ -26,15 +26,6 @@ export const makeRegistrarHandlers = (ownedName: OwnedName) => {
     labelhash: Labelhash,
     cost: bigint,
   ) {
-    // NOTE: ponder intentionally removes null bytes to spare users the footgun of
-    // inserting null bytes into postgres. We don't like this behavior, though, because it's
-    // important that 'vitalik\x00'.eth and vitalik.eth are differentiable.
-    // https://github.com/ponder-sh/ponder/issues/1456
-    // So here we use the labelhash fn to determine whether ponder modified our `name` argument,
-    // in which case we know that it used to have null bytes in it, and we should ignore it.
-    const didHaveNullBytes = _labelhash(name) !== labelhash;
-    if (didHaveNullBytes) return;
-
     // if the label is otherwise un-indexable, ignore it (see isLabelIndexable for context)
     if (!isLabelIndexable(name)) return;
 

--- a/apps/ensindexer/src/handlers/Resolver.ts
+++ b/apps/ensindexer/src/handlers/Resolver.ts
@@ -1,7 +1,7 @@
 import { type Context } from "ponder:registry";
 import schema from "ponder:schema";
 import type { Node } from "@ensnode/utils/types";
-import { Hex } from "viem";
+import { Hex, namehash } from "viem";
 import { createSharedEventValues, upsertAccount, upsertResolver } from "../lib/db-helpers";
 import { makeResolverId } from "../lib/ids";
 import { hasNullByte, uniq } from "../lib/lib-helpers";
@@ -100,6 +100,7 @@ export const makeResolverHandlers = (ownedName: OwnedName) => {
     }) {
       const { node, name } = event.args;
       if (hasNullByte(name)) return;
+      if (namehash(name) !== node) return; // also check to make sure ponder didn't strip our null bytes
 
       const id = makeResolverId(event.log.address, node);
       await upsertResolver(context, {

--- a/apps/ensindexer/src/plugins/base/handlers/Registrar.ts
+++ b/apps/ensindexer/src/plugins/base/handlers/Registrar.ts
@@ -1,8 +1,9 @@
 import { ponder } from "ponder:registry";
 import schema from "ponder:schema";
+import DeploymentConfigs from "@ensnode/ens-deployments";
 import { makeSubnodeNamehash, uint256ToHex32 } from "@ensnode/utils/subname-helpers";
-import type { Labelhash } from "@ensnode/utils/types";
-import { zeroAddress } from "viem";
+import { Labelhash } from "@ensnode/utils/types";
+import { decodeEventLog, zeroAddress } from "viem";
 import { makeRegistrarHandlers } from "../../../handlers/Registrar";
 import { upsertAccount } from "../../../lib/db-helpers";
 import { PonderENSPluginHandlerArgs } from "../../../lib/plugin-helpers";
@@ -101,27 +102,47 @@ export default function ({ ownedName, namespace }: PonderENSPluginHandlerArgs<"b
   });
 
   ponder.on(namespace("EARegistrarController:NameRegistered"), async ({ context, event }) => {
-    // TODO: registration expected here
+    // NOTE(name-null-bytes): manually decode args that may contain null bytes
+    const { args } = decodeEventLog({
+      eventName: "NameRegistered",
+      abi: DeploymentConfigs.mainnet.base.contracts.EARegistrarController.abi,
+      topics: event.log.topics,
+      data: event.log.data,
+    });
 
     await handleNameRegisteredByController({
       context,
-      event: { ...event, args: { ...event.args, cost: 0n } },
+      event: { ...event, args: { ...args, cost: 0n } },
     });
   });
 
   ponder.on(namespace("RegistrarController:NameRegistered"), async ({ context, event }) => {
-    // TODO: registration expected here
+    // NOTE(name-null-bytes): manually decode args that may contain null bytes
+    const { args } = decodeEventLog({
+      eventName: "NameRegistered",
+      abi: DeploymentConfigs.mainnet.base.contracts.RegistrarController.abi,
+      topics: event.log.topics,
+      data: event.log.data,
+    });
 
     await handleNameRegisteredByController({
       context,
-      event: { ...event, args: { ...event.args, cost: 0n } },
+      event: { ...event, args: { ...args, cost: 0n } },
     });
   });
 
   ponder.on(namespace("RegistrarController:NameRenewed"), async ({ context, event }) => {
+    // NOTE(name-null-bytes): manually decode args that may contain null bytes
+    const { args } = decodeEventLog({
+      eventName: "NameRenewed",
+      abi: DeploymentConfigs.mainnet.base.contracts.RegistrarController.abi,
+      topics: event.log.topics,
+      data: event.log.data,
+    });
+
     await handleNameRenewedByController({
       context,
-      event: { ...event, args: { ...event.args, cost: 0n } },
+      event: { ...event, args: { ...args, cost: 0n } },
     });
   });
 }


### PR DESCRIPTION
- [x] `NameRegistered` handler wasn't catching null bytes correctly because of ponder stripping them — we fixed in preimage but not at this callsite.
- [x] updates all other callsites with manual arg parsing as well, removes the labelhash comparison in `setNamePreimage`
- [x] need to take a snapshot of mainnet again to make sure these edits keep the same logic, so waiting on that before merging