### PR TITLE
docs(ensnode): include `Try it Now` CTA

### DIFF
--- a/apps/ensadmin/.env.local.example
+++ b/apps/ensadmin/.env.local.example
@@ -7,10 +7,10 @@
 ENSADMIN_PUBLIC_URL=http://localhost:4173
 
 # Default ENSNode URLs (used by default when ENSAdmin is opened)
-# If not set, the fallback URL from `DEFAULT_ENSNODE_URL` const is used.
-# Note: it must be a comma-separated list of URLs that are accessible from web browser
-# (i.e. it cannot be a hostname in docker network)
-# Note: the first URL will be used as default ENSNode connection URL
+# If not set, the fallback URL from the `DEFAULT_ENSNODE_URL` const is used.
+# Note: it must be a comma-separated list of URLs that are accessible from a web browser
+# (i.e. it cannot be a hostname in a docker network)
+# Note: the first URL will be used as the default ENSNode connection URL
 NEXT_PUBLIC_DEFAULT_ENSNODE_URLS=https://api.alpha.ensnode.io,https://api.mainnet.ensnode.io,https://api.sepolia.ensnode.io,https://api.holesky.ensnode.io
 
 # RPC URLs for ENS Deployment Chains

--- a/apps/ensadmin/.env.local.example
+++ b/apps/ensadmin/.env.local.example
@@ -6,9 +6,12 @@
 # the default public URL will be based on localhost and PORT.
 ENSADMIN_PUBLIC_URL=http://localhost:4173
 
-# Default ENSNode URL (used by default when ENSAdmin is opened)
+# Default ENSNode URLs (used by default when ENSAdmin is opened)
 # If not set, the fallback URL from `DEFAULT_ENSNODE_URL` const is used.
-NEXT_PUBLIC_DEFAULT_ENSNODE_URL=https://api.alpha.ensnode.io
+# Note: it must be a comma-separated list of URLs that are accessible from web browser
+# (i.e. it cannot be a hostname in docker network)
+# Note: the first URL will be used as default ENSNode connection URL
+NEXT_PUBLIC_DEFAULT_ENSNODE_URLS=https://api.alpha.ensnode.io,https://api.mainnet.ensnode.io,https://api.sepolia.ensnode.io,https://api.holesky.ensnode.io
 
 # RPC URLs for ENS Deployment Chains
 # Replace these with your actual RPC URLs (e.g., from Alchemy, Infura, etc.)

--- a/apps/ensadmin/.env.local.example
+++ b/apps/ensadmin/.env.local.example
@@ -6,9 +6,9 @@
 # the default public URL will be based on localhost and PORT.
 ENSADMIN_PUBLIC_URL=http://localhost:4173
 
-# Preferred ENSNode URL (used by default when ENSAdmin is opened)
-# If not set, the fallback URL from `PREFERRED_ENSNODE_URL` const is used.
-NEXT_PUBLIC_PREFERRED_ENSNODE_URL=https://alpha.ensnode.io
+# Default ENSNode URL (used by default when ENSAdmin is opened)
+# If not set, the fallback URL from `DEFAULT_ENSNODE_URL` const is used.
+NEXT_PUBLIC_DEFAULT_ENSNODE_URL=https://api.alpha.ensnode.io
 
 # RPC URLs for ENS Deployment Chains
 # Replace these with your actual RPC URLs (e.g., from Alchemy, Infura, etc.)

--- a/apps/ensadmin/Dockerfile
+++ b/apps/ensadmin/Dockerfile
@@ -2,7 +2,7 @@ FROM node:18-slim AS base
 
 FROM base AS builder
 
-ARG NEXT_PUBLIC_DEFAULT_ENSNODE_URL
+ARG NEXT_PUBLIC_DEFAULT_ENSNODE_URLS
 ARG PNPM_VERSION=9.12.0
 
 RUN apt-get update && \
@@ -32,8 +32,8 @@ RUN pnpm install --frozen-lockfile
 # This will be used to determine if the build output should be standalone
 ENV NEXT_BUILD_OUTPUT_STANDALONE=true
 
-# Set the environment variable for the default ENSNode URL
-ENV NEXT_PUBLIC_DEFAULT_ENSNODE_URL=${NEXT_PUBLIC_DEFAULT_ENSNODE_URL}
+# Set the environment variable for the default ENSNode URLs
+ENV NEXT_PUBLIC_DEFAULT_ENSNODE_URLS=${NEXT_PUBLIC_DEFAULT_ENSNODE_URLS}
 
 # Copy the app source code
 COPY apps/ensadmin ./apps/ensadmin

--- a/apps/ensadmin/Dockerfile
+++ b/apps/ensadmin/Dockerfile
@@ -2,7 +2,7 @@ FROM node:18-slim AS base
 
 FROM base AS builder
 
-ARG NEXT_PUBLIC_PREFERRED_ENSNODE_URL
+ARG NEXT_PUBLIC_DEFAULT_ENSNODE_URL
 ARG PNPM_VERSION=9.12.0
 
 RUN apt-get update && \
@@ -32,8 +32,8 @@ RUN pnpm install --frozen-lockfile
 # This will be used to determine if the build output should be standalone
 ENV NEXT_BUILD_OUTPUT_STANDALONE=true
 
-# Set the environment variable for the preferred ENSNode URL
-ENV NEXT_PUBLIC_PREFERRED_ENSNODE_URL=${NEXT_PUBLIC_PREFERRED_ENSNODE_URL}
+# Set the environment variable for the default ENSNode URL
+ENV NEXT_PUBLIC_DEFAULT_ENSNODE_URL=${NEXT_PUBLIC_DEFAULT_ENSNODE_URL}
 
 # Copy the app source code
 COPY apps/ensadmin ./apps/ensadmin

--- a/apps/ensadmin/README.md
+++ b/apps/ensadmin/README.md
@@ -16,7 +16,7 @@ pnpm install
 cp .env.local.example .env.local
 ```
 
-You can update `NEXT_PUBLIC_DEFAULT_ENSNODE_URLS` environment variable if you wish ENSAdmin to include a given list of comma-separated URLs as initial connection options.
+You can update the `NEXT_PUBLIC_DEFAULT_ENSNODE_URLS` environment variable if you wish ENSAdmin to include a given list of comma-separated URLs as initial connection options.
 
 #### RPC URLs
 

--- a/apps/ensadmin/README.md
+++ b/apps/ensadmin/README.md
@@ -16,7 +16,7 @@ pnpm install
 cp .env.local.example .env.local
 ```
 
-You can update `NEXT_PUBLIC_PREFERRED_ENSNODE_URL` environment variable if you wish ENSAdmin to include a given URL as an initial connection option.
+You can update `NEXT_PUBLIC_DEFAULT_ENSNODE_URL` environment variable if you wish ENSAdmin to include a given URL as an initial connection option.
 
 #### RPC URLs
 

--- a/apps/ensadmin/README.md
+++ b/apps/ensadmin/README.md
@@ -16,7 +16,7 @@ pnpm install
 cp .env.local.example .env.local
 ```
 
-You can update `NEXT_PUBLIC_DEFAULT_ENSNODE_URL` environment variable if you wish ENSAdmin to include a given URL as an initial connection option.
+You can update `NEXT_PUBLIC_DEFAULT_ENSNODE_URLS` environment variable if you wish ENSAdmin to include a given list of comma-separated URLs as initial connection options.
 
 #### RPC URLs
 

--- a/apps/ensadmin/src/app/@actions/gql/ponder/page.tsx
+++ b/apps/ensadmin/src/app/@actions/gql/ponder/page.tsx
@@ -1,5 +1,5 @@
 import { CopyButton } from "@/components/ui/copy-button";
-import { preferredEnsNodeUrl } from "@/lib/env";
+import { defaultEnsNodeUrl } from "@/lib/env";
 
 type ActionProps = {
   searchParams: Promise<{
@@ -8,13 +8,13 @@ type ActionProps = {
 };
 
 export default async function ActionsPonderPage({ searchParams }: ActionProps) {
-  const { ensnode = preferredEnsNodeUrl() } = await searchParams;
+  const { ensnode = defaultEnsNodeUrl() } = await searchParams;
 
   const baseUrl = Array.isArray(ensnode)
     ? ensnode[0]
     : typeof ensnode === "string"
       ? ensnode
-      : preferredEnsNodeUrl();
+      : defaultEnsNodeUrl();
 
   const url = new URL(`/ponder`, baseUrl).toString();
 

--- a/apps/ensadmin/src/app/@actions/gql/subgraph-compat/page.tsx
+++ b/apps/ensadmin/src/app/@actions/gql/subgraph-compat/page.tsx
@@ -1,5 +1,5 @@
 import { CopyButton } from "@/components/ui/copy-button";
-import { preferredEnsNodeUrl } from "@/lib/env";
+import { defaultEnsNodeUrl } from "@/lib/env";
 
 type ActionProps = {
   searchParams: Promise<{
@@ -8,13 +8,13 @@ type ActionProps = {
 };
 
 export default async function ActionsSubgraphCompatPage({ searchParams }: ActionProps) {
-  const { ensnode = preferredEnsNodeUrl() } = await searchParams;
+  const { ensnode = defaultEnsNodeUrl() } = await searchParams;
 
   const baseUrl = Array.isArray(ensnode)
     ? ensnode[0]
     : typeof ensnode === "string"
       ? ensnode
-      : preferredEnsNodeUrl();
+      : defaultEnsNodeUrl();
 
   const url = new URL(`/subgraph`, baseUrl).toString();
 

--- a/apps/ensadmin/src/app/gql/ponder/page.tsx
+++ b/apps/ensadmin/src/app/gql/ponder/page.tsx
@@ -1,5 +1,5 @@
 import { GraphiQLEditor } from "@/components/graphiql-editor";
-import { preferredEnsNodeUrl } from "@/lib/env";
+import { defaultEnsNodeUrl } from "@/lib/env";
 
 type PageProps = {
   searchParams: Promise<{
@@ -8,13 +8,13 @@ type PageProps = {
 };
 
 export default async function PonderGraphQLPage({ searchParams }: PageProps) {
-  const { ensnode = preferredEnsNodeUrl() } = await searchParams;
+  const { ensnode = defaultEnsNodeUrl() } = await searchParams;
 
   const baseUrl = Array.isArray(ensnode)
     ? ensnode[0]
     : typeof ensnode === "string"
       ? ensnode
-      : preferredEnsNodeUrl();
+      : defaultEnsNodeUrl();
 
   const url = new URL(`/ponder`, baseUrl).toString();
 

--- a/apps/ensadmin/src/app/gql/subgraph-compat/page.tsx
+++ b/apps/ensadmin/src/app/gql/subgraph-compat/page.tsx
@@ -1,5 +1,5 @@
 import { GraphiQLEditor } from "@/components/graphiql-editor";
-import { preferredEnsNodeUrl } from "@/lib/env";
+import { defaultEnsNodeUrl } from "@/lib/env";
 
 type PageProps = {
   searchParams: Promise<{
@@ -8,13 +8,13 @@ type PageProps = {
 };
 
 export default async function SubgraphGraphQLPage({ searchParams }: PageProps) {
-  const { ensnode = preferredEnsNodeUrl() } = await searchParams;
+  const { ensnode = defaultEnsNodeUrl() } = await searchParams;
 
   const baseUrl = Array.isArray(ensnode)
     ? ensnode[0]
     : typeof ensnode === "string"
       ? ensnode
-      : preferredEnsNodeUrl();
+      : defaultEnsNodeUrl();
 
   const url = new URL(`/subgraph`, baseUrl).toString();
 

--- a/apps/ensadmin/src/app/ponder-client-api/page.tsx
+++ b/apps/ensadmin/src/app/ponder-client-api/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from "react";
 
-import { preferredEnsNodeUrl } from "@/lib/env";
+import { defaultEnsNodeUrl } from "@/lib/env";
 import { PonderClientContent } from "./examples-content";
 import { Provider as PonderClientProvider } from "./provider";
 
@@ -11,13 +11,13 @@ type PageProps = {
 };
 
 export default async function PonderClientPage({ searchParams }: PageProps) {
-  const { ensnode = preferredEnsNodeUrl() } = await searchParams;
+  const { ensnode = defaultEnsNodeUrl() } = await searchParams;
 
   const baseUrl = Array.isArray(ensnode)
     ? ensnode[0]
     : typeof ensnode === "string"
       ? ensnode
-      : preferredEnsNodeUrl();
+      : defaultEnsNodeUrl();
 
   const url = new URL(`/subgraph`, baseUrl).toString();
 

--- a/apps/ensadmin/src/components/connections/connection-selector.tsx
+++ b/apps/ensadmin/src/components/connections/connection-selector.tsx
@@ -123,7 +123,7 @@ export function ConnectionSelector() {
               </SidebarMenuButton>
             </DropdownMenuTrigger>
             <DropdownMenuContent
-              className="w-[--radix-dropdown-menu-trigger-width] min-w-56 rounded-lg"
+              className="w-[--radix-dropdown-menu-trigger-width] min-w-72 rounded-lg"
               align="start"
               side={isMobile ? "bottom" : "right"}
               sideOffset={4}
@@ -137,50 +137,54 @@ export function ConnectionSelector() {
                   <Loader2 className="w-4 h-4 animate-spin text-muted-foreground" />
                 </div>
               ) : (
-                connections.map(({ url, isDefault }) => (
-                  <DropdownMenuItem
-                    key={url}
-                    onClick={() => handleSelect(url)}
-                    className={cn(
-                      "group gap-2 p-2 font-mono text-xs justify-between",
-                      url === selectedUrl.toString() ? "bg-primary/10 text-primary" : "",
-                    )}
-                  >
-                    <span className="truncate flex-1">{url}</span>
-                    <div className="flex items-center gap-1">
-                      <a
-                        href={url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        onClick={(e) => e.stopPropagation()}
-                        className="p-1 hover:text-foreground rounded"
-                      >
-                        <ExternalLink className="w-3 h-3" />
-                      </a>
-                      {!isDefault && (
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            handleRemove(url);
-                          }}
-                          disabled={removeConnection.isPending}
-                          className={cn(
-                            "p-1 rounded",
-                            removeConnection.isPending
-                              ? "text-muted-foreground cursor-not-allowed"
-                              : "hover:text-destructive",
-                          )}
-                        >
-                          {removeConnection.isPending && removeConnection.variables?.url === url ? (
-                            <Loader2 className="w-3 h-3 animate-spin" />
-                          ) : (
-                            <Trash2 className="w-3 h-3" />
-                          )}
-                        </button>
+                connections.map(({ url, isDefault }) => {
+                  const isCurrentlySelectedConnection = url === selectedUrl.toString();
+                  return (
+                    <DropdownMenuItem
+                      key={url}
+                      onClick={() => handleSelect(url)}
+                      className={cn(
+                        "group gap-2 p-2 font-mono text-xs justify-between",
+                        isCurrentlySelectedConnection ? "bg-primary/10 text-primary" : "",
                       )}
-                    </div>
-                  </DropdownMenuItem>
-                ))
+                    >
+                      <span className="truncate flex-1">{url}</span>
+                      <div className="flex items-center gap-1">
+                        <a
+                          href={url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          onClick={(e) => e.stopPropagation()}
+                          className="p-1 hover:text-foreground rounded"
+                        >
+                          <ExternalLink className="w-3 h-3" />
+                        </a>
+                        {!isDefault && !isCurrentlySelectedConnection && (
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleRemove(url);
+                            }}
+                            disabled={removeConnection.isPending}
+                            className={cn(
+                              "p-1 rounded",
+                              removeConnection.isPending
+                                ? "text-muted-foreground cursor-not-allowed"
+                                : "hover:text-destructive",
+                            )}
+                          >
+                            {removeConnection.isPending &&
+                            removeConnection.variables?.url === url ? (
+                              <Loader2 className="w-3 h-3 animate-spin" />
+                            ) : (
+                              <Trash2 className="w-3 h-3" />
+                            )}
+                          </button>
+                        )}
+                      </div>
+                    </DropdownMenuItem>
+                  );
+                })
               )}
 
               <DropdownMenuSeparator />

--- a/apps/ensadmin/src/components/connections/connection-selector.tsx
+++ b/apps/ensadmin/src/components/connections/connection-selector.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { defaultEnsNodeUrl, selectedEnsNodeUrl } from "@/lib/env";
+import { selectedEnsNodeUrl } from "@/lib/env";
 import { cn } from "@/lib/utils";
 import { ChevronsUpDown, ExternalLink, Loader2, Plus, Trash2 } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
@@ -60,7 +60,9 @@ export function ConnectionSelector() {
 
   const [dialogOpen, setDialogOpen] = useState(false);
 
-  const { connections, isLoading, addConnection, removeConnection } = useConnections();
+  const { connections, isLoading, addConnection, removeConnection } = useConnections({
+    selectedEnsNodeUrl: selectedUrl,
+  });
 
   const handleSelect = (url: string) => {
     const params = new URLSearchParams(searchParams);
@@ -93,8 +95,11 @@ export function ConnectionSelector() {
   };
 
   const handleRemove = (url: string) => {
-    if (url === defaultEnsNodeUrl()) return;
-    removeConnection.mutate({ url });
+    const connectionToBeRemoved = connections.find((c) => c.isDefault === false && c.url === url);
+
+    if (connectionToBeRemoved) {
+      removeConnection.mutate(connectionToBeRemoved);
+    }
   };
 
   return (
@@ -112,7 +117,7 @@ export function ConnectionSelector() {
                 </div>
                 <div className="grid flex-1 text-left text-sm leading-tight">
                   <span className="truncate font-semibold">ENSAdmin</span>
-                  <span className="truncate text-xs font-mono">{selectedUrl}</span>
+                  <span className="truncate text-xs font-mono">{selectedUrl.toString()}</span>
                 </div>
                 <ChevronsUpDown className="ml-auto" />
               </SidebarMenuButton>
@@ -138,7 +143,7 @@ export function ConnectionSelector() {
                     onClick={() => handleSelect(url)}
                     className={cn(
                       "group gap-2 p-2 font-mono text-xs justify-between",
-                      url === selectedUrl ? "bg-primary/10 text-primary" : "",
+                      url === selectedUrl.toString() ? "bg-primary/10 text-primary" : "",
                     )}
                   >
                     <span className="truncate flex-1">{url}</span>

--- a/apps/ensadmin/src/components/connections/connection-selector.tsx
+++ b/apps/ensadmin/src/components/connections/connection-selector.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { preferredEnsNodeUrl, selectedEnsNodeUrl } from "@/lib/env";
+import { defaultEnsNodeUrl, selectedEnsNodeUrl } from "@/lib/env";
 import { cn } from "@/lib/utils";
 import { ChevronsUpDown, ExternalLink, Loader2, Plus, Trash2 } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
@@ -93,7 +93,7 @@ export function ConnectionSelector() {
   };
 
   const handleRemove = (url: string) => {
-    if (url === preferredEnsNodeUrl()) return;
+    if (url === defaultEnsNodeUrl()) return;
     removeConnection.mutate({ url });
   };
 
@@ -132,7 +132,7 @@ export function ConnectionSelector() {
                   <Loader2 className="w-4 h-4 animate-spin text-muted-foreground" />
                 </div>
               ) : (
-                connections.map(({ url, isPreferred }) => (
+                connections.map(({ url, isDefault }) => (
                   <DropdownMenuItem
                     key={url}
                     onClick={() => handleSelect(url)}
@@ -152,7 +152,7 @@ export function ConnectionSelector() {
                       >
                         <ExternalLink className="w-3 h-3" />
                       </a>
-                      {!isPreferred && (
+                      {!isDefault && (
                         <button
                           onClick={(e) => {
                             e.stopPropagation();

--- a/apps/ensadmin/src/components/connections/ensnode-url-validator.ts
+++ b/apps/ensadmin/src/components/connections/ensnode-url-validator.ts
@@ -2,8 +2,10 @@ export interface EnsNodeValidator {
   validate(url: string): Promise<{ isValid: boolean; error?: string }>;
 }
 
+type ValidationResult = { isValid: true; error?: never } | { isValid: false; error: string };
+
 export class BasicEnsNodeValidator implements EnsNodeValidator {
-  async validate(url: string): Promise<{ isValid: boolean; error?: string }> {
+  async validate(url: string): Promise<ValidationResult> {
     try {
       const parsedUrl = new URL(url);
 

--- a/apps/ensadmin/src/components/connections/use-connections.ts
+++ b/apps/ensadmin/src/components/connections/use-connections.ts
@@ -131,10 +131,12 @@ export function useConnections({ selectedEnsNodeUrl }: UseConnectionsProps) {
   // attempt adding `selectedEnsNodeUrl` to connections list
   useEffect(() => {
     if (connections.length === 0) {
-      // only try adding selec
+      // don't add a new connection before the list of connections is loaded
       return;
     }
 
+    // only attempt adding a new connection if there's no other connection
+    // being added at the moment
     if (addConnection.isIdle) {
       const url = selectedEnsNodeUrl.toString();
 

--- a/apps/ensadmin/src/components/connections/use-connections.ts
+++ b/apps/ensadmin/src/components/connections/use-connections.ts
@@ -1,10 +1,10 @@
-import { preferredEnsNodeUrl } from "@/lib/env";
+import { defaultEnsNodeUrl } from "@/lib/env";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { BasicEnsNodeValidator } from "./ensnode-url-validator";
 
 interface Connection {
   url: string;
-  isPreferred: boolean;
+  isDefault: boolean;
 }
 
 interface AddConnectionVariables {
@@ -21,18 +21,18 @@ const STORAGE_KEY = "ensadmin:connections:urls";
 function loadConnections(): Array<Connection> {
   try {
     const saved = localStorage.getItem(STORAGE_KEY);
-    const urls = saved ? (JSON.parse(saved) as Array<string>) : [preferredEnsNodeUrl()];
+    const urls = saved ? (JSON.parse(saved) as Array<string>) : [defaultEnsNodeUrl()];
 
-    if (!urls.includes(preferredEnsNodeUrl())) {
-      urls.unshift(preferredEnsNodeUrl());
+    if (!urls.includes(defaultEnsNodeUrl())) {
+      urls.unshift(defaultEnsNodeUrl());
     }
 
     return urls.map((url) => ({
       url,
-      isPreferred: url === preferredEnsNodeUrl(),
+      isDefault: url === defaultEnsNodeUrl(),
     }));
   } catch {
-    return [{ url: preferredEnsNodeUrl(), isPreferred: true }];
+    return [{ url: defaultEnsNodeUrl(), isDefault: true }];
   }
 }
 
@@ -71,7 +71,7 @@ export function useConnections() {
       }
 
       // Add new connection
-      const newConnections = [...connections, { url, isPreferred: false }];
+      const newConnections = [...connections, { url, isDefault: false }];
       saveConnections(newConnections);
 
       return { url };
@@ -88,7 +88,7 @@ export function useConnections() {
       if (!connection) {
         throw new Error("Connection not found");
       }
-      if (connection.isPreferred) {
+      if (connection.isDefault) {
         throw new Error("Cannot remove preferred connection");
       }
 

--- a/apps/ensadmin/src/components/ensnode/hooks.ts
+++ b/apps/ensadmin/src/components/ensnode/hooks.ts
@@ -9,7 +9,7 @@ import type { EnsNode } from "./types";
  * @param baseUrl ENSNode URL
  * @returns Information about the ENSNode runtime, environment, dependencies, and more.
  */
-async function fetchEnsNodeStatus(baseUrl: string): Promise<EnsNode.Metadata> {
+async function fetchEnsNodeStatus(baseUrl: URL): Promise<EnsNode.Metadata> {
   const response = await fetch(new URL(`/metadata`, baseUrl), {
     headers: {
       "content-type": "application/json",

--- a/apps/ensadmin/src/components/recent-registrations/hooks.ts
+++ b/apps/ensadmin/src/components/recent-registrations/hooks.ts
@@ -8,7 +8,7 @@ import { RecentRegistrationsResponse } from "./types";
  * @param baseUrl ENSNode URL
  * @returns Info about the 5 most recently registered .eth domains that have been indexed.
  */
-async function fetchRecentRegistrations(baseUrl: string): Promise<RecentRegistrationsResponse> {
+async function fetchRecentRegistrations(baseUrl: URL): Promise<RecentRegistrationsResponse> {
   const query = `
     query RecentRegistrationsQuery {
       registrations(first: 5, orderBy: registrationDate, orderDirection: desc) {

--- a/apps/ensadmin/src/lib/env.ts
+++ b/apps/ensadmin/src/lib/env.ts
@@ -134,14 +134,18 @@ export function defaultEnsNodeUrls(): Array<URL> {
     const urlList = envVarValue.split(",").map((maybeUrl) => parseUrl(maybeUrl));
 
     if (urlList.length === 0) {
-      throw new Error(`Invalid ${envVarName} value: "${envVarValue}" must contain at least one valid URL`);
+      throw new Error(
+        `Invalid ${envVarName} value: "${envVarValue}" must contain at least one valid URL`,
+      );
     }
 
     return urlList;
   } catch (error) {
     console.error(error);
 
-    throw new Error(`Invalid ${envVarName} value "${envVarValue}" must contain a comma separated list of valid URLs.`);
+    throw new Error(
+      `Invalid ${envVarName} value "${envVarValue}" must contain a comma separated list of valid URLs.`,
+    );
   }
 }
 

--- a/apps/ensadmin/src/lib/env.ts
+++ b/apps/ensadmin/src/lib/env.ts
@@ -97,21 +97,21 @@ function getVercelAppPublicUrl(): URL {
 }
 
 export function selectedEnsNodeUrl(params: URLSearchParams): string {
-  return new URL(params.get("ensnode") || preferredEnsNodeUrl()).toString();
+  return new URL(params.get("ensnode") || defaultEnsNodeUrl()).toString();
 }
 
-const PREFERRED_ENSNODE_URL = "https://alpha.ensnode.io";
+const DEFAULT_ENSNODE_URL = "https://api.alpha.ensnode.io";
 
-export function preferredEnsNodeUrl(): string {
-  const envVarName = "NEXT_PUBLIC_PREFERRED_ENSNODE_URL";
-  const envVarValue = process.env.NEXT_PUBLIC_PREFERRED_ENSNODE_URL;
+export function defaultEnsNodeUrl(): string {
+  const envVarName = "NEXT_PUBLIC_DEFAULT_ENSNODE_URL";
+  const envVarValue = process.env.NEXT_PUBLIC_DEFAULT_ENSNODE_URL;
 
   if (!envVarValue) {
     console.warn(
-      `No preferred URL provided in "${envVarName}". Using fallback: ${PREFERRED_ENSNODE_URL}`,
+      `No default ENSNode URL provided in "${envVarName}". Using fallback: ${DEFAULT_ENSNODE_URL}`,
     );
 
-    return PREFERRED_ENSNODE_URL;
+    return DEFAULT_ENSNODE_URL;
   }
 
   try {

--- a/apps/ensadmin/src/lib/env.ts
+++ b/apps/ensadmin/src/lib/env.ts
@@ -134,14 +134,14 @@ export function defaultEnsNodeUrls(): Array<URL> {
     const urlList = envVarValue.split(",").map((maybeUrl) => parseUrl(maybeUrl));
 
     if (urlList.length === 0) {
-      throw new Error(`At least one valid URL must be set to "${envVarName}"`);
+      throw new Error(`Invalid ${envVarName} value: "${envVarValue}" must contain at least one valid URL`);
     }
 
     return urlList;
   } catch (error) {
     console.error(error);
 
-    throw new Error(`Invalid ${envVarName} value "${envVarValue}". It should be a valid URL.`);
+    throw new Error(`Invalid ${envVarName} value "${envVarValue}" must contain a comma separated list of valid URLs.`);
   }
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,10 +42,10 @@ services:
       # Override ENSADMIN_PUBLIC_URL to point to docker compose ensindexer
       # Note: it must be URL accessible from web browser (i.e. it cannot be a hostname in docker network)
       ENSADMIN_PUBLIC_URL: http://localhost:4173
-      # Override NEXT_PUBLIC_DEFAULT_ENSNODE_URLS to docker compose ensindexer
-      # Note: it must be a comma-separated list of URLs that are accessible from web browser
-      # (i.e. it cannot be a hostname in docker network)
-      NEXT_PUBLIC_DEFAULT_ENSNODE_URLS: http://localhost:42069,https://api.alpha.ensnode.io
+      # Override NEXT_PUBLIC_DEFAULT_ENSNODE_URLS to the docker compose ensindexer
+      # Note: it must be a comma-separated list of URLs that are accessible from a web browser
+      # (i.e. it cannot be a hostname in the docker network)
+      NEXT_PUBLIC_DEFAULT_ENSNODE_URLS: http://localhost:42069
     env_file:
       # NOTE: can define apps/ensadmin/.env.local (see apps/ensadmin/.env.local.example)
       - path: ./apps/ensadmin/.env.local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,9 +42,10 @@ services:
       # Override ENSADMIN_PUBLIC_URL to point to docker compose ensindexer
       # Note: it must be URL accessible from web browser (i.e. it cannot be a hostname in docker network)
       ENSADMIN_PUBLIC_URL: http://localhost:4173
-      # Override NEXT_PUBLIC_DEFAULT_ENSNODE_URL to docker compose ensindexer
-      # Note: it must be URL accessible from web browser (i.e. it cannot be a hostname in docker network)
-      NEXT_PUBLIC_DEFAULT_ENSNODE_URL: http://localhost:42069
+      # Override NEXT_PUBLIC_DEFAULT_ENSNODE_URLS to docker compose ensindexer
+      # Note: it must be a comma-separated list of URLs that are accessible from web browser
+      # (i.e. it cannot be a hostname in docker network)
+      NEXT_PUBLIC_DEFAULT_ENSNODE_URLS: http://localhost:42069,https://api.alpha.ensnode.io
     env_file:
       # NOTE: can define apps/ensadmin/.env.local (see apps/ensadmin/.env.local.example)
       - path: ./apps/ensadmin/.env.local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,9 +42,9 @@ services:
       # Override ENSADMIN_PUBLIC_URL to point to docker compose ensindexer
       # Note: it must be URL accessible from web browser (i.e. it cannot be a hostname in docker network)
       ENSADMIN_PUBLIC_URL: http://localhost:4173
-      # Override NEXT_PUBLIC_PREFERRED_ENSNODE_URL to docker compose ensindexer
+      # Override NEXT_PUBLIC_DEFAULT_ENSNODE_URL to docker compose ensindexer
       # Note: it must be URL accessible from web browser (i.e. it cannot be a hostname in docker network)
-      NEXT_PUBLIC_PREFERRED_ENSNODE_URL: http://localhost:42069
+      NEXT_PUBLIC_DEFAULT_ENSNODE_URL: http://localhost:42069
     env_file:
       # NOTE: can define apps/ensadmin/.env.local (see apps/ensadmin/.env.local.example)
       - path: ./apps/ensadmin/.env.local

--- a/docs/ensnode.io/src/content/docs/index.mdx
+++ b/docs/ensnode.io/src/content/docs/index.mdx
@@ -5,6 +5,12 @@ template: splash
 hero:
   tagline: Multichain indexer for ENS with ENS Subgraph backwards compatibility.
   actions:
+    - text: Try it Now
+      link: https://admin.ensnode.io/status?ensnode=https%3A%2F%2Fapi.mainnet.ensnode.io 
+      icon: external
+      variant: primary
+      attrs:
+        target: _blank
     - text: Documentation
       link: /ensnode/
       icon: right-arrow

--- a/examples/example-docker-compose/docker-compose.yml
+++ b/examples/example-docker-compose/docker-compose.yml
@@ -42,10 +42,10 @@ services:
       # Override ENSADMIN_PUBLIC_URL to point to docker compose ensindexer
       # Note: it must be URL accessible from web browser (i.e. it cannot be a hostname in docker network)
       ENSADMIN_PUBLIC_URL: http://localhost:4173
-      # Override NEXT_PUBLIC_DEFAULT_ENSNODE_URLS to docker compose ensindexer
-      # Note: it must be a comma-separated list of URLs that are accessible from web browser
-      # (i.e. it cannot be a hostname in docker network)
-      NEXT_PUBLIC_DEFAULT_ENSNODE_URLS: http://localhost:42069,https://api.alpha.ensnode.io
+      # Override NEXT_PUBLIC_DEFAULT_ENSNODE_URLS to the docker compose ensindexer
+      # Note: it must be a comma-separated list of URLs that are accessible from a web browser
+      # (i.e. it cannot be a hostname in the docker network)
+      NEXT_PUBLIC_DEFAULT_ENSNODE_URLS: http://localhost:42069
     env_file:
       # NOTE: can define apps/ensadmin/.env.local (see apps/ensadmin/.env.local.example)
       - path: ./apps/ensadmin/.env.local

--- a/examples/example-docker-compose/docker-compose.yml
+++ b/examples/example-docker-compose/docker-compose.yml
@@ -42,9 +42,10 @@ services:
       # Override ENSADMIN_PUBLIC_URL to point to docker compose ensindexer
       # Note: it must be URL accessible from web browser (i.e. it cannot be a hostname in docker network)
       ENSADMIN_PUBLIC_URL: http://localhost:4173
-      # Override NEXT_PUBLIC_DEFAULT_ENSNODE_URL to docker compose ensindexer
-      # Note: it must be URL accessible from web browser (i.e. it cannot be a hostname in docker network)
-      NEXT_PUBLIC_DEFAULT_ENSNODE_URL: http://localhost:42069
+      # Override NEXT_PUBLIC_DEFAULT_ENSNODE_URLS to docker compose ensindexer
+      # Note: it must be a comma-separated list of URLs that are accessible from web browser
+      # (i.e. it cannot be a hostname in docker network)
+      NEXT_PUBLIC_DEFAULT_ENSNODE_URLS: http://localhost:42069,https://api.alpha.ensnode.io
     env_file:
       # NOTE: can define apps/ensadmin/.env.local (see apps/ensadmin/.env.local.example)
       - path: ./apps/ensadmin/.env.local

--- a/examples/example-docker-compose/docker-compose.yml
+++ b/examples/example-docker-compose/docker-compose.yml
@@ -42,9 +42,9 @@ services:
       # Override ENSADMIN_PUBLIC_URL to point to docker compose ensindexer
       # Note: it must be URL accessible from web browser (i.e. it cannot be a hostname in docker network)
       ENSADMIN_PUBLIC_URL: http://localhost:4173
-      # Override NEXT_PUBLIC_PREFERRED_ENSNODE_URL to docker compose ensindexer
+      # Override NEXT_PUBLIC_DEFAULT_ENSNODE_URL to docker compose ensindexer
       # Note: it must be URL accessible from web browser (i.e. it cannot be a hostname in docker network)
-      NEXT_PUBLIC_PREFERRED_ENSNODE_URL: http://localhost:42069
+      NEXT_PUBLIC_DEFAULT_ENSNODE_URL: http://localhost:42069
     env_file:
       # NOTE: can define apps/ensadmin/.env.local (see apps/ensadmin/.env.local.example)
       - path: ./apps/ensadmin/.env.local


### PR DESCRIPTION
This PR adds a CTA that links to ENSAdmin.

But also, this PR updates:
- The way we define default ENSNode instance URLs. 
    - It was a single URL
    - It's a list of URLs from now on
- The way we call ENSNode instance URLs in application config
    - It used to be _preferred_ URL
    - Now it's _default_ URL