### PR TITLE
fix(ensadmin): use dynamic metadata

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,6 @@
 ens_names.sql
 ens_name.sql.*
 apps/ensrainbow/data/
+
+# ignore env files (and let docker compose link to env files)
+**/.env*

--- a/apps/ensadmin/.env.local.example
+++ b/apps/ensadmin/.env.local.example
@@ -1,7 +1,3 @@
-# The ENSAdmin public service URL
-# The ENSAdmin web application needs this value to reference static assets.
-ENSADMIN_PUBLIC_URL=http://localhost:4173
-
 # Preferred ENSNode URL (used by default when ENSAdmin is opened)
 # If not set, the fallback URL from `PREFERRED_ENSNODE_URL` const is used.
 NEXT_PUBLIC_PREFERRED_ENSNODE_URL=https://alpha.ensnode.io

--- a/apps/ensadmin/.env.local.example
+++ b/apps/ensadmin/.env.local.example
@@ -1,3 +1,8 @@
+# The ENSAdmin public service URL
+# The ENSAdmin web application needs this value to reference static assets.
+# Note: make sure to define this value for all deployments outside Vercel platform.
+ENSADMIN_PUBLIC_URL=http://localhost:4173
+
 # Preferred ENSNode URL (used by default when ENSAdmin is opened)
 # If not set, the fallback URL from `PREFERRED_ENSNODE_URL` const is used.
 NEXT_PUBLIC_PREFERRED_ENSNODE_URL=https://alpha.ensnode.io

--- a/apps/ensadmin/.env.local.example
+++ b/apps/ensadmin/.env.local.example
@@ -1,6 +1,9 @@
 # The ENSAdmin public service URL
 # The ENSAdmin web application needs this value to reference static assets.
-# Note: make sure to define this value for all deployments outside Vercel platform.
+# Note: it's recommended to explicitly set it. If not explicitly set,
+# the application will try guess this value. For example, if hosting in Vercel,
+# the Vercel env and Vercel URLs will be used. If not provided,
+# the default public URL will be based on localhost and PORT.
 ENSADMIN_PUBLIC_URL=http://localhost:4173
 
 # Preferred ENSNode URL (used by default when ENSAdmin is opened)

--- a/apps/ensadmin/package.json
+++ b/apps/ensadmin/package.json
@@ -42,7 +42,7 @@
     "date-fns": "^4.1.0",
     "graphiql": "^3.8.3",
     "lucide-react": "^0.476.0",
-    "next": "15.1.7",
+    "next": "15.2.3",
     "next-themes": "^0.4.6",
     "react": "^18",
     "react-dom": "^18",

--- a/apps/ensadmin/src/app/layout.tsx
+++ b/apps/ensadmin/src/app/layout.tsx
@@ -22,17 +22,10 @@ const title = "ENSAdmin";
 const description = "Explore the ENS Protocol like never before";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const metadataBaseUrl = ensAdminPublicUrl();
-
   return {
     title: title,
     description: description,
-    /**
-     * Note: using Vercel platform for ENSAdmin deployments works best when
-     * this function returns undefined and lets default values to be applied.
-     * Read more: https://nextjs.org/docs/app/api-reference/functions/generate-metadata#default-value
-     */
-    metadataBase: metadataBaseUrl ? new URL(metadataBaseUrl) : undefined,
+    metadataBase: ensAdminPublicUrl(),
     openGraph: {
       title: {
         template: `${siteName} - %s`,

--- a/apps/ensadmin/src/app/layout.tsx
+++ b/apps/ensadmin/src/app/layout.tsx
@@ -21,32 +21,34 @@ const siteName = "ENSAdmin";
 const title = "ENSAdmin";
 const description = "Explore the ENS Protocol like never before";
 
-export const metadata: Metadata = {
-  title: title,
-  description: description,
-  metadataBase: new URL(ensAdminPublicUrl()),
-  openGraph: {
-    title: {
-      template: `${siteName} - %s`,
-      default: title,
-    },
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: title,
     description: description,
-    url: "/",
-    type: "website",
-    siteName: siteName,
-    images: ["/opengraph-image.png"],
-  },
-  twitter: {
-    title: {
-      template: `${siteName} - %s`,
-      default: title,
+    metadataBase: new URL(ensAdminPublicUrl()),
+    openGraph: {
+      title: {
+        template: `${siteName} - %s`,
+        default: title,
+      },
+      description: description,
+      url: "/",
+      type: "website",
+      siteName: siteName,
+      images: ["/opengraph-image.png"],
     },
-    card: "summary_large_image",
-    site: "@NamehashLabs",
-    creator: "@NamehashLabs",
-    images: ["/twitter-image.png"],
-  },
-};
+    twitter: {
+      title: {
+        template: `${siteName} - %s`,
+        default: title,
+      },
+      card: "summary_large_image",
+      site: "@NamehashLabs",
+      creator: "@NamehashLabs",
+      images: ["/twitter-image.png"],
+    },
+  };
+}
 
 export default function Layout({
   children,

--- a/apps/ensadmin/src/app/layout.tsx
+++ b/apps/ensadmin/src/app/layout.tsx
@@ -10,7 +10,6 @@ import { Provider as QueryProvider } from "@/components/query-client/provider";
 import { Header, HeaderActions, HeaderBreadcrumbs, HeaderNav } from "@/components/ui/header";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { Toaster } from "@/components/ui/sonner";
-import { ensAdminPublicUrl } from "@/lib/env";
 
 const inter = Inter({
   variable: "--font-inter",
@@ -21,34 +20,31 @@ const siteName = "ENSAdmin";
 const title = "ENSAdmin";
 const description = "Explore the ENS Protocol like never before";
 
-export async function generateMetadata(): Promise<Metadata> {
-  return {
-    title: title,
+export const metadata = {
+  title: title,
+  description: description,
+  openGraph: {
+    title: {
+      template: `${siteName} - %s`,
+      default: title,
+    },
     description: description,
-    metadataBase: new URL(ensAdminPublicUrl()),
-    openGraph: {
-      title: {
-        template: `${siteName} - %s`,
-        default: title,
-      },
-      description: description,
-      url: "/",
-      type: "website",
-      siteName: siteName,
-      images: ["/opengraph-image.png"],
+    url: "/",
+    type: "website",
+    siteName: siteName,
+    images: ["/opengraph-image.png"],
+  },
+  twitter: {
+    title: {
+      template: `${siteName} - %s`,
+      default: title,
     },
-    twitter: {
-      title: {
-        template: `${siteName} - %s`,
-        default: title,
-      },
-      card: "summary_large_image",
-      site: "@NamehashLabs",
-      creator: "@NamehashLabs",
-      images: ["/twitter-image.png"],
-    },
-  };
-}
+    card: "summary_large_image",
+    site: "@NamehashLabs",
+    creator: "@NamehashLabs",
+    images: ["/twitter-image.png"],
+  },
+} satisfies Metadata;
 
 export default function Layout({
   children,

--- a/apps/ensadmin/src/app/layout.tsx
+++ b/apps/ensadmin/src/app/layout.tsx
@@ -10,6 +10,7 @@ import { Provider as QueryProvider } from "@/components/query-client/provider";
 import { Header, HeaderActions, HeaderBreadcrumbs, HeaderNav } from "@/components/ui/header";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { Toaster } from "@/components/ui/sonner";
+import { ensAdminPublicUrl } from "@/lib/env";
 
 const inter = Inter({
   variable: "--font-inter",
@@ -20,31 +21,41 @@ const siteName = "ENSAdmin";
 const title = "ENSAdmin";
 const description = "Explore the ENS Protocol like never before";
 
-export const metadata = {
-  title: title,
-  description: description,
-  openGraph: {
-    title: {
-      template: `${siteName} - %s`,
-      default: title,
-    },
+export async function generateMetadata(): Promise<Metadata> {
+  const metadataBaseUrl = ensAdminPublicUrl();
+
+  return {
+    title: title,
     description: description,
-    url: "/",
-    type: "website",
-    siteName: siteName,
-    images: ["/opengraph-image.png"],
-  },
-  twitter: {
-    title: {
-      template: `${siteName} - %s`,
-      default: title,
+    /**
+     * Note: using Vercel platform for ENSAdmin deployments works best when
+     * this function returns undefined and lets default values to be applied.
+     * Read more: https://nextjs.org/docs/app/api-reference/functions/generate-metadata#default-value
+     */
+    metadataBase: metadataBaseUrl ? new URL(metadataBaseUrl) : undefined,
+    openGraph: {
+      title: {
+        template: `${siteName} - %s`,
+        default: title,
+      },
+      description: description,
+      url: "/",
+      type: "website",
+      siteName: siteName,
+      images: ["/opengraph-image.png"],
     },
-    card: "summary_large_image",
-    site: "@NamehashLabs",
-    creator: "@NamehashLabs",
-    images: ["/twitter-image.png"],
-  },
-} satisfies Metadata;
+    twitter: {
+      title: {
+        template: `${siteName} - %s`,
+        default: title,
+      },
+      card: "summary_large_image",
+      site: "@NamehashLabs",
+      creator: "@NamehashLabs",
+      images: ["/twitter-image.png"],
+    },
+  };
+}
 
 export default function Layout({
   children,

--- a/apps/ensadmin/src/lib/env.ts
+++ b/apps/ensadmin/src/lib/env.ts
@@ -1,3 +1,27 @@
+/**
+ * Get ENSAdmin service public URL.
+ *
+ * Note: using Vercel platform for ENSAdmin deployments works best when
+ * this function returns undefined and lets default values to be applied.
+ * Read more: https://nextjs.org/docs/app/api-reference/functions/generate-metadata#default-value
+ */
+export function ensAdminPublicUrl(): string | undefined {
+  const envVarName = "ENSADMIN_PUBLIC_URL";
+  const envVarValue = process.env.ENSADMIN_PUBLIC_URL;
+
+  if (!envVarValue) {
+    return undefined;
+  }
+
+  try {
+    return parseUrl(envVarValue).toString();
+  } catch (error) {
+    console.error(error);
+
+    throw new Error(`Invalid ${envVarName} value "${envVarValue}". It should be a valid URL.`);
+  }
+}
+
 export function selectedEnsNodeUrl(params: URLSearchParams): string {
   return new URL(params.get("ensnode") || preferredEnsNodeUrl()).toString();
 }

--- a/apps/ensadmin/src/lib/env.ts
+++ b/apps/ensadmin/src/lib/env.ts
@@ -1,23 +1,3 @@
-/**
- * Get ENSAdmin service public URL.
- */
-export function ensAdminPublicUrl() {
-  const envVarName = "ENSADMIN_PUBLIC_URL";
-  const envVarValue = process.env[envVarName];
-
-  if (!envVarValue) {
-    throw new Error(`Required "${envVarName}" value was not set`);
-  }
-
-  try {
-    return parseUrl(envVarValue).toString();
-  } catch (error) {
-    console.error(error);
-
-    throw new Error(`Invalid ${envVarName} value "${envVarValue}". It should be a valid URL.`);
-  }
-}
-
 export function selectedEnsNodeUrl(params: URLSearchParams): string {
   return new URL(params.get("ensnode") || preferredEnsNodeUrl()).toString();
 }

--- a/apps/ensadmin/src/lib/env.ts
+++ b/apps/ensadmin/src/lib/env.ts
@@ -12,7 +12,6 @@ export function ensAdminPublicUrl(): URL {
   const envVarValue = process.env[envVarName];
 
   if (!envVarValue) {
-    // if public URL was provided and the application runs on Vercel platform
     if (isAppOnVercelPlatform()) {
       // build public URL using the Vercel-specific way
       return getVercelAppPublicUrl();
@@ -31,7 +30,7 @@ export function ensAdminPublicUrl(): URL {
   }
 }
 
-/** Build a default URL for ENSAdmin application */
+/** Build a default public URL for ENSAdmin */
 function defaultEnsAdminPublicUrl(): URL {
   let applicationPort: number;
 
@@ -40,7 +39,7 @@ function defaultEnsAdminPublicUrl(): URL {
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : "Unknown error";
 
-    console.error(`Could not build default URL for ENSAdmin application due to: ${errorMessage}`);
+    console.error(`Error building default public URL for ENSAdmin: ${errorMessage}`);
 
     applicationPort = 4173;
   }
@@ -67,14 +66,14 @@ function parseApplicationPort(rawValue?: string): number {
 }
 
 /**
- * Tells if application runs on Vercel platform.
+ * Tells if the application runs on Vercel.
  */
 function isAppOnVercelPlatform(): boolean {
   return process.env.VERCEL === "1";
 }
 
 /**
- * Builds a public URL of an application running on Vercel platform.
+ * Builds a public URL of the app assuming it runs on Vercel.
  * @returns public URL
  * @throws when application hostname could not be determined based on `VERCEL_*` env vars
  */

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,9 +39,9 @@ services:
     ports:
       - "4173:4173"
     environment:
-      # Override ENSNODE_PUBLIC_URL to point to docker compose ensindexer
+      # Override ENSADMIN_PUBLIC_URL to point to docker compose ensindexer
       # Note: it must be URL accessible from web browser (i.e. it cannot be a hostname in docker network)
-      ENSNODE_PUBLIC_URL: http://localhost:4173
+      ENSADMIN_PUBLIC_URL: http://localhost:4173
       # Override NEXT_PUBLIC_PREFERRED_ENSNODE_URL to docker compose ensindexer
       # Note: it must be URL accessible from web browser (i.e. it cannot be a hostname in docker network)
       NEXT_PUBLIC_PREFERRED_ENSNODE_URL: http://localhost:42069

--- a/examples/example-docker-compose/docker-compose.yml
+++ b/examples/example-docker-compose/docker-compose.yml
@@ -39,9 +39,9 @@ services:
     ports:
       - "4173:4173"
     environment:
-      # Override ENSNODE_PUBLIC_URL to point to docker compose ensindexer
+      # Override ENSADMIN_PUBLIC_URL to point to docker compose ensindexer
       # Note: it must be URL accessible from web browser (i.e. it cannot be a hostname in docker network)
-      ENSNODE_PUBLIC_URL: http://localhost:4173
+      ENSADMIN_PUBLIC_URL: http://localhost:4173
       # Override NEXT_PUBLIC_PREFERRED_ENSNODE_URL to docker compose ensindexer
       # Note: it must be URL accessible from web browser (i.e. it cannot be a hostname in docker network)
       NEXT_PUBLIC_PREFERRED_ENSNODE_URL: http://localhost:42069

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,27 @@ catalogs:
     '@ponder/utils':
       specifier: ^0.2.3
       version: 0.2.3
+    '@types/node':
+      specifier: ^20.10.0
+      version: 20.17.14
+    '@vitest/coverage-v8':
+      specifier: ^3.0.5
+      version: 3.0.5
+    drizzle-orm:
+      specifier: ^0.39.3
+      version: 0.39.3
+    hono:
+      specifier: ^4.6.14
+      version: 4.6.17
+    ponder:
+      specifier: ^0.9.27
+      version: 0.9.27
+    tsup:
+      specifier: ^8.3.6
+      version: 8.3.6
+    typescript:
+      specifier: ^5.7.3
+      version: 5.7.3
     viem:
       specifier: ^2.22.13
       version: 2.22.13
@@ -122,8 +143,8 @@ importers:
         specifier: ^0.476.0
         version: 0.476.0(react@18.3.1)
       next:
-        specifier: 15.1.7
-        version: 15.1.7(@opentelemetry/api@1.7.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 15.2.3
+        version: 15.2.3(@opentelemetry/api@1.7.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1595,56 +1616,56 @@ packages:
       react: ^18
       react-dom: ^18
 
-  '@next/env@15.1.7':
-    resolution: {integrity: sha512-d9jnRrkuOH7Mhi+LHav2XW91HOgTAWHxjMPkXMGBc9B2b7614P7kjt8tAplRvJpbSt4nbO1lugcT/kAaWzjlLQ==}
+  '@next/env@15.2.3':
+    resolution: {integrity: sha512-a26KnbW9DFEUsSxAxKBORR/uD9THoYoKbkpFywMN/AFvboTt94b8+g/07T8J6ACsdLag8/PDU60ov4rPxRAixw==}
 
   '@next/eslint-plugin-next@15.1.7':
     resolution: {integrity: sha512-kRP7RjSxfTO13NE317ek3mSGzoZlI33nc/i5hs1KaWpK+egs85xg0DJ4p32QEiHnR0mVjuUfhRIun7awqfL7pQ==}
 
-  '@next/swc-darwin-arm64@15.1.7':
-    resolution: {integrity: sha512-hPFwzPJDpA8FGj7IKV3Yf1web3oz2YsR8du4amKw8d+jAOHfYHYFpMkoF6vgSY4W6vB29RtZEklK9ayinGiCmQ==}
+  '@next/swc-darwin-arm64@15.2.3':
+    resolution: {integrity: sha512-uaBhA8aLbXLqwjnsHSkxs353WrRgQgiFjduDpc7YXEU0B54IKx3vU+cxQlYwPCyC8uYEEX7THhtQQsfHnvv8dw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@15.1.7':
-    resolution: {integrity: sha512-2qoas+fO3OQKkU0PBUfwTiw/EYpN+kdAx62cePRyY1LqKtP09Vp5UcUntfZYajop5fDFTjSxCHfZVRxzi+9FYQ==}
+  '@next/swc-darwin-x64@15.2.3':
+    resolution: {integrity: sha512-pVwKvJ4Zk7h+4hwhqOUuMx7Ib02u3gDX3HXPKIShBi9JlYllI0nU6TWLbPT94dt7FSi6mSBhfc2JrHViwqbOdw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@15.1.7':
-    resolution: {integrity: sha512-sKLLwDX709mPdzxMnRIXLIT9zaX2w0GUlkLYQnKGoXeWUhcvpCrK+yevcwCJPdTdxZEUA0mOXGLdPsGkudGdnA==}
+  '@next/swc-linux-arm64-gnu@15.2.3':
+    resolution: {integrity: sha512-50ibWdn2RuFFkOEUmo9NCcQbbV9ViQOrUfG48zHBCONciHjaUKtHcYFiCwBVuzD08fzvzkWuuZkd4AqbvKO7UQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@15.1.7':
-    resolution: {integrity: sha512-zblK1OQbQWdC8fxdX4fpsHDw+VSpBPGEUX4PhSE9hkaWPrWoeIJn+baX53vbsbDRaDKd7bBNcXRovY1hEhFd7w==}
+  '@next/swc-linux-arm64-musl@15.2.3':
+    resolution: {integrity: sha512-2gAPA7P652D3HzR4cLyAuVYwYqjG0mt/3pHSWTCyKZq/N/dJcUAEoNQMyUmwTZWCJRKofB+JPuDVP2aD8w2J6Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@15.1.7':
-    resolution: {integrity: sha512-GOzXutxuLvLHFDAPsMP2zDBMl1vfUHHpdNpFGhxu90jEzH6nNIgmtw/s1MDwpTOiM+MT5V8+I1hmVFeAUhkbgQ==}
+  '@next/swc-linux-x64-gnu@15.2.3':
+    resolution: {integrity: sha512-ODSKvrdMgAJOVU4qElflYy1KSZRM3M45JVbeZu42TINCMG3anp7YCBn80RkISV6bhzKwcUqLBAmOiWkaGtBA9w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@15.1.7':
-    resolution: {integrity: sha512-WrZ7jBhR7ATW1z5iEQ0ZJfE2twCNSXbpCSaAunF3BKcVeHFADSI/AW1y5Xt3DzTqPF1FzQlwQTewqetAABhZRQ==}
+  '@next/swc-linux-x64-musl@15.2.3':
+    resolution: {integrity: sha512-ZR9kLwCWrlYxwEoytqPi1jhPd1TlsSJWAc+H/CJHmHkf2nD92MQpSRIURR1iNgA/kuFSdxB8xIPt4p/T78kwsg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@15.1.7':
-    resolution: {integrity: sha512-LDnj1f3OVbou1BqvvXVqouJZKcwq++mV2F+oFHptToZtScIEnhNRJAhJzqAtTE2dB31qDYL45xJwrc+bLeKM2Q==}
+  '@next/swc-win32-arm64-msvc@15.2.3':
+    resolution: {integrity: sha512-+G2FrDcfm2YDbhDiObDU/qPriWeiz/9cRR0yMWJeTLGGX6/x8oryO3tt7HhodA1vZ8r2ddJPCjtLcpaVl7TE2Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@15.1.7':
-    resolution: {integrity: sha512-dC01f1quuf97viOfW05/K8XYv2iuBgAxJZl7mbCKEjMgdQl5JjAKJ0D2qMKZCgPWDeFbFT0Q0nYWwytEW0DWTQ==}
+  '@next/swc-win32-x64-msvc@15.2.3':
+    resolution: {integrity: sha512-gHYS9tc+G2W0ZC8rBL+H6RdtXIyk40uLiaos0yj5US85FNhbFEndMA2nW3z47nzOWiSvXTZ5kBClc3rD0zJg0w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -5163,8 +5184,8 @@ packages:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
-  next@15.1.7:
-    resolution: {integrity: sha512-GNeINPGS9c6OZKCvKypbL8GTsT5GhWPp4DM0fzkXJuXMilOO2EeFxuAY6JZbtk6XIl6Ws10ag3xRINDjSO5+wg==}
+  next@15.2.3:
+    resolution: {integrity: sha512-x6eDkZxk2rPpu46E1ZVUWIBhYCLszmUY6fvHBFcbzJ9dD+qRX6vcHusaqqDlnY+VngKzKbAiG2iRCkPbmi8f7w==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
     peerDependencies:
@@ -8799,34 +8820,34 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@next/env@15.1.7': {}
+  '@next/env@15.2.3': {}
 
   '@next/eslint-plugin-next@15.1.7':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@15.1.7':
+  '@next/swc-darwin-arm64@15.2.3':
     optional: true
 
-  '@next/swc-darwin-x64@15.1.7':
+  '@next/swc-darwin-x64@15.2.3':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@15.1.7':
+  '@next/swc-linux-arm64-gnu@15.2.3':
     optional: true
 
-  '@next/swc-linux-arm64-musl@15.1.7':
+  '@next/swc-linux-arm64-musl@15.2.3':
     optional: true
 
-  '@next/swc-linux-x64-gnu@15.1.7':
+  '@next/swc-linux-x64-gnu@15.2.3':
     optional: true
 
-  '@next/swc-linux-x64-musl@15.1.7':
+  '@next/swc-linux-x64-musl@15.2.3':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@15.1.7':
+  '@next/swc-win32-arm64-msvc@15.2.3':
     optional: true
 
-  '@next/swc-win32-x64-msvc@15.1.7':
+  '@next/swc-win32-x64-msvc@15.2.3':
     optional: true
 
   '@noble/ciphers@1.2.1': {}
@@ -13362,9 +13383,9 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  next@15.1.7(@opentelemetry/api@1.7.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@15.2.3(@opentelemetry/api@1.7.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@next/env': 15.1.7
+      '@next/env': 15.2.3
       '@swc/counter': 0.1.3
       '@swc/helpers': 0.5.15
       busboy: 1.6.0
@@ -13374,14 +13395,14 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       styled-jsx: 5.1.6(react@18.3.1)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.1.7
-      '@next/swc-darwin-x64': 15.1.7
-      '@next/swc-linux-arm64-gnu': 15.1.7
-      '@next/swc-linux-arm64-musl': 15.1.7
-      '@next/swc-linux-x64-gnu': 15.1.7
-      '@next/swc-linux-x64-musl': 15.1.7
-      '@next/swc-win32-arm64-msvc': 15.1.7
-      '@next/swc-win32-x64-msvc': 15.1.7
+      '@next/swc-darwin-arm64': 15.2.3
+      '@next/swc-darwin-x64': 15.2.3
+      '@next/swc-linux-arm64-gnu': 15.2.3
+      '@next/swc-linux-arm64-musl': 15.2.3
+      '@next/swc-linux-x64-gnu': 15.2.3
+      '@next/swc-linux-x64-musl': 15.2.3
+      '@next/swc-win32-arm64-msvc': 15.2.3
+      '@next/swc-win32-x64-msvc': 15.2.3
       '@opentelemetry/api': 1.7.0
       sharp: 0.33.5
     transitivePeerDependencies:
@@ -15452,7 +15473,7 @@ snapshots:
     dependencies:
       debug: 4.4.0
       globrex: 0.1.2
-      tsconfck: 3.1.4(typescript@5.7.3)
+      tsconfck: 3.1.5(typescript@5.7.3)
     optionalDependencies:
       vite: 5.4.14(@types/node@20.17.14)(lightningcss@1.29.1)
     transitivePeerDependencies:
@@ -15463,7 +15484,7 @@ snapshots:
     dependencies:
       debug: 4.4.0
       globrex: 0.1.2
-      tsconfck: 3.1.4(typescript@5.7.3)
+      tsconfck: 3.1.5(typescript@5.7.3)
     optionalDependencies:
       vite: 5.4.14(@types/node@22.13.9)(lightningcss@1.29.1)
     transitivePeerDependencies:


### PR DESCRIPTION
This is a follow up PR to:
- https://github.com/namehash/ensnode/pull/398

This PR support reading env vars during runtime, and avoid doing so during build time. It also allows leveraging Vercel defaults for setting `metadataBase` URL to a correct deployment URL. For other platforms, setting `ENSADMIN_PUBLIC_URL` should be done instead.

Also, resolves:
- https://github.com/namehash/ensnode/security/dependabot/13
- https://github.com/namehash/ensnode/security/dependabot/14