### PR TITLE
feat(subgraph): _meta resolver data provider

### DIFF
--- a/apps/ensindexer/src/api/index.ts
+++ b/apps/ensindexer/src/api/index.ts
@@ -2,39 +2,33 @@ import packageJson from "@/../package.json";
 
 import { db, publicClients } from "ponder:api";
 import schema from "ponder:schema";
-import {
-  createEnsRainbowVersionFetcher,
-  createFirstBlockToIndexByChainIdFetcher,
-  createPrometheusMetricsFetcher,
-  ensAdminUrl,
-  ensNodePublicUrl,
-  getEnsDeploymentChain,
-  getEnsDeploymentChainId,
-  ponderDatabaseSchema,
-  ponderPort,
-  requestedPluginNames,
-} from "@/lib/ponder-helpers";
-import {
-  PrometheusMetrics,
-  ponderMetadata,
-  queryPonderMeta,
-  queryPonderStatus,
-} from "@ensnode/ponder-metadata";
-import {
-  type Block,
-  buildGraphQLSchema,
-  graphql as subgraphGraphQL,
-} from "@ensnode/ponder-subgraph";
 import { Hono, MiddlewareHandler } from "hono";
 import { cors } from "hono/cors";
 import { client, graphql as ponderGraphQL } from "ponder";
-import type { PublicClient } from "viem";
+
+import {
+  ensAdminUrl,
+  ensNodePublicUrl,
+  getEnsDeploymentChain,
+  ponderDatabaseSchema,
+  requestedPluginNames,
+} from "@/lib/ponder-helpers";
+import {
+  fetchEnsRainbowVersion,
+  fetchFirstBlockToIndexByChainId,
+  fetchPrometheusMetrics,
+  makePonderMetdataProvider,
+} from "@/lib/ponder-metadata-provider";
+import { ponderMetadata } from "@ensnode/ponder-metadata";
+import {
+  buildGraphQLSchema as buildSubgraphGraphQLSchema,
+  graphql as subgraphGraphQL,
+} from "@ensnode/ponder-subgraph";
 
 const app = new Hono();
 
 const ensNodeVersionResponseHeader: MiddlewareHandler = async (ctx, next) => {
   ctx.header("x-ensnode-version", packageJson.version);
-
   return next();
 };
 
@@ -66,82 +60,6 @@ app.use("/", async (ctx) => {
     throw new Error(`Cannot redirect to ENSAdmin: ${errorMessage}`);
   }
 });
-
-// setup block indexing status fetching
-const fetchFirstBlockToIndexByChainId = createFirstBlockToIndexByChainIdFetcher(
-  import("../../ponder.config").then((m) => m.default),
-);
-
-// setup prometheus metrics fetching
-const fetchPrometheusMetrics = createPrometheusMetricsFetcher(ponderPort());
-
-// setup ENSRainbow version fetching
-const fetchEnsRainbowVersion = createEnsRainbowVersionFetcher();
-
-// setup the data provider for the ponder subgraph middleware
-const createPonderSubgraphDataProvider = () => {
-  // get the chain ID for the ENS deployment
-  const ensDeploymentChainId = getEnsDeploymentChainId();
-
-  /**
-   * Get the public client for the ENS deployment chain
-   * @returns the public client for the ENS deployment chain
-   * @throws an error if the public client is not found
-   */
-  function getEnsDeploymentPublicClient(): PublicClient {
-    // get the public client for the ENS deployment chain
-    const publicClient = publicClients[ensDeploymentChainId];
-
-    if (!publicClient) {
-      throw new Error(`Could not find public client for chain ID: ${ensDeploymentChainId}`);
-    }
-
-    return publicClient;
-  }
-
-  /**
-   * Get the last block indexed by Ponder.
-   *
-   * @returns the block info fetched from the public client
-   */
-  const getLastIndexedBlock = async (): Promise<Block> => {
-    const ponderStatus = await queryPonderStatus(ponderDatabaseSchema(), db);
-    const chainStatus = ponderStatus.find(
-      (status) => status.network_name === ensDeploymentChainId.toString(),
-    );
-
-    if (!chainStatus || !chainStatus.block_number) {
-      throw new Error(
-        `Could not find latest indexed block number for chain ID: ${ensDeploymentChainId}`,
-      );
-    }
-
-    return getEnsDeploymentPublicClient().getBlock({
-      blockNumber: BigInt(chainStatus.block_number),
-    });
-  };
-
-  /**
-   * Get the Ponder build ID
-   * @returns The Ponder build ID
-   */
-  const getPonderBuildId = async (): Promise<string> => {
-    const meta = await queryPonderMeta(ponderDatabaseSchema(), db);
-
-    return meta.build_id;
-  };
-
-  /**
-   * Check if there are any indexing errors logged in the prometheus metrics
-   * @returns true if there are no indexing errors, false otherwise
-   */
-  const hasIndexingErrors = async () => {
-    const metrics = PrometheusMetrics.parse(await fetchPrometheusMetrics());
-    return metrics.getValue("ponder_indexing_has_error") === 1;
-  };
-
-  return { getLastIndexedBlock, getPonderBuildId, hasIndexingErrors };
-};
 
 // use ENSNode middleware at /metadata
 app.get(
@@ -177,12 +95,10 @@ app.use(
   "/subgraph",
   subgraphGraphQL({
     db,
-    graphqlSchema: buildGraphQLSchema({
+    graphqlSchema: buildSubgraphGraphQLSchema({
       schema,
-      metaConfig: {
-        version: packageJson.version,
-        schema: ponderDatabaseSchema(),
-      },
+      // provide the schema with ponder's internal metadata to power _meta
+      metadataProvider: makePonderMetdataProvider(),
       // describes the polymorphic (interface) relationships in the schema
       polymorphicConfig: {
         types: {
@@ -217,7 +133,6 @@ app.use(
           "Resolver.events": "ResolverEvent",
         },
       },
-      dataProvider: createPonderSubgraphDataProvider(),
     }),
   }),
 );

--- a/apps/ensindexer/src/lib/ponder-helpers.ts
+++ b/apps/ensindexer/src/lib/ponder-helpers.ts
@@ -1,10 +1,8 @@
 import type { Event } from "ponder:registry";
 import { Blockrange } from "@/lib/types";
 import { type ENSDeploymentChain, ENSDeployments } from "@ensnode/ens-deployments";
-import { DEFAULT_ENSRAINBOW_URL } from "@ensnode/ensrainbow-sdk";
-import { EnsRainbowApiClient } from "@ensnode/ensrainbow-sdk";
+import { DEFAULT_ENSRAINBOW_URL, EnsRainbowApiClient } from "@ensnode/ensrainbow-sdk";
 import type { BlockInfo } from "@ensnode/ponder-metadata";
-import type { ContractConfig } from "ponder";
 import { merge as tsDeepMerge } from "ts-deepmerge";
 import { PublicClient } from "viem";
 
@@ -242,6 +240,15 @@ export const getEnsDeploymentChain = (): ENSDeploymentChain => {
   }
 
   return value as ENSDeploymentChain;
+};
+
+/**
+ * Get the ENSDeployment chain ID.
+ *
+ * @returns the ENSDeployment chain ID
+ */
+export const getEnsDeploymentChainId = (): number => {
+  return ENSDeployments[getEnsDeploymentChain()].root.chain.id;
 };
 
 /**

--- a/apps/ensindexer/src/lib/ponder-helpers.ts
+++ b/apps/ensindexer/src/lib/ponder-helpers.ts
@@ -1,10 +1,11 @@
 import type { Event } from "ponder:registry";
+import { merge as tsDeepMerge } from "ts-deepmerge";
+import { PublicClient } from "viem";
+
 import { Blockrange } from "@/lib/types";
 import { type ENSDeploymentChain, ENSDeployments } from "@ensnode/ens-deployments";
 import { DEFAULT_ENSRAINBOW_URL, EnsRainbowApiClient } from "@ensnode/ensrainbow-sdk";
 import type { BlockInfo } from "@ensnode/ponder-metadata";
-import { merge as tsDeepMerge } from "ts-deepmerge";
-import { PublicClient } from "viem";
 
 export type EventWithArgs<ARGS extends Record<string, unknown> = {}> = Omit<Event, "args"> & {
   args: ARGS;

--- a/apps/ensindexer/src/lib/ponder-metadata-provider.ts
+++ b/apps/ensindexer/src/lib/ponder-metadata-provider.ts
@@ -1,0 +1,95 @@
+import packageJson from "@/../package.json";
+
+import { db, publicClients } from "ponder:api";
+import type { PublicClient } from "viem";
+
+import {
+  createEnsRainbowVersionFetcher,
+  createFirstBlockToIndexByChainIdFetcher,
+  createPrometheusMetricsFetcher,
+  getEnsDeploymentChainId,
+  ponderDatabaseSchema,
+  ponderPort,
+} from "@/lib/ponder-helpers";
+import { PrometheusMetrics, queryPonderMeta, queryPonderStatus } from "@ensnode/ponder-metadata";
+import type { PonderMetadataProvider } from "@ensnode/ponder-subgraph";
+
+// setup block indexing status fetching
+export const fetchFirstBlockToIndexByChainId = createFirstBlockToIndexByChainIdFetcher(
+  import("@/../ponder.config").then((m) => m.default),
+);
+
+// setup ENSRainbow version fetching
+export const fetchEnsRainbowVersion = createEnsRainbowVersionFetcher();
+
+// setup prometheus metrics fetching
+export const fetchPrometheusMetrics = createPrometheusMetricsFetcher(ponderPort());
+
+export const makePonderMetdataProvider = (): PonderMetadataProvider => {
+  // get the chain ID for the ENS deployment
+  const ensDeploymentChainId = getEnsDeploymentChainId();
+
+  /**
+   * Get the public client for the ENS deployment chain
+   * @returns the public client for the ENS deployment chain
+   * @throws an error if the public client is not found
+   */
+  function getEnsDeploymentPublicClient(): PublicClient {
+    // get the public client for the ENS deployment chain
+    const publicClient = publicClients[ensDeploymentChainId];
+
+    if (!publicClient) {
+      throw new Error(`Could not find public client for chain ID: ${ensDeploymentChainId}`);
+    }
+
+    return publicClient;
+  }
+
+  /**
+   * Get the last block indexed by Ponder.
+   *
+   * @returns the block info fetched from the public client
+   */
+  const getLastIndexedBlock = async () => {
+    const ponderStatus = await queryPonderStatus(ponderDatabaseSchema(), db);
+    const chainStatus = ponderStatus.find(
+      (status) => status.network_name === ensDeploymentChainId.toString(),
+    );
+
+    if (!chainStatus || !chainStatus.block_number) {
+      throw new Error(
+        `Could not find latest indexed block number for chain ID: ${ensDeploymentChainId}`,
+      );
+    }
+
+    return getEnsDeploymentPublicClient().getBlock({
+      blockNumber: BigInt(chainStatus.block_number),
+    });
+  };
+
+  /**
+   * Get the Ponder build ID
+   * @returns The Ponder build ID
+   */
+  const getPonderBuildId = async (): Promise<string> => {
+    const meta = await queryPonderMeta(ponderDatabaseSchema(), db);
+
+    return meta.build_id;
+  };
+
+  /**
+   * Check if there are any indexing errors logged in the prometheus metrics
+   * @returns true if there are no indexing errors, false otherwise
+   */
+  const hasIndexingErrors = async () => {
+    const metrics = PrometheusMetrics.parse(await fetchPrometheusMetrics());
+    return metrics.getValue("ponder_indexing_has_error") === 1;
+  };
+
+  return {
+    version: packageJson.version,
+    getLastIndexedBlock,
+    getPonderBuildId,
+    hasIndexingErrors,
+  };
+};

--- a/packages/ponder-metadata/package.json
+++ b/packages/ponder-metadata/package.json
@@ -17,8 +17,7 @@
     "dist"
   ],
   "exports": {
-    ".": "./src/index.ts",
-    "./db-helpers": "./src/db-helpers.ts"
+    ".": "./src/index.ts"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/ponder-metadata/src/index.ts
+++ b/packages/ponder-metadata/src/index.ts
@@ -1,3 +1,5 @@
 export { ponderMetadata, type MetadataMiddlewareResponse } from "./middleware";
+export { queryPonderMeta, queryPonderStatus } from "./db-helpers";
 export type { PonderMetadataMiddlewareResponse } from "./types/api";
 export type { BlockInfo, NetworkIndexingStatus } from "./types/common";
+export { PrometheusMetrics } from "./prometheus-metrics";

--- a/packages/ponder-metadata/src/prometheus-metrics.test.ts
+++ b/packages/ponder-metadata/src/prometheus-metrics.test.ts
@@ -19,6 +19,10 @@ ponder_historical_start_timestamp_seconds 1740391265
 # TYPE ponder_historical_total_indexing_seconds gauge
 ponder_historical_total_indexing_seconds{network="1"} 251224935
 ponder_historical_total_indexing_seconds{network="8453"} 251224935
+
+# HELP ponder_indexing_has_error Boolean (0 or 1) indicating if there is an indexing error
+# TYPE ponder_indexing_has_error gauge
+ponder_indexing_has_error 0
 `;
 
   describe("parsePrometheusText", () => {
@@ -103,6 +107,10 @@ ponder_historical_total_indexing_seconds{network="8453"} 251224935
       expect(networks).toContain("1");
       expect(networks).toContain("8453");
       expect(networks.length).toBe(2);
+    });
+
+    it("should get indexing has error metrics", () => {
+      expect(parser.getValue("ponder_indexing_has_error")).toBe(0);
     });
 
     it("should get help text", () => {

--- a/packages/ponder-subgraph-api/package.json
+++ b/packages/ponder-subgraph-api/package.json
@@ -15,7 +15,7 @@
     "Subgraph"
   ],
   "exports": {
-    "./middleware": "./src/middleware.ts"
+    ".": "./src/index.ts"
   },
   "files": [
     "dist"
@@ -23,22 +23,22 @@
   "publishConfig": {
     "access": "public",
     "exports": {
-      "./middleware": {
-        "types": "./dist/middleware.d.ts",
-        "default": "./dist/middleware.js"
+      ".": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
       }
     },
-    "main": "./dist/middleware.js",
-    "module": "./dist/middleware.mjs",
-    "types": "./dist/middleware.d.ts"
+    "main": "./dist/index.js",
+    "module": "./dist/index.mjs",
+    "types": "./dist/index.d.ts"
   },
   "scripts": {
     "prepublish": "tsup",
     "typecheck": "tsc --noEmit",
+    "lint": "biome check --write",
     "lint:ci": "biome ci"
   },
   "dependencies": {
-    "@ensnode/ponder-metadata": "workspace:*",
     "@escape.tech/graphql-armor-max-aliases": "^2.6.0",
     "@escape.tech/graphql-armor-max-depth": "^2.4.0",
     "@escape.tech/graphql-armor-max-tokens": "^2.5.0",

--- a/packages/ponder-subgraph-api/src/index.ts
+++ b/packages/ponder-subgraph-api/src/index.ts
@@ -1,4 +1,3 @@
 export * from "./middleware";
+export * from "./types";
 export { buildGraphQLSchema } from "./graphql";
-export type { DataProvider } from "./types";
-export type { Block } from "./types";

--- a/packages/ponder-subgraph-api/src/index.ts
+++ b/packages/ponder-subgraph-api/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./middleware";
+export { buildGraphQLSchema } from "./graphql";
+export type { DataProvider } from "./types";
+export type { Block } from "./types";

--- a/packages/ponder-subgraph-api/src/middleware.ts
+++ b/packages/ponder-subgraph-api/src/middleware.ts
@@ -10,21 +10,18 @@
 import { maxAliasesPlugin } from "@escape.tech/graphql-armor-max-aliases";
 import { maxDepthPlugin } from "@escape.tech/graphql-armor-max-depth";
 import { maxTokensPlugin } from "@escape.tech/graphql-armor-max-tokens";
+import type { GraphQLSchema } from "graphql";
 import { createYoga } from "graphql-yoga";
 import { createMiddleware } from "hono/factory";
-import { MetaConfig, PolymorphicConfig, buildDataLoaderCache, buildGraphQLSchema } from "./graphql";
+import { buildDataLoaderCache } from "./graphql";
 
 export const graphql = (
   {
     db,
-    schema,
-    metaConfig,
-    polymorphicConfig,
+    graphqlSchema,
   }: {
     db: any;
-    schema: any;
-    metaConfig: MetaConfig;
-    polymorphicConfig: PolymorphicConfig;
+    graphqlSchema: GraphQLSchema;
   },
   {
     maxOperationTokens = 1000,
@@ -42,8 +39,6 @@ export const graphql = (
     maxOperationAliases: 30,
   },
 ) => {
-  const graphqlSchema = buildGraphQLSchema(schema, metaConfig, polymorphicConfig);
-
   const yoga = createYoga({
     graphqlEndpoint: "*", // Disable built-in route validation, use Hono routing instead
     schema: graphqlSchema,

--- a/packages/ponder-subgraph-api/src/types.ts
+++ b/packages/ponder-subgraph-api/src/types.ts
@@ -1,4 +1,4 @@
-export type Block = {
+export type SubgraphMetaBlock = {
   /** Block number */
   number: bigint;
 
@@ -13,14 +13,19 @@ export type Block = {
 };
 
 /**
- * The data provider interface used to fetch data from the application layer.
+ * The metadata provider interface used to fetch data from the application layer.
  */
-export interface DataProvider {
+export interface PonderMetadataProvider {
+  /**
+   * ENSIndexer app version.
+   */
+  version: string;
+
   /**
    * Get last indexed block status
    * @returns The last indexed block status
    */
-  getLastIndexedBlock(): Promise<Block>;
+  getLastIndexedBlock(): Promise<SubgraphMetaBlock>;
 
   /**
    * Get the Ponder build ID

--- a/packages/ponder-subgraph-api/src/types.ts
+++ b/packages/ponder-subgraph-api/src/types.ts
@@ -1,0 +1,36 @@
+export type Block = {
+  /** Block number */
+  number: bigint;
+
+  /** Block unix timestamp */
+  timestamp: bigint;
+
+  /** Block hash */
+  hash: `0x${string}`;
+
+  /** Block parent hash */
+  parentHash: `0x${string}`;
+};
+
+/**
+ * The data provider interface used to fetch data from the application layer.
+ */
+export interface DataProvider {
+  /**
+   * Get last indexed block status
+   * @returns The last indexed block status
+   */
+  getLastIndexedBlock(): Promise<Block>;
+
+  /**
+   * Get the Ponder build ID
+   * @returns The Ponder build ID
+   */
+  getPonderBuildId(): Promise<string>;
+
+  /**
+   * Get the indexing errors status
+   * @returns The indexing errors status
+   */
+  hasIndexingErrors: () => Promise<boolean>;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -597,9 +597,6 @@ importers:
 
   packages/ponder-subgraph-api:
     dependencies:
-      '@ensnode/ponder-metadata':
-        specifier: workspace:*
-        version: link:../ponder-metadata
       '@escape.tech/graphql-armor-max-aliases':
         specifier: ^2.6.0
         version: 2.6.0


### PR DESCRIPTION
This PR introduces a data provider interface for `ponder-subgraph-api` package. With this change, it's the application's (i.e. ENSIndexer's) responsibility to provide async methods to fetch current data for Subgraph's `_meta` field. This data includes :
- the last indexed block info (deriver from Ponder status DB table and RPC request),
- Ponder build ID (derived from Ponder metadata DB table),
- if there were any indexing errors (derived from Ponder metrics).

With these changes, the `ponder-subgraph-api` package does not a direct dependency on the `ponder-metadata` packages. They are integrated on the ENSIndexer application level.

Also, `_meta` field can now be built for all supported ENS Deployments: `mainnet`, `sepolia`, `holesky`, and `ens-test-env`.