### PR TITLE
docs: fix outdated links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to ENSNode! We welcome contributions
 
 For detailed contribution guidelines and setup instructions:
 
-- **ENSNode**: Visit [ENSNode Contributing Guide](https://ensnode.io/ensnode/contributing)
+- **ENSNode**: Visit [ENSNode Contributing Guide](https://ensnode.io/docs/contributing)
 - **ENSRainbow**: Visit [ENSRainbow Contributing Guide](https://ensnode.io/ensrainbow/contributing)
 
 ## Getting Help

--- a/apps/ensindexer/README.md
+++ b/apps/ensindexer/README.md
@@ -4,7 +4,7 @@ Indexes EVM chains for ENSNode.
 
 ## Documentation
 
-For detailed documentation and guides, see the [ENSNode Documentation](https://ensnode.io/ensnode).
+For detailed documentation and guides, see the [ENSNode Documentation](https://ensnode.io/docs).
 
 ## License
 

--- a/examples/example-docker-compose/README.md
+++ b/examples/example-docker-compose/README.md
@@ -4,7 +4,7 @@ This example demonstrates running the ENSNode suite of services within Docker Co
 
 ## Documentation
 
-For detailed documentation and guides, see the [Deploying ENSNode with Docker](https://ensnode.io/ensnode/deploying/docker/) guide.
+For detailed documentation and guides, see the [Deploying ENSNode with Docker](https://ensnode.io/docs/deploying/docker/) guide.
 
 ## License
 


### PR DESCRIPTION
Three links weren't updated when the docs folder got renamed. This fixes that.