### PR TITLE
fix(docker): include `ghcr.io` in image names

### DIFF
--- a/apps/ensrainbow/.env.local.example
+++ b/apps/ensrainbow/.env.local.example
@@ -1,0 +1,3 @@
+# Define log level to manage log output
+# Allowed values: fatal, error, warn, info, debug, trace, silent
+LOG_LEVEL=info

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       # Note: it must be URL accessible from web browser (i.e. it cannot be a hostname in docker network)
       ENSNODE_PUBLIC_URL: http://localhost:42069
     env_file:
+      # NOTE: must define apps/ensindexer/.env.local (see apps/ensindexer/.env.local.example)
       - path: ./apps/ensindexer/.env.local
         required: true
     depends_on:
@@ -27,6 +28,7 @@ services:
     ports:
       - "3223:3223"
     env_file:
+      # NOTE: can define apps/ensrainbow/.env.local (see apps/ensrainbow/.env.local.example)
       - path: ./apps/ensrainbow/.env.local
         required: false
     restart: unless-stopped
@@ -44,6 +46,7 @@ services:
       # Note: it must be URL accessible from web browser (i.e. it cannot be a hostname in docker network)
       NEXT_PUBLIC_PREFERRED_ENSNODE_URL: http://localhost:42069
     env_file:
+      # NOTE: can define apps/ensadmin/.env.local (see apps/ensadmin/.env.local.example)
       - path: ./apps/ensadmin/.env.local
         required: false
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   ensindexer:
     container_name: ensindexer
-    image: namehash/ensnode/ensindexer
+    image: ghcr.io/namehash/ensnode/ensindexer:latest
     ports:
       - "42069:42069"
     environment:
@@ -11,7 +11,8 @@ services:
       ENSRAINBOW_URL: http://ensrainbow:3223
       # Override ENSADMIN_URL to point to docker compose ensadmin
       ENSADMIN_URL: http://localhost:4321
-      # Override ENSNODE_PUBLIC_URL to point to docker compose ensadmin
+      # Override ENSNODE_PUBLIC_URL to point to docker compose ensindexer
+      # Note: it must be URL accessible from web browser (i.e. it cannot be a hostname in docker network)
       ENSNODE_PUBLIC_URL: http://localhost:42069
     env_file:
       - path: ./apps/ensindexer/.env.local
@@ -22,7 +23,7 @@ services:
 
   ensrainbow:
     container_name: ensrainbow
-    image: namehash/ensnode/ensrainbow
+    image: ghcr.io/namehash/ensnode/ensrainbow:latest
     ports:
       - "3223:3223"
     env_file:
@@ -32,11 +33,16 @@ services:
 
   ensadmin:
     container_name: ensadmin
-    image: namehash/ensnode/ensadmin
+    image: ghcr.io/namehash/ensnode/ensadmin:latest
     ports:
       - "4173:4173"
     environment:
-      VITE_ENSNODE_URL: http://ensindexer:42069
+      # Override ENSNODE_PUBLIC_URL to point to docker compose ensindexer
+      # Note: it must be URL accessible from web browser (i.e. it cannot be a hostname in docker network)
+      ENSNODE_PUBLIC_URL: http://localhost:4173
+      # Override NEXT_PUBLIC_PREFERRED_ENSNODE_URL to docker compose ensindexer
+      # Note: it must be URL accessible from web browser (i.e. it cannot be a hostname in docker network)
+      NEXT_PUBLIC_PREFERRED_ENSNODE_URL: http://localhost:42069
     env_file:
       - path: ./apps/ensadmin/.env.local
         required: false

--- a/docs/ensnode.io/src/content/docs/ensnode/contributing/index.mdx
+++ b/docs/ensnode.io/src/content/docs/ensnode/contributing/index.mdx
@@ -127,7 +127,7 @@ If you make changes in the application code and wish to run those updates, you m
 Run the built images with:
 
 ```bash
-docker compose up
+docker compose up -d
 ```
 
 - **ENSIndexer**: Available at [http://localhost:42069](http://localhost:42069)

--- a/docs/ensnode.io/src/content/docs/ensrainbow/contributing/building.mdx
+++ b/docs/ensnode.io/src/content/docs/ensrainbow/contributing/building.mdx
@@ -13,14 +13,14 @@ This image downloads the source `ens_names.sql.gz` and ingests them to produce t
 
 ```bash
 # from the monorepo root
-docker build -f apps/ensrainbow/Dockerfile.data -t namehash/ensnode/ensrainbow-data .
+docker build -f apps/ensrainbow/Dockerfile.data -t ghcr.io/namehash/ensnode/ensrainbow-data .
 ```
 
 ## ENSRainbow (`namehash/ensnode/ensrainbow`)
 
 ```bash
 # from the monorepo root
-docker build -f apps/ensrainbow/Dockerfile -t namehash/ensnode/ensrainbow .
+docker build -f apps/ensrainbow/Dockerfile -t ghcr.io/namehash/ensnode/ensrainbow .
 ```
 
 ## ENSRainbow-v2-data (`ghcr.io/<your-repo>/ensrainbow-v2-data`)
@@ -29,7 +29,7 @@ This image includes the latest LevelDB data for rainbow table lookups. It uses t
 
 ```bash
 # from the monorepo root
-docker build -f apps/ensrainbow/Dockerfile.data --build-arg DATA_VERSION=v2 -t namehash/ensnode/ensrainbow-v2-data .
+docker build -f apps/ensrainbow/Dockerfile.data --build-arg DATA_VERSION=v2 -t ghcr.io/namehash/ensnode/ensrainbow-v2-data .
 ```
 
 ## ENSRainbow v2 (`ghcr.io/<your-repo>/ensrainbow-v2`)
@@ -38,5 +38,5 @@ This image builds the ENSRainbow v2 app and uses the `ensrainbow-v2-data` image 
 
 ```bash
 # from the monorepo root
-docker build -f apps/ensrainbow/Dockerfile --build-arg DATA_IMAGE_NAME=ensrainbow-v2-data -t namehash/ensnode/ensrainbow-v2 .
+docker build -f apps/ensrainbow/Dockerfile --build-arg DATA_IMAGE_NAME=ensrainbow-v2-data -t ghcr.io/namehash/ensnode/ensrainbow-v2 .
 ```

--- a/examples/example-docker-compose/docker-compose.yml
+++ b/examples/example-docker-compose/docker-compose.yml
@@ -12,9 +12,9 @@ services:
       ENSRAINBOW_URL: http://ensrainbow:3223
       # Override ENSADMIN_URL to point to docker compose ensadmin
       ENSADMIN_URL: http://localhost:4321
-      # Override ENSNODE_PUBLIC_URL to point to docker compose ensadmin
+      # Override ENSNODE_PUBLIC_URL to point to docker compose ensindexer
+      # Note: it must be URL accessible from web browser (i.e. it cannot be a hostname in docker network)
       ENSNODE_PUBLIC_URL: http://localhost:42069
-      # NOTE: must define indexing behavior in .env.local (see .env.local.example)
     env_file:
       - ./.env.local
     depends_on:
@@ -23,7 +23,7 @@ services:
 
   ensrainbow:
     container_name: ensrainbow
-    image: ghcr.io/namehash/ensnode/ensrainbow:latest
+    image: ghcr.io/namehash/ensnode/ensrainbow:stable
     pull_policy: always
     ports:
       - "3223:3223"
@@ -33,12 +33,17 @@ services:
 
   ensadmin:
     container_name: ensadmin
-    image: ghcr.io/namehash/ensnode/ensadmin:latest
+    image: ghcr.io/namehash/ensnode/ensadmin:stable
     pull_policy: always
     ports:
       - "4173:4173"
     environment:
-      VITE_ENSNODE_URL: http://ensindexer:42069
+      # Override ENSNODE_PUBLIC_URL to point to docker compose ensindexer
+      # Note: it must be URL accessible from web browser (i.e. it cannot be a hostname in docker network)
+      ENSNODE_PUBLIC_URL: http://localhost:4173
+      # Override NEXT_PUBLIC_PREFERRED_ENSNODE_URL to docker compose ensindexer
+      # Note: it must be URL accessible from web browser (i.e. it cannot be a hostname in docker network)
+      NEXT_PUBLIC_PREFERRED_ENSNODE_URL: http://localhost:42069
     env_file:
       - ./.env.local
     depends_on:

--- a/examples/example-docker-compose/docker-compose.yml
+++ b/examples/example-docker-compose/docker-compose.yml
@@ -1,8 +1,7 @@
 services:
   ensindexer:
     container_name: ensindexer
-    image: ghcr.io/namehash/ensnode/ensindexer:stable
-    pull_policy: always
+    image: ghcr.io/namehash/ensnode/ensindexer:latest
     ports:
       - "42069:42069"
     environment:
@@ -16,25 +15,27 @@ services:
       # Note: it must be URL accessible from web browser (i.e. it cannot be a hostname in docker network)
       ENSNODE_PUBLIC_URL: http://localhost:42069
     env_file:
-      - ./.env.local
+      # NOTE: must define apps/ensindexer/.env.local (see apps/ensindexer/.env.local.example)
+      - path: ./apps/ensindexer/.env.local
+        required: true
     depends_on:
       - ensrainbow
       - postgres
 
   ensrainbow:
     container_name: ensrainbow
-    image: ghcr.io/namehash/ensnode/ensrainbow:stable
-    pull_policy: always
+    image: ghcr.io/namehash/ensnode/ensrainbow:latest
     ports:
       - "3223:3223"
     env_file:
-      - ./.env.local
+      # NOTE: can define apps/ensrainbow/.env.local (see apps/ensrainbow/.env.local.example)
+      - path: ./apps/ensrainbow/.env.local
+        required: false
     restart: unless-stopped
 
   ensadmin:
     container_name: ensadmin
-    image: ghcr.io/namehash/ensnode/ensadmin:stable
-    pull_policy: always
+    image: ghcr.io/namehash/ensnode/ensadmin:latest
     ports:
       - "4173:4173"
     environment:
@@ -45,7 +46,9 @@ services:
       # Note: it must be URL accessible from web browser (i.e. it cannot be a hostname in docker network)
       NEXT_PUBLIC_PREFERRED_ENSNODE_URL: http://localhost:42069
     env_file:
-      - ./.env.local
+      # NOTE: can define apps/ensadmin/.env.local (see apps/ensadmin/.env.local.example)
+      - path: ./apps/ensadmin/.env.local
+        required: false
     depends_on:
       - ensindexer
 

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "version": "changeset version",
     "packages:prepublish": "pnpm -r --filter='@ensnode/*' prepublish",
     "docker:build:ensnode": "pnpm run docker:build:ensindexer && pnpm run docker:build:ensrainbow && pnpm run docker:build:ensadmin",
-    "docker:build:ensindexer": "docker build -f apps/ensindexer/Dockerfile -t namehash/ensnode/ensindexer:latest .",
-    "docker:build:ensrainbow": "docker build -f apps/ensrainbow/Dockerfile -t namehash/ensnode/ensrainbow:latest .",
-    "docker:build:ensadmin": "docker build -f apps/ensadmin/Dockerfile -t namehash/ensnode/ensadmin:latest ."
+    "docker:build:ensindexer": "docker build -f apps/ensindexer/Dockerfile -t ghcr.io/namehash/ensnode/ensindexer:latest .",
+    "docker:build:ensrainbow": "docker build -f apps/ensrainbow/Dockerfile -t ghcr.io/namehash/ensnode/ensrainbow:latest .",
+    "docker:build:ensadmin": "docker build -f apps/ensadmin/Dockerfile -t ghcr.io/namehash/ensnode/ensadmin:latest ."
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",


### PR DESCRIPTION
This PR:
1. Allows selectively building local docker images from source code, ie. by running any of the following commands
  - `pnpm docker:build:ensadmin` 
  - `pnpm docker:build:ensindexer` 
  - `pnpm docker:build:ensrainbow`
  - `pnpm docker:build:ensnode`
  
2. Enables auto-pulling docker images from ghcr.io registry that were not found locally. This way, a user can run all services just with the following command:
  - `docker compose up -d`

3. Aligns docker compose example file (`examples/example-docker-compose/docker-compose.yml`) with the root docker compose file (`docker-compose.yml`). Uses only the `latest` tag for service images.