### PR TITLE
fix: allow rpc endpoints to be undefined at runtime and checked at config gen time

### DIFF
--- a/.changeset/fast-badgers-trade.md
+++ b/.changeset/fast-badgers-trade.md
@@ -1,0 +1,5 @@
+---
+"ensindexer": minor
+---
+
+fix issue where rpc endpoints for all plugins were required at runtime

--- a/apps/ensindexer/src/lib/plugin-helpers.ts
+++ b/apps/ensindexer/src/lib/plugin-helpers.ts
@@ -166,19 +166,16 @@ export const activateHandlers =
 
 /**
  * Defines a ponder#NetworksConfig for a single, specific chain.
- * Implemented as a computed getter to avoid runtime assertions for unused RPC env vars.
  */
 export function networksConfigForChain(chain: Chain) {
   return {
-    get [chain.id.toString()]() {
-      return {
-        chainId: chain.id,
-        transport: http(rpcEndpointUrl(chain.id)),
-        maxRequestsPerSecond: rpcMaxRequestsPerSecond(chain.id),
-        // NOTE: disable cache on 'Anvil' chains
-        ...(chain.name === "Anvil" && { disableCache: true }),
-      } satisfies NetworkConfig;
-    },
+    [chain.id.toString()]: {
+      chainId: chain.id,
+      transport: http(rpcEndpointUrl(chain.id)),
+      maxRequestsPerSecond: rpcMaxRequestsPerSecond(chain.id),
+      // NOTE: disable cache on 'Anvil' chains
+      ...(chain.name === "Anvil" && { disableCache: true }),
+    } satisfies NetworkConfig,
   };
 }
 

--- a/apps/ensindexer/src/lib/ponder-helpers.ts
+++ b/apps/ensindexer/src/lib/ponder-helpers.ts
@@ -74,7 +74,7 @@ const parseBlockheightEnvVar = (envVarName: "START_BLOCK" | "END_BLOCK"): number
  * @param chainId the chain ID to get the RPC URL for
  * @returns the URL of the RPC endpoint
  */
-export const rpcEndpointUrl = (chainId: number): string => {
+export const rpcEndpointUrl = (chainId: number): string | undefined => {
   /**
    * Reads the RPC URL for a given chain ID from the environment variable:
    * RPC_URL_{chainId}. For example, for Ethereum mainnet the chainId is `1`,
@@ -90,12 +90,9 @@ export const rpcEndpointUrl = (chainId: number): string => {
   }
 };
 
-export const parseRpcEndpointUrl = (rawValue?: string): string => {
-  // no RPC URL provided
-  if (!rawValue) {
-    // throw an error, as the RPC URL is required and no defaults apply
-    throw new Error(`Expected value not set`);
-  }
+export const parseRpcEndpointUrl = (rawValue?: string): string | undefined => {
+  // no RPC URL provided, default to undefined
+  if (!rawValue) return undefined;
 
   try {
     return new URL(rawValue).toString();

--- a/apps/ensindexer/test/ponder-helpers.test.ts
+++ b/apps/ensindexer/test/ponder-helpers.test.ts
@@ -110,11 +110,11 @@ describe("ponder helpers", () => {
     });
 
     it("should throw an error if the URL is invalid", () => {
-      expect(() => parseRpcEndpointUrl("invalid")).toThrowError("'invalid' is not a valid URL");
+      expect(() => parseRpcEndpointUrl("invalid")).toThrowError(/is not a valid URL/);
     });
 
-    it("should throw an error if the URL is missing", () => {
-      expect(() => parseRpcEndpointUrl()).toThrowError("Expected value not set");
+    it("should return undefined if the URL is missing", () => {
+      expect(parseRpcEndpointUrl()).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
panics if there are no custom rpc endpoints defined for the networks that the config ends up using and provides verbose error message