### PR TITLE
feat(ci): update github release workflow

### DIFF
--- a/.github/workflows/create_github_release.yml
+++ b/.github/workflows/create_github_release.yml
@@ -1,0 +1,49 @@
+name: Create GitHub Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  create-release:
+    # Only run when PR is merged (not just closed) and has the title "Release New Version"
+    # Note the title is set in the release.yml workflow as changeset-action@v1 inputs.title
+    if: github.event.pull_request.merged == true && github.event.pull_request.title == 'Release New Version'
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from PR description
+        id: extract-version
+        run: |
+          PR_BODY="${{ github.event.pull_request.body }}"
+          
+          # Try to extract version from any package
+          # Note: all packages are released with the same version (see .changeset/config.json->fixed)
+          VERSION=$(echo "$PR_BODY" | grep -o '@[^@]*@[0-9]\+\.[0-9]\+\.[0-9]\+' | head -1 | awk -F@ '{print $3}')
+
+          
+          # If still no version found, exit with error
+          if [ -z "$VERSION" ]; then
+            echo "ERROR: Could not extract version number from PR description"
+            exit 1
+          fi
+          
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Extracted version: $VERSION"
+          
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ steps.extract-version.outputs.version }}
+          name: Release v${{ steps.extract-version.outputs.version }}
+          body: ${{ github.event.pull_request.body }}
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Changesets Release
 
 on:
   workflow_dispatch:
@@ -44,6 +44,7 @@ jobs:
           commit: "chore(release): version apps"
           title: "Release New Version"
           publish: pnpm changeset-publish
+          createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -63,13 +63,13 @@ jobs:
       - name: Run Ponder runtime integrity checks
         working-directory: apps/ensindexer
         env:
-          ACTIVE_PLUGINS: eth,base,linea
+          ACTIVE_PLUGINS: subgraph,basenames,lineanames
           RPC_URL_1: https://eth.drpc.org
           RPC_URL_8453: https://base.drpc.org
           RPC_URL_59144: https://linea.drpc.org
           RUNTIME_CHECK_TIMEOUT_SECONDS: 10
         run: |
-          pnpm dev -vv &
+          pnpm dev --disable-ui -vv &
           PID=$!
           sleep $RUNTIME_CHECK_TIMEOUT_SECONDS
           if ps -p $PID > /dev/null; then

--- a/apps/ensindexer/src/plugins/README.md
+++ b/apps/ensindexer/src/plugins/README.md
@@ -4,5 +4,5 @@ This directory contains plugins that define subname-specific processing of block
 One or more plugins are activated at a time. Use the `ACTIVE_PLUGINS` env variable to select the active plugins, for example:
 
 ```
-ACTIVE_PLUGINS=eth,base,linea
+ACTIVE_PLUGINS=subgraph,basenames,lineanames
 ```


### PR DESCRIPTION
This PR makes Changesets to not create a Github Release and instead, has a separate Github Action to read the changesets-made PR and create the new Github Release from its description.

Also, this PR updates `ACTIVE_PLUGINS` values to match recent refactorings.