### PR TITLE
fix(ensindexer): update validation logic

### DIFF
--- a/apps/ensindexer/src/lib/ponder-helpers.ts
+++ b/apps/ensindexer/src/lib/ponder-helpers.ts
@@ -350,9 +350,16 @@ export function createFirstBlockToIndexByChainIdFetcher(
     const startBlockNumberForChainId = startBlockNumbers[chainId];
 
     // each chain should have a start block number
-    if (!startBlockNumberForChainId) {
+    if (typeof startBlockNumberForChainId !== "number") {
       // throw an error if the start block number is not found for the chain ID
       throw new Error(`No start block number found for chain ID ${chainId}`);
+    }
+
+    if (startBlockNumberForChainId < 0) {
+      // throw an error if the start block number is invalid block number
+      throw new Error(
+        `Start block number "${startBlockNumberForChainId}" for chain ID ${chainId} must be a non-negative integer`,
+      );
     }
 
     const block = await publicClient.getBlock({


### PR DESCRIPTION
This PR allows `0` to be a valid start block for a chain. The Anvil network starts at block `0` and we need to handle it well.