### PR TITLE
fix(ensadmin): allow displaying networks that have not yet been indexed

### DIFF
--- a/.changeset/brown-terms-search.md
+++ b/.changeset/brown-terms-search.md
@@ -1,0 +1,5 @@
+---
+"ensadmin": patch
+---
+
+Allow displaying indexing status for chains pending indexing.

--- a/apps/ensadmin/src/components/ensnode/hooks.ts
+++ b/apps/ensadmin/src/components/ensnode/hooks.ts
@@ -78,18 +78,6 @@ function validateResponse(response: EnsNode.Metadata) {
         .join(", ")}`,
     );
   }
-
-  const networksWithoutLastIndexedBlock = Object.entries(networkIndexingStatusByChainId).filter(
-    ([, network]) => network.lastIndexedBlock === null,
-  );
-
-  if (networksWithoutLastIndexedBlock.length > 0) {
-    throw new Error(
-      `Missing last indexed block for some networks with the following chain IDs: ${networksWithoutLastIndexedBlock
-        .map(([chainId]) => chainId)
-        .join(", ")}`,
-    );
-  }
 }
 
 /**

--- a/apps/ensadmin/src/components/indexing-status/components.tsx
+++ b/apps/ensadmin/src/components/indexing-status/components.tsx
@@ -365,15 +365,19 @@ export function IndexingTimeline({
   currentIndexingDate,
   indexingStartsAt,
 }: TimelineProps) {
-  if (!currentIndexingDate) {
-    return <IndexingTimelineFallback />;
-  }
-
   // Timeline boundaries
   const timelineStart = indexingStartsAt;
   const timelineEnd = new Date();
 
   const yearMarkers = generateYearMarkers(timelineStart, timelineEnd);
+  const timelinePositionValue = currentIndexingDate
+    ? getTimelinePosition(currentIndexingDate, timelineStart, timelineEnd)
+    : 0;
+
+  const timelinePosition =
+    timelinePositionValue > 0 && timelinePositionValue < 100
+      ? timelinePositionValue.toFixed(4)
+      : timelinePositionValue;
 
   return (
     <Card className="w-full">
@@ -383,7 +387,8 @@ export function IndexingTimeline({
           <div className="flex items-center gap-1.5">
             <Clock size={16} className="text-blue-600" />
             <span className="text-sm font-medium">
-              Last indexed block on {intlFormat(currentIndexingDate)}
+              Last indexed block on{" "}
+              {currentIndexingDate ? intlFormat(currentIndexingDate) : "pending"}
             </span>
           </div>
         </CardTitle>
@@ -414,7 +419,7 @@ export function IndexingTimeline({
             <div
               className="absolute h-full w-0.5 bg-green-800 z-20"
               style={{
-                left: `${getTimelinePosition(currentIndexingDate, timelineStart, timelineEnd)}%`,
+                left: `${timelinePosition}%`,
                 top: "0",
                 bottom: "0",
                 height: `${networkStatuses.length * 60}px`,
@@ -422,13 +427,7 @@ export function IndexingTimeline({
             >
               <div className="absolute -bottom-8 -translate-x-1/2 whitespace-nowrap">
                 <Badge className="text-xs bg-green-800 text-white flex flex-col">
-                  <span>Processing data</span>{" "}
-                  <span>
-                    {getTimelinePosition(currentIndexingDate, timelineStart, timelineEnd).toFixed(
-                      4,
-                    )}
-                    %
-                  </span>
+                  <span>Processing data</span> <span>{timelinePosition}%</span>
                 </Badge>
               </div>
             </div>
@@ -469,7 +468,7 @@ export function IndexingTimeline({
 }
 
 interface NetworkIndexingStatusProps {
-  currentIndexingDate: Date;
+  currentIndexingDate: Date | null;
   timelineStart: Date;
   timelineEnd: Date;
   networkStatus: NetworkStatusViewModel;

--- a/apps/ensadmin/src/components/indexing-status/utils.ts
+++ b/apps/ensadmin/src/components/indexing-status/utils.ts
@@ -56,9 +56,14 @@ export function generateYearMarkers(timelineStart: Date, timelineEnd: Date): Arr
  * @param networkStatus view model
  */
 export function currentPhase(
-  date: Date,
+  date: Date | null,
   networkStatus: NetworkStatusViewModel,
 ): NetworkIndexingPhaseViewModel {
+  // if the network is not indexed yet, return the first phase
+  if (!date) {
+    return networkStatus.phases[0];
+  }
+
   for (let i = networkStatus.phases.length - 1; i >= 0; i--) {
     if (date >= networkStatus.phases[i].startDate) {
       return networkStatus.phases[i];

--- a/apps/ensadmin/src/components/indexing-status/view-models.ts
+++ b/apps/ensadmin/src/components/indexing-status/view-models.ts
@@ -66,17 +66,22 @@ export function globalIndexingStatusViewModel(
       ),
   ) satisfies Array<NetworkStatusViewModel>;
 
-  const currentIndexingDate = Math.max(
-    // get the last indexed block date for each network for which it is available
-    ...networkStatusesViewModel
-      .filter((n) => Boolean(n.lastIndexedBlock))
-      .map((n) => n.lastIndexedBlock!.timestamp),
+  // Sort the network statuses by the first block to index timestamp
+  networkStatusesViewModel.sort(
+    (a, b) => a.firstBlockToIndex.timestamp - b.firstBlockToIndex.timestamp,
   );
+
+  const lastIndexedBlockDates = networkStatusesViewModel
+    .filter((n) => Boolean(n.lastIndexedBlock))
+    .map((n) => n.lastIndexedBlock!.timestamp);
+
+  const currentIndexingDate =
+    lastIndexedBlockDates.length > 0 ? fromUnixTime(Math.max(...lastIndexedBlockDates)) : null;
 
   return {
     networkStatuses: networkStatusesViewModel,
-    currentIndexingDate: fromUnixTime(currentIndexingDate),
     indexingStartsAt: fromUnixTime(firstBlockToIndexGloballyTimestamp),
+    currentIndexingDate,
   };
 }
 


### PR DESCRIPTION
This PR allows ENSAdmin to display indexing status for chains that have not yet been indexed.

### Before

![image](https://github.com/user-attachments/assets/eb1df8e3-0656-48ba-a4f0-787c906d4376)

### After

Resolves #468