### PR TITLE
feat(ponder-metadata): make package generic again

### DIFF
--- a/.changeset/eleven-parents-sing.md
+++ b/.changeset/eleven-parents-sing.md
@@ -1,0 +1,8 @@
+---
+"@ensnode/ponder-metadata": minor
+"ensindexer": minor
+"ensadmin": minor
+---
+
+Generalize `ponder-metadata` package and let ENSAdmin to ensure ENSRainbow version info is available.
+  

--- a/apps/ensadmin/package.json
+++ b/apps/ensadmin/package.json
@@ -21,6 +21,7 @@
     "test": "vitest"
   },
   "dependencies": {
+    "@ensnode/ensrainbow-sdk": "workspace:*",
     "@ensnode/ponder-metadata": "workspace:*",
     "@ensnode/ponder-schema": "workspace:*",
     "@graphiql/toolkit": "^0.11.1",

--- a/apps/ensadmin/src/components/ensnode/hooks.ts
+++ b/apps/ensadmin/src/components/ensnode/hooks.ts
@@ -90,6 +90,10 @@ function validateResponse(response: EnsNode.Metadata) {
         .join(", ")}`,
     );
   }
+
+  if (typeof response.deps.ensRainbow === "undefined") {
+    throw new Error(`ENSRainbow version not found in the response.`);
+  }
 }
 
 /**

--- a/apps/ensadmin/src/components/ensnode/types.ts
+++ b/apps/ensadmin/src/components/ensnode/types.ts
@@ -1,4 +1,5 @@
 import type { ENSDeploymentChain, ENSDeploymentConfig } from "@ensnode/ens-deployments";
+import type { EnsRainbow } from "@ensnode/ensrainbow-sdk";
 import type * as PonderMetadata from "@ensnode/ponder-metadata";
 
 /**
@@ -12,7 +13,12 @@ export namespace EnsNode {
   /**
    * The status of the ENS node.
    */
-  export interface Metadata extends Omit<PonderMetadata.MetadataMiddlewareResponse, "env"> {
+  export interface Metadata extends PonderMetadata.MetadataMiddlewareResponse {
+    /** Application dependencies info */
+    deps: PonderMetadata.MetadataMiddlewareResponse["deps"] & {
+      ensRainbow: EnsRainbow.VersionInfo;
+    };
+
     // override the `env` field to include the fields required by the ENSAdmin client
     env: {
       ACTIVE_PLUGINS: Array<keyof ENSDeploymentConfig>;

--- a/apps/ensadmin/src/components/indexing-status/components.tsx
+++ b/apps/ensadmin/src/components/indexing-status/components.tsx
@@ -213,7 +213,7 @@ function NetworkIndexingTimeline(props: NetworkIndexingTimelineProps) {
   }
 
   const { data } = indexingStatus;
-  const ensRainbowVersion = ensRainbowViewModel(data.runtime);
+  const ensRainbowVersion = ensRainbowViewModel(data.deps);
 
   return (
     <section className="px-6">

--- a/apps/ensadmin/src/components/indexing-status/view-models.test.ts
+++ b/apps/ensadmin/src/components/indexing-status/view-models.test.ts
@@ -17,6 +17,10 @@ describe("View Models", () => {
       const result = ensNodeDepsViewModel({
         nodejs: "v22.14.0",
         ponder: "v0.9.9",
+        ensRainbow: {
+          schema_version: 3,
+          version: "3.1.0",
+        },
       });
 
       expect(result).toEqual([

--- a/apps/ensadmin/src/components/indexing-status/view-models.ts
+++ b/apps/ensadmin/src/components/indexing-status/view-models.ts
@@ -154,19 +154,12 @@ export function ensNodeEnvViewModel(env: EnsNode.Metadata["env"]) {
  * @param runtime The runtime info from the ENSNode metadata
  * @returns An array of label-value pairs for ENSRainbow version info, or null if not available
  */
-export function ensRainbowViewModel(runtime: EnsNode.Metadata["runtime"]) {
-  //TODO: uncomment and fix this when current ENSIndexer is deployed
-  // if (!runtime.ensRainbow) {
-  //   return null;
-  // }
-
-  // return [
-  //   { label: "Version", value: runtime.ensRainbow.version },
-  //   { label: "Schema Version", value: runtime.ensRainbow.schema_version.toString() },
-  // ] as const;
-
+export function ensRainbowViewModel(deps: EnsNode.Metadata["deps"]) {
   return [
-    { label: "Version", value: "0.1.0" },
-    { label: "Schema Version", value: 2 },
+    { label: "Version", value: deps.ensRainbow.version },
+    {
+      label: "Schema Version",
+      value: deps.ensRainbow.schema_version.toString(),
+    },
   ] as const;
 }

--- a/apps/ensindexer/src/api/index.ts
+++ b/apps/ensindexer/src/api/index.ts
@@ -76,6 +76,9 @@ app.get(
       name: packageJson.name,
       version: packageJson.version,
     },
+    deps: {
+      ensRainbow: await fetchEnsRainbowVersion(),
+    },
     env: {
       ACTIVE_PLUGINS: requestedPluginNames().join(","),
       DATABASE_SCHEMA: ponderDatabaseSchema(),
@@ -85,7 +88,6 @@ app.get(
     query: {
       firstBlockToIndexByChainId: fetchFirstBlockToIndexByChainId,
       prometheusMetrics: fetchPrometheusMetrics,
-      ensRainbowVersion: fetchEnsRainbowVersion,
     },
     publicClients,
   }),

--- a/apps/ensindexer/src/lib/ponder-helpers.ts
+++ b/apps/ensindexer/src/lib/ponder-helpers.ts
@@ -1,7 +1,7 @@
 import type { Event } from "ponder:registry";
 import { Blockrange } from "@/lib/types";
 import DeploymentConfigs, { type ENSDeploymentChain } from "@ensnode/ens-deployments";
-import { DEFAULT_ENSRAINBOW_URL } from "@ensnode/ensrainbow-sdk";
+import { DEFAULT_ENSRAINBOW_URL, type EnsRainbow } from "@ensnode/ensrainbow-sdk";
 import { EnsRainbowApiClient } from "@ensnode/ensrainbow-sdk";
 import type { BlockInfo } from "@ensnode/ponder-metadata";
 import { merge as tsDeepMerge } from "ts-deepmerge";
@@ -194,9 +194,10 @@ export const createEnsRainbowVersionFetcher = () => {
     endpointUrl: new URL(ensRainbowEndpointUrl()),
   });
 
-  return async () => {
+  return async function ensRainbowVersionFetcher(): Promise<EnsRainbow.VersionInfo> {
     try {
       const versionResponse = await client.version();
+
       return {
         version: versionResponse.versionInfo.version,
         schema_version: versionResponse.versionInfo.schema_version,

--- a/packages/ponder-metadata/src/types/api.ts
+++ b/packages/ponder-metadata/src/types/api.ts
@@ -1,16 +1,22 @@
-import type { EnsRainbow } from "@ensnode/ensrainbow-sdk";
 import type { ReadonlyDrizzle } from "ponder";
 import type { PublicClient } from "viem";
 
 import type { BlockInfo } from "./common";
 
 export type PonderEnvVarsInfo = Record<string, unknown>;
-export interface PonderMetadataMiddlewareOptions<AppInfo, EnvVars extends PonderEnvVarsInfo> {
+export interface PonderMetadataMiddlewareOptions<
+  AppInfo,
+  DepsInfo extends Record<string, unknown>,
+  EnvVars extends PonderEnvVarsInfo,
+> {
   /** Database access object (readonly Drizzle) */
   db: ReadonlyDrizzle<Record<string, unknown>>;
 
   /** Application info */
   app: AppInfo;
+
+  /** Application dependencies info */
+  deps: DepsInfo;
 
   /** Environment settings info */
   env: EnvVars;
@@ -22,9 +28,6 @@ export interface PonderMetadataMiddlewareOptions<AppInfo, EnvVars extends Ponder
 
     /** Fetches the first block do be indexed for a requested chain ID */
     firstBlockToIndexByChainId(chainId: number, publicClient: PublicClient): Promise<BlockInfo>;
-
-    /** Fetches ENSRainbow version information */
-    ensRainbowVersion?(): Promise<EnsRainbow.VersionInfo>;
   };
 
   /** Public clients for each blockchain network fetching data */
@@ -33,6 +36,7 @@ export interface PonderMetadataMiddlewareOptions<AppInfo, EnvVars extends Ponder
 
 export interface PonderMetadataMiddlewareResponse<
   AppInfo,
+  DepsInfo extends Record<string, unknown>,
   EnvVarsInfo extends PonderEnvVarsInfo,
   RuntimeInfo,
 > {
@@ -46,7 +50,7 @@ export interface PonderMetadataMiddlewareResponse<
 
     /** Node.js runtime version */
     nodejs: string;
-  };
+  } & DepsInfo;
 
   /** Environment settings info */
   env: EnvVarsInfo;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
 
   apps/ensadmin:
     dependencies:
+      '@ensnode/ensrainbow-sdk':
+        specifier: workspace:*
+        version: link:../../packages/ensrainbow-sdk
       '@ensnode/ponder-metadata':
         specifier: workspace:*
         version: link:../../packages/ponder-metadata


### PR DESCRIPTION
This PR abstracts fetching ENSRainbow version away from the `ponder-metadata` package and moves it into the ENSIndexer application layer.

### Preview

| ENSRainbow info included in ENSNode response | ENSRainbow info not included in ENSNode response |
| - | - |
| ![image](https://github.com/user-attachments/assets/c4f2c85f-9280-4332-b956-a0551eb2b993) | ![image](https://github.com/user-attachments/assets/d0526c68-c231-4220-b35a-1b1fea7a2435) |

Resolves:
- #521 