### PR TITLE
Remove hardcoded env

### DIFF
--- a/.github/workflows/deploy_ensnode.yml
+++ b/.github/workflows/deploy_ensnode.yml
@@ -38,7 +38,6 @@ jobs:
 
       - name: Calculate env variables
         run: |
-            TARGET_ENVIRONMENT="green"
             case "$TARGET_ENVIRONMENT" in
               "green")
                 #ENVIRONMENT


### PR DESCRIPTION
PR fixing Railway deployment workflow. Currently it always overrides target env to green. After the fix, it'll read the target env from job's input.