### PR TITLE
fix(ensadmin): include optimism mainnet config

### DIFF
--- a/.changeset/six-crabs-kneel.md
+++ b/.changeset/six-crabs-kneel.md
@@ -1,0 +1,5 @@
+---
+"ensadmin": patch
+---
+
+Enable ENSAdmin to present Optimism Mainnet metadata properly.

--- a/apps/ensadmin/src/lib/chains.ts
+++ b/apps/ensadmin/src/lib/chains.ts
@@ -1,9 +1,10 @@
-import { base, holesky, linea, mainnet, sepolia } from "viem/chains";
+import { base, holesky, linea, mainnet, optimism, sepolia } from "viem/chains";
 
 const chains = {
   [mainnet.id]: mainnet,
   [sepolia.id]: sepolia,
   [holesky.id]: holesky,
+  [optimism.id]: optimism,
   [base.id]: base,
   [linea.id]: linea,
 } as const;


### PR DESCRIPTION
This PR allows ENSAdmin UI to present Optimism Mainnet network name properly.

Please note, there's another PR updating how ENSAdmin reads information about available chains:
- #674 
however, PR 674 has a dependency, so I decided to go ahead with a simple fix, and then enable the proper fix.

### Preview

URL: https://adminensnodeio-git-fix-ensadmin-include-optimis-4a97fc-namehash.vercel.app/status?ensnode=https%3A%2F%2F3dns.dev.ensnode.io

![image](https://github.com/user-attachments/assets/64dd6e67-492e-48cf-8464-17c4cfe5a6f9)
