### PR TITLE
docs(changeset): Ensuring Github Release Notes correctness: NPM links

### DIFF
--- a/.changeset/famous-views-guess.md
+++ b/.changeset/famous-views-guess.md
@@ -1,0 +1,5 @@
+---
+"@ensnode/utils": patch
+---
+
+Ensuring Github Release Notes correctness: NPM links


### PR DESCRIPTION
A PR triggering patch release in order to test the Github Release Notes correctess.