### PR TITLE
fix(ci): allow github release action to read PR details

### DIFF
--- a/.changeset/two-ways-shout.md
+++ b/.changeset/two-ways-shout.md
@@ -1,0 +1,5 @@
+---
+"@ensnode/utils": patch
+---
+
+Allow CI workflow to read PR information to generate Github Release notes.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,8 @@ jobs:
 
       - name: Get PR information
         id: get-pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Get the PR number from the commit message
           # Note: it must be a release PR with a title "Release New Version"


### PR DESCRIPTION
This PR fixes an error where our CI workflow job cannot access pull request details in order to generate release notes. The job needs to include github token in order to use `gh` command from Github CLI.

Related:
- https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/using-github-cli-in-workflows

Failed CI job:
- https://github.com/namehash/ensnode/actions/runs/14516776624/job/40730436088