### PR TITLE
fix(ci): prevent `docs` from being published to npm

### DIFF
--- a/apps/ensadmin/package.json
+++ b/apps/ensadmin/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "description": "Control ENSNode via ENSAdmin Dashboard Interface",
+  "description": "Explore the ENS Protocol like never before",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/docs/ensrainbow/package.json
+++ b/docs/ensrainbow/package.json
@@ -2,6 +2,7 @@
   "name": "@docs/ensrainbow",
   "type": "module",
   "version": "0.0.1",
+  "private": true,
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",


### PR DESCRIPTION
This PR is a fix to situation where changesets attempt to publish to NPM from `docs` website package. For example:
- https://github.com/namehash/ensnode/actions/runs/13908403750