### PR TITLE
fix(ensadmin): set `/about` path redirect

### DIFF
--- a/apps/ensadmin/next.config.ts
+++ b/apps/ensadmin/next.config.ts
@@ -13,6 +13,18 @@ const nextConfig: NextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  async redirects() {
+    return [
+      {
+        // Provide backward compatibility for ENSNode services.
+        // The older ones would redirect their homepage to ENSAdmin `/about`
+        // which was discontinued in the application router.
+        source: "/about",
+        destination: "/",
+        permanent: true,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
This PR provide backward compatibility for ENSNode services. The older ones would redirect their homepage to ENSAdmin `/about` which was discontinued in the application router.

Feel free to test out the redirect from ENSAdmin `/about` to ENSAdmin `/` (which ENSAdmin app internally resolves to `/status`)
- https://adminensnodeio-git-fix-ensadmin-about-redirect-namehash.vercel.app/about?ensnode=https%3A%2F%2Fapi.mainnet.green.ensnode.io%2F