### PR TITLE
chore: update GitHub workflows to trigger on specific paths for ENSRainbow and ENSIndexer images

### DIFF
--- a/.github/workflows/build_ensadmin_image.yml
+++ b/.github/workflows/build_ensadmin_image.yml
@@ -4,6 +4,19 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'apps/ensadmin/**'
+      - 'packages/ponder-metadata/**'
+      - 'packages/ponder-schema/**'
+      - 'packages/ens-deployments/**'
+      - 'packages/ensnode-utils/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'biome.json'
+      - '.nvmrc'
+      - '.dockerignore'
+      - '.github/workflows/build_ensadmin_image.yml'
   release:
     types: [published]
 

--- a/.github/workflows/build_ensindexer_image.yml
+++ b/.github/workflows/build_ensindexer_image.yml
@@ -4,6 +4,21 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'apps/ensindexer/**'
+      - 'packages/ens-deployments/**'
+      - 'packages/ensrainbow-sdk/**'
+      - 'packages/ponder-metadata/**'
+      - 'packages/ponder-schema/**'
+      - 'packages/ponder-subgraph-api/**'
+      - 'packages/ensnode-utils/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'biome.json'
+      - '.nvmrc'
+      - '.dockerignore'
+      - '.github/workflows/build_ensindexer_image.yml'
   release:
     types: [published]
 

--- a/.github/workflows/build_ensrainbow_image.yml
+++ b/.github/workflows/build_ensrainbow_image.yml
@@ -4,6 +4,17 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'apps/ensrainbow/**'
+      - 'packages/ensrainbow-sdk/**'
+      - 'packages/ensnode-utils/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'biome.json'
+      - '.nvmrc'
+      - '.dockerignore'
+      - '.github/workflows/build_ensrainbow_image.yml'
   release:
     types: [published]
 

--- a/.github/workflows/build_ensrainbow_test_data_image.yml
+++ b/.github/workflows/build_ensrainbow_test_data_image.yml
@@ -1,6 +1,16 @@
 name: Build ENSRainbow-test-data image
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'apps/ensrainbow/Dockerfile.data'
+      - 'apps/ensrainbow/download-rainbow-tables.sh'
+      - 'apps/ensrainbow/**'
+      - 'packages/ensrainbow-sdk/**'
+      - '.github/workflows/build_ensrainbow_test_data_image.yml'
 
 jobs:
   image-build-and-push:

--- a/.github/workflows/build_ensrainbow_test_image.yml
+++ b/.github/workflows/build_ensrainbow_test_image.yml
@@ -1,9 +1,26 @@
 name: Build ENSRainbow test image
 
 on:
+  workflow_run:
+    workflows: ["Build ENSRainbow-test-data image"]
+    types:
+      - completed
+    branches:
+      - main
   push:
     branches:
       - main
+    paths:
+      - 'apps/ensrainbow/**'
+      - 'packages/ensrainbow-sdk/**'
+      - 'packages/ensnode-utils/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'biome.json'
+      - '.nvmrc'
+      - '.dockerignore'
+      - '.github/workflows/build_ensrainbow_test_image.yml'
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -11,6 +28,9 @@ jobs:
 
   image-build-and-push:
     runs-on: blacksmith-4vcpu-ubuntu-2204
+    # Only run this job if the workflow_run trigger was activated by a successful completion
+    # or if this workflow was triggered by a push event
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build_ensrainbow_v2_image.yml
+++ b/.github/workflows/build_ensrainbow_v2_image.yml
@@ -4,6 +4,17 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'apps/ensrainbow/**'
+      - 'packages/ensrainbow-sdk/**'
+      - 'packages/ensnode-utils/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'biome.json'
+      - '.nvmrc'
+      - '.dockerignore'
+      - '.github/workflows/build_ensrainbow_v2_image.yml'
 
 jobs:
 

--- a/.github/workflows/test_ensrainbow_image_on_mac.yml
+++ b/.github/workflows/test_ensrainbow_image_on_mac.yml
@@ -2,6 +2,9 @@ name: Test ENSRainbow Test Image on macOS
 
 on:
   workflow_dispatch:
+  schedule:
+    # Run once a week on Monday at 10:00 UTC
+    - cron: '0 10 * * 1'
 
 jobs:
   test-image-on-mac:

--- a/.github/workflows/test_ensrainbow_image_on_ubuntu_arm.yml
+++ b/.github/workflows/test_ensrainbow_image_on_ubuntu_arm.yml
@@ -2,6 +2,9 @@ name: Test ENSRainbow Test Image on Ubuntu ARM
 
 on:
   workflow_dispatch:
+  schedule:
+    # Run once a week on Monday at 10:00 UTC
+    - cron: '0 10 * * 1'
 
 jobs:
   test-image-on-ubuntu-arm:


### PR DESCRIPTION
1. It builds images only when appropriate files are changed. The drawback is that there is a lot of dependencies (paths) - maybe we can exclude some of them.
2. It also enables building test data ENSRainbow image (it is fast).
3. Scheduled testing ENSRainbow images on Mac and arm once per week.