### PR TITLE
feat: improved connection library

### DIFF
--- a/apps/ensadmin/package.json
+++ b/apps/ensadmin/package.json
@@ -22,8 +22,8 @@
   },
   "dependencies": {
     "@ensnode/ponder-metadata": "workspace:*",
-    "@ensnode/utils": "workspace:*",
     "@ensnode/ponder-schema": "workspace:*",
+    "@ensnode/utils": "workspace:*",
     "@graphiql/toolkit": "^0.11.1",
     "@ponder/client": "catalog:",
     "@ponder/react": "catalog:",
@@ -49,7 +49,7 @@
     "next-themes": "^0.4.6",
     "react": "^18",
     "react-dom": "^18",
-    "sonner": "^2.0.1",
+    "sonner": "^2.0.3",
     "tailwind-merge": "^3.0.2",
     "tailwindcss-animate": "^1.0.7",
     "viem": "catalog:",

--- a/apps/ensadmin/src/components/connections/connection-selector.tsx
+++ b/apps/ensadmin/src/components/connections/connection-selector.tsx
@@ -140,22 +140,21 @@ export function ConnectionSelector() {
               ) : (
                 connections
                   .filter(({ isDefault }) => isDefault)
-                  .map(({ url, isDefault }) => {
+                  .map(({ url }) => {
                     const isCurrentlySelectedConnection = url === selectedUrl.toString();
                     return (
-                      <DropdownMenuItem
-                        key={url}
-                        onClick={() => handleSelect(url)}
-                        className={cn(
-                          "group gap-2 p-2 font-mono text-xs justify-between cursor-pointer",
-                          isCurrentlySelectedConnection ? "bg-primary/10 text-primary" : "",
-                        )}
-                      >
-                        <span className="truncate flex-1">{url}</span>
-                        <div className="flex items-center gap-1">
-                          <CopyButton value={url} size="sm" className="-mr-2" />
-                        </div>
-                      </DropdownMenuItem>
+                      <div key={url} className="flex items-center justify-between gap-1">
+                        <DropdownMenuItem
+                          onClick={() => handleSelect(url)}
+                          className={cn(
+                            "cursor-pointer flex-1 py-2.5",
+                            isCurrentlySelectedConnection ? "bg-primary/10 text-primary" : null,
+                          )}
+                        >
+                          <span className="font-mono text-xs truncate flex-1">{url}</span>
+                        </DropdownMenuItem>
+                        <CopyButton value={url} />
+                      </div>
                     );
                   })
               )}
@@ -172,19 +171,21 @@ export function ConnectionSelector() {
                     .map(({ url }) => {
                       const isCurrentlySelectedConnection = url === selectedUrl.toString();
                       return (
-                        <DropdownMenuItem
-                          key={url}
-                          onClick={() => handleSelect(url)}
-                          className={cn(
-                            "group gap-2 p-2 font-mono text-xs justify-between cursor-pointer",
-                            isCurrentlySelectedConnection ? "bg-primary/10 text-primary" : "",
-                          )}
-                        >
-                          <span className="truncate flex-1">{url}</span>
-                          <div className="flex items-center gap-1">
+                        <div key={url} className="flex items-center justify-between gap-1">
+                          <DropdownMenuItem
+                            onClick={() => handleSelect(url)}
+                            className={cn(
+                              "cursor-pointer flex-1 py-2.5",
+                              isCurrentlySelectedConnection ? "bg-primary/10 text-primary" : null,
+                            )}
+                          >
+                            <span className="font-mono text-xs truncate flex-1">{url}</span>
+                          </DropdownMenuItem>
+                          <div className="flex items-center">
                             {!isCurrentlySelectedConnection && (
                               <Button
-                                variant="destructive"
+                                variant="ghost"
+                                size="icon"
                                 onClick={(e) => {
                                   e.stopPropagation();
                                   handleRemove(url);
@@ -202,9 +203,9 @@ export function ConnectionSelector() {
                                 )}
                               </Button>
                             )}
-                            <CopyButton value={url} size="sm" className="-mr-2" />
+                            <CopyButton value={url} />
                           </div>
-                        </DropdownMenuItem>
+                        </div>
                       );
                     })}
                 </>

--- a/apps/ensadmin/src/components/connections/connection-selector.tsx
+++ b/apps/ensadmin/src/components/connections/connection-selector.tsx
@@ -124,7 +124,7 @@ export function ConnectionSelector() {
               </SidebarMenuButton>
             </DropdownMenuTrigger>
             <DropdownMenuContent
-              className="w-[--radix-dropdown-menu-trigger-width] min-w-72 rounded-lg"
+              className="w-[--radix-dropdown-menu-trigger-width] min-w-80 rounded-lg"
               align="start"
               side={isMobile ? "bottom" : "right"}
               sideOffset={4}
@@ -147,11 +147,11 @@ export function ConnectionSelector() {
                         <DropdownMenuItem
                           onClick={() => handleSelect(url)}
                           className={cn(
-                            "cursor-pointer flex-1 py-2.5",
+                            "cursor-pointer flex-1 py-2.5 truncate",
                             isCurrentlySelectedConnection ? "bg-primary/10 text-primary" : null,
                           )}
                         >
-                          <span className="font-mono text-xs truncate flex-1">{url}</span>
+                          <span className="font-mono text-xs flex-1">{url}</span>
                         </DropdownMenuItem>
                         <CopyButton value={url} />
                       </div>
@@ -175,11 +175,11 @@ export function ConnectionSelector() {
                           <DropdownMenuItem
                             onClick={() => handleSelect(url)}
                             className={cn(
-                              "cursor-pointer flex-1 py-2.5",
+                              "cursor-pointer flex-1 py-2.5 truncate",
                               isCurrentlySelectedConnection ? "bg-primary/10 text-primary" : null,
                             )}
                           >
-                            <span className="font-mono text-xs truncate flex-1">{url}</span>
+                            <span className="font-mono text-xs flex-1">{url}</span>
                           </DropdownMenuItem>
                           <div className="flex items-center">
                             {!isCurrentlySelectedConnection && (

--- a/apps/ensadmin/src/components/connections/connection-selector.tsx
+++ b/apps/ensadmin/src/components/connections/connection-selector.tsx
@@ -2,7 +2,7 @@
 
 import { selectedEnsNodeUrl } from "@/lib/env";
 import { cn } from "@/lib/utils";
-import { ChevronsUpDown, ExternalLink, Loader2, Plus, Trash2 } from "lucide-react";
+import { ChevronsUpDown, Loader2, Plus, Trash2 } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
 
@@ -33,6 +33,7 @@ import {
   SidebarMenuItem,
   useSidebar,
 } from "@/components/ui/sidebar";
+import { CopyButton } from "../ui/copy-button";
 import { useConnections } from "./use-connections";
 
 const validateUrl = (url: string) => {
@@ -129,7 +130,7 @@ export function ConnectionSelector() {
               sideOffset={4}
             >
               <DropdownMenuLabel className="text-xs text-muted-foreground">
-                ENSNode Connections
+                ENSNode Connection Library
               </DropdownMenuLabel>
 
               {isLoading ? (
@@ -137,60 +138,82 @@ export function ConnectionSelector() {
                   <Loader2 className="w-4 h-4 animate-spin text-muted-foreground" />
                 </div>
               ) : (
-                connections.map(({ url, isDefault }) => {
-                  const isCurrentlySelectedConnection = url === selectedUrl.toString();
-                  return (
-                    <DropdownMenuItem
-                      key={url}
-                      onClick={() => handleSelect(url)}
-                      className={cn(
-                        "group gap-2 p-2 font-mono text-xs justify-between",
-                        isCurrentlySelectedConnection ? "bg-primary/10 text-primary" : "",
-                      )}
-                    >
-                      <span className="truncate flex-1">{url}</span>
-                      <div className="flex items-center gap-1">
-                        <a
-                          href={url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          onClick={(e) => e.stopPropagation()}
-                          className="p-1 hover:text-foreground rounded"
-                        >
-                          <ExternalLink className="w-3 h-3" />
-                        </a>
-                        {!isDefault && !isCurrentlySelectedConnection && (
-                          <button
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              handleRemove(url);
-                            }}
-                            disabled={removeConnection.isPending}
-                            className={cn(
-                              "p-1 rounded",
-                              removeConnection.isPending
-                                ? "text-muted-foreground cursor-not-allowed"
-                                : "hover:text-destructive",
-                            )}
-                          >
-                            {removeConnection.isPending &&
-                            removeConnection.variables?.url === url ? (
-                              <Loader2 className="w-3 h-3 animate-spin" />
-                            ) : (
-                              <Trash2 className="w-3 h-3" />
-                            )}
-                          </button>
+                connections
+                  .filter(({ isDefault }) => isDefault)
+                  .map(({ url, isDefault }) => {
+                    const isCurrentlySelectedConnection = url === selectedUrl.toString();
+                    return (
+                      <DropdownMenuItem
+                        key={url}
+                        onClick={() => handleSelect(url)}
+                        className={cn(
+                          "group gap-2 p-2 font-mono text-xs justify-between cursor-pointer",
+                          isCurrentlySelectedConnection ? "bg-primary/10 text-primary" : "",
                         )}
-                      </div>
-                    </DropdownMenuItem>
-                  );
-                })
+                      >
+                        <span className="truncate flex-1">{url}</span>
+                        <div className="flex items-center gap-1">
+                          <CopyButton value={url} size="sm" className="-mr-2" />
+                        </div>
+                      </DropdownMenuItem>
+                    );
+                  })
+              )}
+
+              {!isLoading && connections.some(({ isDefault }) => !isDefault) && (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuLabel className="text-xs text-muted-foreground">
+                    My Custom Connections
+                  </DropdownMenuLabel>
+
+                  {connections
+                    .filter(({ isDefault }) => !isDefault)
+                    .map(({ url }) => {
+                      const isCurrentlySelectedConnection = url === selectedUrl.toString();
+                      return (
+                        <DropdownMenuItem
+                          key={url}
+                          onClick={() => handleSelect(url)}
+                          className={cn(
+                            "group gap-2 p-2 font-mono text-xs justify-between cursor-pointer",
+                            isCurrentlySelectedConnection ? "bg-primary/10 text-primary" : "",
+                          )}
+                        >
+                          <span className="truncate flex-1">{url}</span>
+                          <div className="flex items-center gap-1">
+                            {!isCurrentlySelectedConnection && (
+                              <Button
+                                variant="destructive"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  handleRemove(url);
+                                }}
+                                disabled={removeConnection.isPending}
+                                className={cn(
+                                  removeConnection.isPending ? "cursor-not-allowed" : "",
+                                )}
+                              >
+                                {removeConnection.isPending &&
+                                removeConnection.variables?.url === url ? (
+                                  <Loader2 className="w-3 h-3 animate-spin" />
+                                ) : (
+                                  <Trash2 className="w-3 h-3" />
+                                )}
+                              </Button>
+                            )}
+                            <CopyButton value={url} size="sm" className="-mr-2" />
+                          </div>
+                        </DropdownMenuItem>
+                      );
+                    })}
+                </>
               )}
 
               <DropdownMenuSeparator />
 
               <DialogTrigger asChild>
-                <DropdownMenuItem className="gap-2 p-2">
+                <DropdownMenuItem className="gap-2 p-2 cursor-pointer">
                   <div className="flex size-6 items-center justify-center rounded-md border bg-background">
                     <Plus className="size-4" />
                   </div>
@@ -206,7 +229,7 @@ export function ConnectionSelector() {
         <DialogHeader>
           <DialogTitle>Add ENSNode Connection</DialogTitle>
           <DialogDescription>
-            Enter the URL of the ENSNode service you want to connect to.
+            Enter the URL of the ENSNode you want to connect to.
           </DialogDescription>
         </DialogHeader>
         <form

--- a/apps/ensadmin/src/components/connections/connection-selector.tsx
+++ b/apps/ensadmin/src/components/connections/connection-selector.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils";
 import { ChevronsUpDown, Loader2, Plus, Trash2 } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
+import { toast } from "sonner";
 
 import { ENSAdminIcon } from "@/components/ensadmin-icon";
 import { Button } from "@/components/ui/button";
@@ -54,6 +55,7 @@ export function ConnectionSelector() {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+
   const selectedUrl = selectedEnsNodeUrl(searchParams);
 
   const [newUrl, setNewUrl] = useState("");
@@ -90,6 +92,7 @@ export function ConnectionSelector() {
           setNewUrl("");
           setUrlError(null);
           setDialogOpen(false);
+          toast.success(`You are now connected to ${newUrl}`);
         },
       },
     );

--- a/apps/ensadmin/src/components/nav-main.tsx
+++ b/apps/ensadmin/src/components/nav-main.tsx
@@ -63,7 +63,7 @@ export function NavMain({
 
   return (
     <SidebarGroup>
-      <SidebarGroupLabel>Index</SidebarGroupLabel>
+      <SidebarGroupLabel>Services</SidebarGroupLabel>
       <SidebarMenu>
         {items.map((item) => {
           const hasItems = item.items && item.items.length > 0;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,18 +6,9 @@ settings:
 
 catalogs:
   default:
-    '@astrojs/react':
-      specifier: ^4.2.0
-      version: 4.2.0
-    '@astrojs/tailwind':
-      specifier: ^6.0.0
-      version: 6.0.0
     '@biomejs/biome':
       specifier: ^1.9.4
       version: 1.9.4
-    '@namehash/namekit-react':
-      specifier: 0.12.0
-      version: 0.12.0
     '@ponder/client':
       specifier: ^0.9.27
       version: 0.9.27
@@ -27,33 +18,6 @@ catalogs:
     '@ponder/utils':
       specifier: ^0.2.3
       version: 0.2.3
-    '@types/node':
-      specifier: ^20.10.0
-      version: 20.17.14
-    '@vitest/coverage-v8':
-      specifier: ^3.1.1
-      version: 3.1.1
-    astro-font:
-      specifier: ^1.0.0
-      version: 1.0.0
-    astro-seo:
-      specifier: ^0.8.4
-      version: 0.8.4
-    drizzle-orm:
-      specifier: ^0.39.3
-      version: 0.39.3
-    hono:
-      specifier: ^4.6.14
-      version: 4.6.17
-    ponder:
-      specifier: ^0.9.27
-      version: 0.9.27
-    tsup:
-      specifier: ^8.3.6
-      version: 8.3.6
-    typescript:
-      specifier: ^5.7.3
-      version: 5.7.3
     viem:
       specifier: ^2.22.13
       version: 2.23.2
@@ -183,8 +147,8 @@ importers:
         specifier: ^18
         version: 18.3.1(react@18.3.1)
       sonner:
-        specifier: ^2.0.1
-        version: 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^2.0.3
+        version: 2.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tailwind-merge:
         specifier: ^3.0.2
         version: 3.0.2
@@ -6304,8 +6268,8 @@ packages:
   sonic-boom@3.8.1:
     resolution: {integrity: sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==}
 
-  sonner@2.0.1:
-    resolution: {integrity: sha512-FRBphaehZ5tLdLcQ8g2WOIRE+Y7BCfWi5Zyd8bCvBjiW8TxxAyoWZIxS661Yz6TGPqFQ4VLzOF89WEYhfynSFQ==}
+  sonner@2.0.3:
+    resolution: {integrity: sha512-njQ4Hht92m0sMqqHVDL32V2Oun9W1+PHO9NDv9FHfJjT3JT22IG4Jpo3FPQy+mouRKCXFWO+r67v6MrHX2zeIA==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
       react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
@@ -11824,7 +11788,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.24.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@9.20.1(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.24.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3(eslint-plugin-import@2.31.0)(eslint@9.20.1(jiti@2.4.2)))(eslint@9.20.1(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -11846,7 +11810,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.20.1(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.24.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@9.20.1(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.24.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3(eslint-plugin-import@2.31.0)(eslint@9.20.1(jiti@2.4.2)))(eslint@9.20.1(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -15016,7 +14980,7 @@ snapshots:
     dependencies:
       atomic-sleep: 1.0.0
 
-  sonner@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  sonner@2.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)


### PR DESCRIPTION
Closes #633 

Screenshots for permuations:

![CleanShot 2025-04-23 at 12 21 39@2x](https://github.com/user-attachments/assets/c2fcb27a-ff9d-4c0e-896d-0521b91534be)
![CleanShot 2025-04-23 at 12 25 05@2x](https://github.com/user-attachments/assets/77933bce-79c5-43b5-b2ef-142c00d4f4ed)
![CleanShot 2025-04-23 at 12 26 39@2x](https://github.com/user-attachments/assets/ad19a088-ac1a-4767-b758-a520ce8a7a5c)
![CleanShot 2025-04-23 at 12 26 16@2x](https://github.com/user-attachments/assets/da7fc425-ae34-4327-a749-2611510b0fd8)

The whole row was clickable before, which worked but it wasn't correct since there was a <button> with another <button> inside. This PR updates that to now have the DropdownMenuItem button, and additional delete/copy buttons:

![CleanShot 2025-04-23 at 12 28 45@2x](https://github.com/user-attachments/assets/4ce34d99-84d7-47ae-94f9-b9a4825feba5)

