### PR TITLE
fix: adjust hero css for larger monitors

### DIFF
--- a/docs/ensnode.io/src/components/molecules/HeroImage.tsx
+++ b/docs/ensnode.io/src/components/molecules/HeroImage.tsx
@@ -13,7 +13,7 @@ export default function HeroImage() {
     <div className="min-h-0 flex-1 flex flex-col justify-center items-center w-full h-full">
       <div className="videoContainer box-border max-h-full min-h-0 relative h-full p-8 flex flex-col justify-center items-center">
         <div className="box-border absolute z-10 w-full h-full flex flex-col sm:flex-row flex-nowrap justify-between items-center sm:pl-16">
-          <div className="flex flex-row sm:flex-col flex-nowrap w-full sm:w-fit h-fit sm:h-full justify-evenly sm:justify-between items-center pt-2 sm:py-5">
+          <div className="flex flex-row sm:flex-col flex-nowrap w-full sm:w-fit h-fit sm:h-full justify-evenly sm:justify-between items-center py-10">
             <ENSLogo className="w-[4rem] sm:w-[5rem] lg:w-[5.5rem] h-auto" />
             <OptimismLogo className="w-[4rem] sm:w-[5rem] lg:w-[5.5rem] h-auto" />
             <UnichainLogo className="w-[4rem] sm:w-[5rem] lg:w-[5.5rem] h-auto" />

--- a/docs/ensnode.io/src/components/molecules/HeroImage.tsx
+++ b/docs/ensnode.io/src/components/molecules/HeroImage.tsx
@@ -10,21 +10,23 @@ import "../../styles/videoShadowStyles.css";
 
 export default function HeroImage() {
   return (
-    <div className="videoContainer relative flex flex-col justify-center items-center w-screen h-[60%] sm:h-auto sm:w-4/5 xl:w-[calc(100vw-15%)] max-w-[1216px] sm:aspect-[10/4] super_wide_hero:aspect-[10/6] z-10">
-      <div className="box-border absolute z-10 w-full h-full flex flex-col sm:flex-row flex-nowrap justify-between items-center sm:pl-16">
-        <div className="flex flex-row sm:flex-col flex-nowrap w-full sm:w-fit h-fit sm:h-full justify-evenly sm:justify-between items-center pt-2 sm:py-5">
-          <ENSLogo className="w-16 sm:w-[86px] lg:w-[100px] h-auto" />
-          <OptimismLogo className="w-16 sm:w-[86px] lg:w-[100px] h-auto" />
-          <UnichainLogo className="w-16 sm:w-[86px] lg:w-[100px] h-auto" />
+    <div className="min-h-0 flex-1 flex flex-col justify-center items-center w-full h-full">
+      <div className="videoContainer box-border max-h-full min-h-0 relative h-full p-8 flex flex-col justify-center items-center">
+        <div className="box-border absolute z-10 w-full h-full flex flex-col sm:flex-row flex-nowrap justify-between items-center sm:pl-16">
+          <div className="flex flex-row sm:flex-col flex-nowrap w-full sm:w-fit h-fit sm:h-full justify-evenly sm:justify-between items-center pt-2 sm:py-5">
+            <ENSLogo className="w-[4rem] sm:w-[5rem] lg:w-[5.5rem] h-auto" />
+            <OptimismLogo className="w-[4rem] sm:w-[5rem] lg:w-[5.5rem] h-auto" />
+            <UnichainLogo className="w-[4rem] sm:w-[5rem] lg:w-[5.5rem] h-auto" />
+          </div>
+          <div className="flex flex-row sm:flex-col flex-nowrap w-1/2 sm:w-fit h-fit sm:h-2/3 justify-between items-center">
+            <BASELogo className="w-[4rem] sm:w-[5rem] lg:w-[5.5rem] h-auto" />
+            <LineaLogo className="w-[4rem] sm:w-[5rem] lg:w-[5.5rem] h-auto" />
+          </div>
+          <EtherumLogo className="w-[4rem] sm:w-[5rem] lg:w-[5.5rem] h-auto" />
+          <ENSNodeLogo className="relative w-[5rem] sm:w-[5.5rem] lg:w-[6rem] h-auto top-0 left-0" />
         </div>
-        <div className="flex flex-row sm:flex-col flex-nowrap w-1/2 sm:w-fit h-fit sm:h-2/3 justify-between items-center">
-          <BASELogo className="w-16 sm:w-[86px] lg:w-[100px] h-auto" />
-          <LineaLogo className="w-16 sm:w-[86px] lg:w-[100px] h-auto" />
-        </div>
-        <EtherumLogo className="w-16 sm:w-[86px] lg:w-[100px] h-auto" />
-        <ENSNodeLogo className="relative w-1/5 sm:w-[100px] lg:w-[148px] h-auto top-6 sm:top-0 sm:left-[25px]" />
+        <VideoBackground />
       </div>
-      <VideoBackground />
     </div>
   );
 }

--- a/docs/ensnode.io/src/components/molecules/VideoBackground.tsx
+++ b/docs/ensnode.io/src/components/molecules/VideoBackground.tsx
@@ -7,7 +7,7 @@ export default function VideoBackground() {
   return (
     <>
       <video
-        className="hidden sm:block z-0 w-full h-full object-cover rounded-lg"
+        className="hidden sm:block z-0 w-full h-full object-cover rounded-2xl"
         src={ensnode_video}
         autoPlay
         playsInline
@@ -16,7 +16,7 @@ export default function VideoBackground() {
         poster={video_thumbnail.src}
       />
       <video
-        className="block sm:hidden z-0 w-full h-full object-cover rounded-lg"
+        className="block sm:hidden z-0 w-full h-full object-cover rounded-2xl"
         src={ensnode_video_rotated}
         autoPlay
         playsInline

--- a/docs/ensnode.io/src/components/molecules/VideoBackground.tsx
+++ b/docs/ensnode.io/src/components/molecules/VideoBackground.tsx
@@ -16,7 +16,7 @@ export default function VideoBackground() {
         poster={video_thumbnail.src}
       />
       <video
-        className="block sm:hidden z-0 w-[calc(100%-40px)] h-full object-cover rounded-lg"
+        className="block sm:hidden z-0 w-full h-full object-cover rounded-lg"
         src={ensnode_video_rotated}
         autoPlay
         playsInline

--- a/docs/ensnode.io/src/components/organisms/Hero.tsx
+++ b/docs/ensnode.io/src/components/organisms/Hero.tsx
@@ -49,7 +49,7 @@ export default function Hero() {
         </div>
       </div>
       <HeroImage />
-      <div className="flex flex-col flex-nowrap justify-center items-center gap-3 sm:gap-6 w-full p-5">
+      <div className="flex flex-col flex-nowrap justify-center items-center gap-3 sm:gap-6 w-full px-5 py-8">
         <h1 className="text-center font-semibold text-2xl sm:text-5xl text-white">
           The new multichain indexer for ENSv2
         </h1>

--- a/docs/ensnode.io/src/components/organisms/Hero.tsx
+++ b/docs/ensnode.io/src/components/organisms/Hero.tsx
@@ -5,8 +5,8 @@ import ensnode_with_name from "../../assets/dark-logo.svg";
 
 export default function Hero() {
   return (
-    <section className="box-border not-content h-screen w-screen flex flex-col flex-nowrap justify-end sm:justify-center items-center gap-8 sm:gap-4 px-5 sm:px-0 sm:pt-[72px] super_wide_hero:pt-0 pb-5 bg-hero_bg_sm sm:bg-hero_bg">
-      <div className="absolute top-0 box-border flex flex-row flex-nowrap justify-center items-center w-full px-5 sm:px-16 py-3 z-20 backdrop-blur-md">
+    <section className="box-border not-content h-screen w-screen max-h-screen max-w-screen overflow-hidden flex flex-col flex-nowrap items-stretch sm:px-0 bg-hero_bg_sm sm:bg-hero_bg">
+      <div className="box-border flex flex-row flex-nowrap justify-center items-center w-full px-5 sm:px-16 py-3">
         <div className="w-full max-w-7xl items-center justify-between flex flex-row">
           <a href="/">
             <img className="hidden sm:block h-10" src={ensnode_with_name.src} alt="ENSNode" />
@@ -49,7 +49,7 @@ export default function Hero() {
         </div>
       </div>
       <HeroImage />
-      <div className="relative z-10 flex flex-col flex-nowrap justify-center items-center gap-3 sm:gap-6 w-full h-1/4 py-5 sm:py-0">
+      <div className="flex flex-col flex-nowrap justify-center items-center gap-3 sm:gap-6 w-full p-5">
         <h1 className="text-center font-semibold text-2xl sm:text-5xl text-white">
           The new multichain indexer for ENSv2
         </h1>

--- a/docs/ensnode.io/src/layouts/Layout.astro
+++ b/docs/ensnode.io/src/layouts/Layout.astro
@@ -7,7 +7,7 @@ import "@namehash/namekit-react/styles.css";
 <html lang="en">
 <head>
     <meta charset="UTF-8"/>
-    <meta name="viewport" content="width=device-width"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="generator" content={Astro.generator}/>
     <AstroFont
             config={[

--- a/docs/ensnode.io/src/styles/videoShadowStyles.css
+++ b/docs/ensnode.io/src/styles/videoShadowStyles.css
@@ -3,7 +3,7 @@
   position: absolute;
 
   inset: 0;
-  filter: blur(27px);
+  filter: blur(25px);
   background: rgba(16, 18, 223, 1);
 
   @media screen and (min-width: 640px) {


### PR DESCRIPTION
previously

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/fa7ecea3-a3c0-485c-9bd0-62b92febe705" />


now

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/d8f9dbf8-4146-491c-9033-dfd034873a1d" />

- the clideo watermark is now visible on common phone sizes (was previously visible with very tall portrait browser) — background video should be rendered without or cropped