### PR TITLE
chore: remove unnecessary on-conflict-do-nothing for events

### DIFF
--- a/apps/ensindexer/src/handlers/NameWrapper.ts
+++ b/apps/ensindexer/src/handlers/NameWrapper.ts
@@ -87,15 +87,12 @@ export const makeNameWrapperHandlers = (ownedName: OwnedName) => {
     await context.db.update(schema.domain, { id: node }).set({ wrappedOwnerId: to });
 
     // log DomainEvent
-    await context.db
-      .insert(schema.wrappedTransfer)
-      .values({
-        ...sharedEventValues(event),
-        id: eventId, // NOTE: override the shared id in this case, to account for TransferBatch
-        domainId: node,
-        ownerId: to,
-      })
-      .onConflictDoNothing(); // upsert for successful recovery when restarting indexing
+    await context.db.insert(schema.wrappedTransfer).values({
+      ...sharedEventValues(event),
+      id: eventId, // NOTE: override the shared id in this case, to account for TransferBatch
+      domainId: node,
+      ownerId: to,
+    });
   }
 
   return {
@@ -146,17 +143,14 @@ export const makeNameWrapperHandlers = (ownedName: OwnedName) => {
       await materializeDomainExpiryDate(context, node);
 
       // log DomainEvent
-      await context.db
-        .insert(schema.nameWrapped)
-        .values({
-          ...sharedEventValues(event),
-          domainId: node,
-          name,
-          fuses,
-          ownerId: owner,
-          expiryDate: expiry,
-        })
-        .onConflictDoNothing(); // upsert for successful recovery when restarting indexing
+      await context.db.insert(schema.nameWrapped).values({
+        ...sharedEventValues(event),
+        domainId: node,
+        name,
+        fuses,
+        ownerId: owner,
+        expiryDate: expiry,
+      });
     },
 
     async handleNameUnwrapped({
@@ -181,14 +175,11 @@ export const makeNameWrapperHandlers = (ownedName: OwnedName) => {
       await context.db.delete(schema.wrappedDomain, { id: node });
 
       // log DomainEvent
-      await context.db
-        .insert(schema.nameUnwrapped)
-        .values({
-          ...sharedEventValues(event),
-          domainId: node,
-          ownerId: owner,
-        })
-        .onConflictDoNothing(); // upsert for successful recovery when restarting indexing
+      await context.db.insert(schema.nameUnwrapped).values({
+        ...sharedEventValues(event),
+        domainId: node,
+        ownerId: owner,
+      });
     },
 
     async handleFusesSet({
@@ -212,14 +203,11 @@ export const makeNameWrapperHandlers = (ownedName: OwnedName) => {
       }
 
       // log DomainEvent
-      await context.db
-        .insert(schema.fusesSet)
-        .values({
-          ...sharedEventValues(event),
-          domainId: node,
-          fuses,
-        })
-        .onConflictDoNothing(); // upsert for successful recovery when restarting indexing
+      await context.db.insert(schema.fusesSet).values({
+        ...sharedEventValues(event),
+        domainId: node,
+        fuses,
+      });
     },
     async handleExpiryExtended({
       context,
@@ -242,14 +230,11 @@ export const makeNameWrapperHandlers = (ownedName: OwnedName) => {
       }
 
       // log DomainEvent
-      await context.db
-        .insert(schema.expiryExtended)
-        .values({
-          ...sharedEventValues(event),
-          domainId: node,
-          expiryDate: expiry,
-        })
-        .onConflictDoNothing(); // upsert for successful recovery when restarting indexing
+      await context.db.insert(schema.expiryExtended).values({
+        ...sharedEventValues(event),
+        domainId: node,
+        expiryDate: expiry,
+      });
     },
     async handleTransferSingle({
       context,

--- a/apps/ensindexer/src/handlers/Registrar.ts
+++ b/apps/ensindexer/src/handlers/Registrar.ts
@@ -104,15 +104,12 @@ export const makeRegistrarHandlers = (ownedName: OwnedName) => {
       });
 
       // log RegistrationEvent
-      await context.db
-        .insert(schema.nameRegistered)
-        .values({
-          ...sharedEventValues(event),
-          registrationId,
-          registrantId: owner,
-          expiryDate: expires,
-        })
-        .onConflictDoNothing(); // upsert for successful recovery when restarting indexing
+      await context.db.insert(schema.nameRegistered).values({
+        ...sharedEventValues(event),
+        registrationId,
+        registrantId: owner,
+        expiryDate: expires,
+      });
     },
 
     async handleNameRegisteredByController({
@@ -162,14 +159,11 @@ export const makeRegistrarHandlers = (ownedName: OwnedName) => {
         .set({ expiryDate: expires + GRACE_PERIOD_SECONDS });
 
       // log RegistrationEvent
-      await context.db
-        .insert(schema.nameRenewed)
-        .values({
-          ...sharedEventValues(event),
-          registrationId: id,
-          expiryDate: expires,
-        })
-        .onConflictDoNothing(); // upsert for successful recovery when restarting indexing
+      await context.db.insert(schema.nameRenewed).values({
+        ...sharedEventValues(event),
+        registrationId: id,
+        expiryDate: expires,
+      });
     },
 
     async handleNameTransferred({
@@ -193,14 +187,11 @@ export const makeRegistrarHandlers = (ownedName: OwnedName) => {
       await context.db.update(schema.domain, { id: node }).set({ registrantId: to });
 
       // log RegistrationEvent
-      await context.db
-        .insert(schema.nameTransferred)
-        .values({
-          ...sharedEventValues(event),
-          registrationId: id,
-          newOwnerId: to,
-        })
-        .onConflictDoNothing(); // upsert for successful recovery when restarting indexing
+      await context.db.insert(schema.nameTransferred).values({
+        ...sharedEventValues(event),
+        registrationId: id,
+        newOwnerId: to,
+      });
     },
   };
 };

--- a/apps/ensindexer/src/handlers/Registry.ts
+++ b/apps/ensindexer/src/handlers/Registry.ts
@@ -149,16 +149,13 @@ export const makeRegistryHandlers = (ownedName: OwnedName) => {
         }
 
         // log DomainEvent
-        await context.db
-          .insert(schema.newOwner)
-          .values({
-            ...sharedEventValues(event),
+        await context.db.insert(schema.newOwner).values({
+          ...sharedEventValues(event),
 
-            parentDomainId: node,
-            domainId: subnode,
-            ownerId: owner,
-          })
-          .onConflictDoNothing(); // upsert for successful recovery when restarting indexing
+          parentDomainId: node,
+          domainId: subnode,
+          ownerId: owner,
+        });
       },
     async handleTransfer({
       context,
@@ -183,14 +180,11 @@ export const makeRegistryHandlers = (ownedName: OwnedName) => {
       }
 
       // log DomainEvent
-      await context.db
-        .insert(schema.transfer)
-        .values({
-          ...sharedEventValues(event),
-          domainId: node,
-          ownerId: owner,
-        })
-        .onConflictDoNothing(); // upsert for successful recovery when restarting indexing
+      await context.db.insert(schema.transfer).values({
+        ...sharedEventValues(event),
+        domainId: node,
+        ownerId: owner,
+      });
     },
 
     async handleNewTTL({
@@ -209,14 +203,11 @@ export const makeRegistryHandlers = (ownedName: OwnedName) => {
       await context.db.update(schema.domain, { id: node }).set({ ttl });
 
       // log DomainEvent
-      await context.db
-        .insert(schema.newTTL)
-        .values({
-          ...sharedEventValues(event),
-          domainId: node,
-          ttl,
-        })
-        .onConflictDoNothing(); // upsert for successful recovery when restarting indexing
+      await context.db.insert(schema.newTTL).values({
+        ...sharedEventValues(event),
+        domainId: node,
+        ttl,
+      });
     },
 
     async handleNewResolver({
@@ -259,20 +250,17 @@ export const makeRegistryHandlers = (ownedName: OwnedName) => {
       }
 
       // log DomainEvent
-      await context.db
-        .insert(schema.newResolver)
-        .values({
-          ...sharedEventValues(event),
-          domainId: node,
-          // NOTE: this actually produces a bug in the subgraph's graphql layer — `resolver` is not nullable
-          // but there is never a resolver record created for the zeroAddress. so if you query the
-          // `resolver { id }` of a NewResolver event that set the resolver to zeroAddress
-          // ex: newResolver(id: "3745840-2") { id resolver {id} }
-          // you will receive a GraphQL type error. for subgraph compatibility we re-implement this
-          // behavior here, but it should be entirely avoided in a v2 restructuring of the schema.
-          resolverId: isZeroResolver ? zeroAddress : resolverId,
-        })
-        .onConflictDoNothing(); // upsert for successful recovery when restarting indexing
+      await context.db.insert(schema.newResolver).values({
+        ...sharedEventValues(event),
+        domainId: node,
+        // NOTE: this actually produces a bug in the subgraph's graphql layer — `resolver` is not nullable
+        // but there is never a resolver record created for the zeroAddress. so if you query the
+        // `resolver { id }` of a NewResolver event that set the resolver to zeroAddress
+        // ex: newResolver(id: "3745840-2") { id resolver {id} }
+        // you will receive a GraphQL type error. for subgraph compatibility we re-implement this
+        // behavior here, but it should be entirely avoided in a v2 restructuring of the schema.
+        resolverId: isZeroResolver ? zeroAddress : resolverId,
+      });
     },
   };
 };

--- a/apps/ensindexer/src/handlers/Resolver.ts
+++ b/apps/ensindexer/src/handlers/Resolver.ts
@@ -49,14 +49,11 @@ export const makeResolverHandlers = (ownedName: OwnedName) => {
       }
 
       // log ResolverEvent
-      await context.db
-        .insert(schema.addrChanged)
-        .values({
-          ...sharedEventValues(event),
-          resolverId: id,
-          addrId: address,
-        })
-        .onConflictDoNothing(); // upsert for successful recovery when restarting indexing
+      await context.db.insert(schema.addrChanged).values({
+        ...sharedEventValues(event),
+        resolverId: id,
+        addrId: address,
+      });
     },
 
     async handleAddressChanged({
@@ -81,15 +78,12 @@ export const makeResolverHandlers = (ownedName: OwnedName) => {
         .set({ coinTypes: uniq([...(resolver.coinTypes ?? []), coinType]) });
 
       // log ResolverEvent
-      await context.db
-        .insert(schema.multicoinAddrChanged)
-        .values({
-          ...sharedEventValues(event),
-          resolverId: id,
-          coinType,
-          addr: newAddress,
-        })
-        .onConflictDoNothing(); // upsert for successful recovery when restarting indexing
+      await context.db.insert(schema.multicoinAddrChanged).values({
+        ...sharedEventValues(event),
+        resolverId: id,
+        coinType,
+        addr: newAddress,
+      });
     },
 
     async handleNameChanged({
@@ -119,14 +113,11 @@ export const makeResolverHandlers = (ownedName: OwnedName) => {
       });
 
       // log ResolverEvent
-      await context.db
-        .insert(schema.nameChanged)
-        .values({
-          ...sharedEventValues(event),
-          resolverId: id,
-          name,
-        })
-        .onConflictDoNothing(); // upsert for successful recovery when restarting indexing
+      await context.db.insert(schema.nameChanged).values({
+        ...sharedEventValues(event),
+        resolverId: id,
+        name,
+      });
     },
 
     async handleABIChanged({
@@ -147,14 +138,11 @@ export const makeResolverHandlers = (ownedName: OwnedName) => {
       });
 
       // log ResolverEvent
-      await context.db
-        .insert(schema.abiChanged)
-        .values({
-          ...sharedEventValues(event),
-          resolverId: id,
-          contentType,
-        })
-        .onConflictDoNothing(); // upsert for successful recovery when restarting indexing
+      await context.db.insert(schema.abiChanged).values({
+        ...sharedEventValues(event),
+        resolverId: id,
+        contentType,
+      });
     },
 
     async handlePubkeyChanged({
@@ -175,15 +163,12 @@ export const makeResolverHandlers = (ownedName: OwnedName) => {
       });
 
       // log ResolverEvent
-      await context.db
-        .insert(schema.pubkeyChanged)
-        .values({
-          ...sharedEventValues(event),
-          resolverId: id,
-          x,
-          y,
-        })
-        .onConflictDoNothing(); // upsert for successful recovery when restarting indexing
+      await context.db.insert(schema.pubkeyChanged).values({
+        ...sharedEventValues(event),
+        resolverId: id,
+        x,
+        y,
+      });
     },
 
     async handleTextChanged({
@@ -212,19 +197,16 @@ export const makeResolverHandlers = (ownedName: OwnedName) => {
         .set({ texts: uniq([...(resolver.texts ?? []), key]) });
 
       // log ResolverEvent
-      await context.db
-        .insert(schema.textChanged)
-        .values({
-          ...sharedEventValues(event),
-          resolverId: id,
-          key,
-          // ponder's (viem's) event parsing produces empty string for some TextChanged events
-          // (which is correct) but the subgraph records null for these instances, so we coalesce
-          // falsy strings to null for compatibility
-          // ex: last TextChanged in tx 0x7fac4f1802c9b1969311be0412e6f900d531c59155421ff8ce1fda78b87956d0
-          value: value || null,
-        })
-        .onConflictDoNothing(); // upsert for successful recovery when restarting indexing
+      await context.db.insert(schema.textChanged).values({
+        ...sharedEventValues(event),
+        resolverId: id,
+        key,
+        // ponder's (viem's) event parsing produces empty string for some TextChanged events
+        // (which is correct) but the subgraph records null for these instances, so we coalesce
+        // falsy strings to null for compatibility
+        // ex: last TextChanged in tx 0x7fac4f1802c9b1969311be0412e6f900d531c59155421ff8ce1fda78b87956d0
+        value: value || null,
+      });
     },
 
     async handleContenthashChanged({
@@ -244,14 +226,11 @@ export const makeResolverHandlers = (ownedName: OwnedName) => {
       });
 
       // log ResolverEvent
-      await context.db
-        .insert(schema.contenthashChanged)
-        .values({
-          ...sharedEventValues(event),
-          resolverId: id,
-          hash,
-        })
-        .onConflictDoNothing(); // upsert for successful recovery when restarting indexing
+      await context.db.insert(schema.contenthashChanged).values({
+        ...sharedEventValues(event),
+        resolverId: id,
+        hash,
+      });
     },
 
     async handleInterfaceChanged({
@@ -270,15 +249,12 @@ export const makeResolverHandlers = (ownedName: OwnedName) => {
       });
 
       // log ResolverEvent
-      await context.db
-        .insert(schema.interfaceChanged)
-        .values({
-          ...sharedEventValues(event),
-          resolverId: id,
-          interfaceID,
-          implementer,
-        })
-        .onConflictDoNothing(); // upsert for successful recovery when restarting indexing
+      await context.db.insert(schema.interfaceChanged).values({
+        ...sharedEventValues(event),
+        resolverId: id,
+        interfaceID,
+        implementer,
+      });
     },
 
     async handleAuthorisationChanged({
@@ -303,17 +279,14 @@ export const makeResolverHandlers = (ownedName: OwnedName) => {
       });
 
       // log ResolverEvent
-      await context.db
-        .insert(schema.authorisationChanged)
-        .values({
-          ...sharedEventValues(event),
-          resolverId: id,
-          owner,
-          target,
-          // NOTE: the spelling difference is kept for subgraph backwards-compatibility
-          isAuthorized: isAuthorised,
-        })
-        .onConflictDoNothing(); // upsert for successful recovery when restarting indexing
+      await context.db.insert(schema.authorisationChanged).values({
+        ...sharedEventValues(event),
+        resolverId: id,
+        owner,
+        target,
+        // NOTE: the spelling difference is kept for subgraph backwards-compatibility
+        isAuthorized: isAuthorised,
+      });
     },
 
     async handleVersionChanged({
@@ -345,14 +318,11 @@ export const makeResolverHandlers = (ownedName: OwnedName) => {
       });
 
       // log ResolverEvent
-      await context.db
-        .insert(schema.versionChanged)
-        .values({
-          ...sharedEventValues(event),
-          resolverId: id,
-          version: newVersion,
-        })
-        .onConflictDoNothing(); // upsert for successful recovery when restarting indexing
+      await context.db.insert(schema.versionChanged).values({
+        ...sharedEventValues(event),
+        resolverId: id,
+        version: newVersion,
+      });
     },
 
     async handleDNSRecordChanged({


### PR DESCRIPTION
closes https://github.com/namehash/ensnode/issues/281

the reason we added these was apparently related to resuming indexing after a crash, though based on ponder semantics they shouldn't be necessary at all (each event gets its own UUID, so there's no case in which that event with that id already exists) and we're now past the release that apparently required this hotfix

to verify that this only updates the correct `.onConflictDoNothing()` calls, check that each update is also marked with `// upsert for successful recovery when restarting indexing`