### PR TITLE
fix(github-release): release notes format

### DIFF
--- a/.changeset/cold-owls-hug.md
+++ b/.changeset/cold-owls-hug.md
@@ -1,0 +1,5 @@
+---
+"@ensnode/utils": patch
+---
+
+Update release notes format when creating Github Release. Also, stop pushing git tag per each released package.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -22,7 +22,7 @@
   "prettier": true,
   "privatePackages": {
     "version": true,
-    "tag": true
+    "tag": false
   },
   "ignore": ["@docs/ensnode", "@docs/ensrainbow"]
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,9 @@ jobs:
       pull-requests: write
     outputs:
       published: ${{ steps.changesets.outputs.published }}
+      # publishedApps example [{"name":"ensadmin","version":"0.15.0"},{"name":"ensindexer","version":"0.15.0"},{"name":"ensrainbow","version":"0.15.0"}]
       publishedApps: ${{ steps.publishedApps.outputs.output }}
-      # [{"name":"ensadmin","version":"0.15.0"},{"name":"ensindexer","version":"0.15.0"},{"name":"ensrainbow","version":"0.15.0"}]
+      publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -152,6 +153,10 @@ jobs:
           # Add NPM package links
           RELEASE_NOTES+=$'\n\n## :package: NPM packages\n'
           RELEASE_NOTES+=$(echo "${{ needs.release.outputs.publishedPackages }}" | jq -r '.[] | "- [\(.name)@\(.version)](https://www.npmjs.com/package/\(.name)/v/\(.version))"')
+
+          # Add Docker image links
+          RELEASE_NOTES+=$'\n\n## :whale: Docker images\n'
+          RELEASE_NOTES+=$(echo "${{ needs.release.outputs.publishedApps }}" | jq -r '.[] | "- [\(.name):\(.version)](https://ghcr.io/namehash/ensnode/\(.name):\(.version))"')
           
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "pr_body<<EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,6 +149,10 @@ jobs:
           # Extract release notes (everything below # Releases)
           RELEASE_NOTES=$(echo "$PR_BODY" | awk '/^# Releases/{p=1;next}p')
           
+          # Add NPM package links
+          RELEASE_NOTES+=$'\n\n## :package: NPM packages\n'
+          RELEASE_NOTES+=$(echo "${{ needs.release.outputs.publishedPackages }}" | jq -r '.[] | "- [\(.name)@\(.version)](https://www.npmjs.com/package/\(.name)/v/\(.version))"')
+          
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "pr_body<<EOF" >> $GITHUB_OUTPUT
           echo "$RELEASE_NOTES" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,9 +146,12 @@ jobs:
             exit 1
           fi
           
+          # Extract release notes (everything below # Releases)
+          RELEASE_NOTES=$(echo "$PR_BODY" | awk '/^# Releases/{p=1;next}p')
+          
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "pr_body<<EOF" >> $GITHUB_OUTPUT
-          echo "$PR_BODY" >> $GITHUB_OUTPUT
+          echo "$RELEASE_NOTES" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
           echo "Extracted version: $VERSION"
 
@@ -156,7 +159,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           tag_name: v${{ steps.get-pr.outputs.version }}
-          name: Release v${{ steps.get-pr.outputs.version }}
+          name: v${{ steps.get-pr.outputs.version }}
           body: ${{ steps.get-pr.outputs.pr_body }}
           draft: false
           prerelease: false

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "pnpm -r --parallel test run",
     "typecheck": "pnpm -r --parallel typecheck",
     "changeset": "changeset",
-    "changeset-publish": "changeset publish",
+    "changeset-publish": "changeset publish --no-git-tag",
     "packages:prepublish": "pnpm -r --filter='@ensnode/*' prepublish",
     "docker:build:ensnode": "pnpm run docker:build:ensindexer && pnpm run docker:build:ensrainbow && pnpm run docker:build:ensadmin",
     "docker:build:ensindexer": "docker build -f apps/ensindexer/Dockerfile -t ghcr.io/namehash/ensnode/ensindexer:latest .",


### PR DESCRIPTION
This PR makes:
- changesets not to publish git tags for any packages
- formats release notes
  - drops initial paragraph and header
  - includes links to NPM packages published with the current release
  - includes links to Docker images published with the current release