### PR TITLE
feat(ensnode.io/docs): promote telegram group

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,6 @@ If you have questions or need help, please:
 1. Check the documentation links above
 2. Open a [GitHub Issue](https://github.com/namehash/ensnode/issues) for bugs/features
 3. Join our community discussions on [GitHub](https://github.com/namehash/ensnode)
-4. Join our community [Telegram](http://t.me/ensnode)
+4. Join our community on [Telegram](http://t.me/ensnode)
 
 We look forward to your contributions!

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@
 
 Full Documentation ➡︎ <a href="https://ensnode.io" target="_blank">ensnode.io</a>
 
+[Join us on Telegram](https://t.me/ensnode) to get support, share ideas, and discuss the future of ENSNode.
+
 ## The future of ENS indexing
 
 ENSNode provides enhanced ENS indexing capabilities beyond the ENS Subgraph, including faster indexing and simpler self-hosted deployments. Initial multichain capabilities include indexing mainnet, Basenames, and Linea, providing a unified multichain namespace via a subgraph-compatible GraphQL api. When indexing just mainnet, it has full data equivalency with the ENS Subgraph.
@@ -104,7 +106,7 @@ NameHash has received generous support from the [ENS DAO](https://ensdao.org/) a
 
 ## Contact Us
 
-Visit our [website](https://namehashlabs.org/) to get in contact.
+Visit our [website](https://namehashlabs.org/) to get in contact, or [Join us on Telegram](https://t.me/ensnode).
 
 ## License
 

--- a/docs/ensnode.io/config/integrations/starlight.ts
+++ b/docs/ensnode.io/config/integrations/starlight.ts
@@ -8,6 +8,7 @@ export function starlight(): AstroIntegration {
     components: {
       ThemeProvider: "./src/components/overrides/ThemeProvider.astro",
       ThemeSelect: "./src/components/overrides/ThemeSelect.astro",
+      TableOfContents: "./src/components/overrides/TableOfContents.astro",
     },
     customCss: ["./src/styles/globals.css", "./src/styles/pagination.css"],
     plugins: [
@@ -193,7 +194,8 @@ export function starlight(): AstroIntegration {
         tag: "meta",
         attrs: {
           name: "twitter:description",
-          content: "Multichain indexer for ENS with ENS Subgraph backwards compatibility.",
+          content:
+            "Multichain indexer for ENS with ENS Subgraph backwards compatibility.",
         },
       },
       {

--- a/docs/ensnode.io/config/integrations/starlight.ts
+++ b/docs/ensnode.io/config/integrations/starlight.ts
@@ -194,8 +194,7 @@ export function starlight(): AstroIntegration {
         tag: "meta",
         attrs: {
           name: "twitter:description",
-          content:
-            "Multichain indexer for ENS with ENS Subgraph backwards compatibility.",
+          content: "Multichain indexer for ENS with ENS Subgraph backwards compatibility.",
         },
       },
       {

--- a/docs/ensnode.io/src/components/molecules/TelegramInvite.astro
+++ b/docs/ensnode.io/src/components/molecules/TelegramInvite.astro
@@ -3,7 +3,7 @@
 
 <div>
     <h3>Join us on Telegram</h3>
-    <p>Get support, share your ideas, and stay updated on the latest developments in the ENS ecosystem.</p>
+    <p>Get support, share your ideas, and stay updated on the latest developments in ENSNode.</p>
     <a class="telegram" href="https://t.me/ensnode" target="_blank" rel="noopener noreferrer">
         <svg
           width="24"

--- a/docs/ensnode.io/src/components/molecules/TelegramInvite.astro
+++ b/docs/ensnode.io/src/components/molecules/TelegramInvite.astro
@@ -27,7 +27,8 @@
 div {
     background-color: var(--sl-color-black);
     border-radius: 0.5rem;
-    border: 1px solid var(--sl-color-gray-6);
+    border: 1px solid var(--sl-color-gray-5);
+    box-shadow: var(--sl-shadow-sm);
     padding: 1rem;
     display: grid;
     gap: 0.5rem;

--- a/docs/ensnode.io/src/components/molecules/TelegramInvite.astro
+++ b/docs/ensnode.io/src/components/molecules/TelegramInvite.astro
@@ -1,0 +1,58 @@
+---
+---
+
+<div>
+    <h3>Join us on Telegram</h3>
+    <p>Get support, share your ideas, and stay updated on the latest developments in the ENS ecosystem.</p>
+    <a class="telegram" href="https://t.me/ensnode" target="_blank" rel="noopener noreferrer">
+        <svg
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M21.9597 4.33581C21.9435 4.26415 21.9081 4.19792 21.857 4.14382C21.806 4.08972 21.7411 4.04967 21.6689 4.02773C21.4062 3.97723 21.1343 3.99594 20.8815 4.08191C20.8815 4.08191 3.35842 10.1941 2.35765 10.8709C2.14267 11.0165 2.07017 11.1014 2.03434 11.2008C1.86102 11.686 2.40015 11.8946 2.40015 11.8946L6.91653 13.3226C6.9929 13.3359 7.07142 13.3315 7.14568 13.3097C8.17228 12.6798 17.4784 6.97509 18.0192 6.78345C18.1025 6.75919 18.1666 6.78345 18.15 6.84409C17.935 7.57588 9.89301 14.508 9.84884 14.5501C9.82733 14.5672 9.81057 14.5892 9.80009 14.6142C9.78961 14.6392 9.78575 14.6664 9.78885 14.6932L9.36721 18.9723C9.36721 18.9723 9.19055 20.3041 10.563 18.9723C11.5362 18.0271 12.4703 17.2443 12.937 16.8635C14.4902 17.9042 16.1609 19.0548 16.8817 19.6572C17.003 19.7711 17.1466 19.8601 17.3041 19.9189C17.4616 19.9776 17.6297 20.005 17.7983 19.9993C18.006 19.9747 18.201 19.8894 18.3575 19.7546C18.5139 19.6198 18.6244 19.442 18.6741 19.2448C18.6741 19.2448 21.8656 6.77375 21.9722 5.10317C21.9831 4.94145 21.9972 4.83472 21.9989 4.72232C22.0041 4.59235 21.9909 4.46231 21.9597 4.33581Z"
+            fill="currentColor"
+          />
+        </svg>
+        <span>
+            Open Telegram
+        </span>
+    </a>
+</div>
+
+<style>
+div {
+    background-color: var(--sl-color-black);
+    border-radius: 0.5rem;
+    border: 1px solid var(--sl-color-gray-6);
+    padding: 1rem;
+    display: grid;
+    gap: 0.5rem;
+}
+h3 {
+    color: var(--sl-color-accent);
+}
+p {
+    font-size: 0.95rem;
+    line-height: 1.55rem;
+    color: var(--sl-color-white);
+}
+a.telegram {
+    background-color: var(--sl-color-accent);
+    color: var(--sl-color-black);
+    border-radius: 0.5rem;
+    padding:  0.5rem 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    font-size: 1rem;
+    font-weight: 500;
+}
+a.telegram:hover {
+    color: var(--sl-color-black);
+}
+</style>

--- a/docs/ensnode.io/src/components/overrides/TableOfContents.astro
+++ b/docs/ensnode.io/src/components/overrides/TableOfContents.astro
@@ -1,7 +1,7 @@
 ---
 import Default from "@astrojs/starlight/components/TableOfContents.astro";
 
-import TelegramInvite from '../molecules/TelegramInvite.astro'
+import TelegramInvite from "../molecules/TelegramInvite.astro";
 ---
 
 <Default />

--- a/docs/ensnode.io/src/components/overrides/TableOfContents.astro
+++ b/docs/ensnode.io/src/components/overrides/TableOfContents.astro
@@ -1,0 +1,9 @@
+---
+import Default from "@astrojs/starlight/components/TableOfContents.astro";
+
+import TelegramInvite from '../molecules/TelegramInvite.astro'
+---
+
+<Default />
+<br />
+<TelegramInvite />

--- a/docs/ensnode.io/src/styles/globals.css
+++ b/docs/ensnode.io/src/styles/globals.css
@@ -30,6 +30,10 @@
   --sl-color-green-low: #c5ddcc;
 
   --pagination-arrow-color: #c4c7c8;
+
+  --sl-shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1),
+    0 2px 4px -2px rgb(0 0 0 / 0.1);
+  --sl-shadow-sm: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
 }
 
 .header {

--- a/docs/ensnode.io/src/styles/globals.css
+++ b/docs/ensnode.io/src/styles/globals.css
@@ -31,8 +31,7 @@
 
   --pagination-arrow-color: #c4c7c8;
 
-  --sl-shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1),
-    0 2px 4px -2px rgb(0 0 0 / 0.1);
+  --sl-shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
   --sl-shadow-sm: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
 }
 


### PR DESCRIPTION
Closes #510 

Another idea (in addition to those marked in 510) is to promote the group on the docs sidebar like below:

![CleanShot 2025-04-09 at 11 37 14@2x](https://github.com/user-attachments/assets/4a7d7cbd-d3bd-4389-ab90-871bfd5bff15)

Wording to be changed of course, just wanted to demonstrate the idea!