### PR TITLE
fix: await handler activation

### DIFF
--- a/apps/ensindexer/ponder.config.ts
+++ b/apps/ensindexer/ponder.config.ts
@@ -36,7 +36,7 @@ const activePluginsMergedConfig = activePlugins
   .reduce((acc, val) => deepMergeRecursive(acc, val), {}) as AllPluginConfigs;
 
 // load indexing handlers from the active plugins into the runtime
-activePlugins.forEach((plugin) => plugin.activate());
+await Promise.all(activePlugins.map((plugin) => plugin.activate()));
 
 ////////
 // Finally, return the merged config for ponder to use for type inference and runtime behavior.

--- a/apps/ensindexer/src/lib/plugin-helpers.ts
+++ b/apps/ensindexer/src/lib/plugin-helpers.ts
@@ -165,7 +165,7 @@ export type MergedTypes<T> = (T extends any ? (x: T) => void : never) extends (x
 export interface PonderENSPlugin<PLUGIN_NAME extends PluginName, CONFIG> {
   pluginName: PLUGIN_NAME;
   config: CONFIG;
-  activate: VoidFunction;
+  activate: () => Promise<void>;
 }
 
 /**


### PR DESCRIPTION
there was no bug caused by this behavior but it bothered me that we weren't actually awaiting the registration of the handlers before passing control back to ponder — so this makes sure that every ponder.on handler is registered before returning the config to ponder