### PR TITLE
ci: add healthcheck script for checking ensindexer properly starts or…

### DIFF
--- a/.github/scripts/run_ensindexer_healthcheck.sh
+++ b/.github/scripts/run_ensindexer_healthcheck.sh
@@ -29,17 +29,6 @@ echo "Starting Ponder in the background from $(pwd)..."
 LOG_FILE=$(mktemp)
 echo "Logging output to $LOG_FILE"
 
-# Create a temporary .env.local file for Ponder
-ENV_FILE="$ENSINDEXER_DIR/.env.local"
-echo "Creating temporary .env.local file at $ENV_FILE"
-cat > "$ENV_FILE" << EOL
-PORT=42069
-# Add any other environment variables needed here
-EOL
-
-# Ensure the original script still has access to these variables
-export PORT=42069
-
 # Run the Ponder dev command in background and redirect output to log file
 pnpm dev --disable-ui -vv > "$LOG_FILE" 2>&1 &
 PID=$!

--- a/.github/scripts/run_ensindexer_healthcheck.sh
+++ b/.github/scripts/run_ensindexer_healthcheck.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+# Simple script to verify Ponder starts up correctly
+# This script is used in CI and can be run locally
+
+# Set default timeout if not provided by environment
+: "${HEALTH_CHECK_TIMEOUT:=60}"  # Use env var if set, otherwise default to 60
+
+# Detect if running from CI or local
+if [ -n "$GITHUB_WORKSPACE" ]; then
+  # Running in GitHub Actions
+  ENSINDEXER_DIR="$GITHUB_WORKSPACE/apps/ensindexer"
+else
+  # Running locally - determine path relative to script location
+  SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+  REPO_ROOT="$( cd "$SCRIPT_DIR/../.." && pwd )"  # Adjusted for .github/scripts path
+  ENSINDEXER_DIR="$REPO_ROOT/apps/ensindexer"
+fi
+
+# Navigate to the ensindexer directory
+cd "$ENSINDEXER_DIR" || {
+  echo "Error: Could not navigate to $ENSINDEXER_DIR"
+  exit 1
+}
+
+echo "Starting Ponder in the background from $(pwd)..."
+
+# Create a temporary log file
+LOG_FILE=$(mktemp)
+echo "Logging output to $LOG_FILE"
+
+# # Create a temporary .env.local file for Ponder
+# ENV_FILE="$ENSINDEXER_DIR/.env.local"
+# echo "Creating temporary .env.local file at $ENV_FILE"
+# cat > "$ENV_FILE" << EOL
+# PORT=42069
+# # Add any other environment variables needed here
+# EOL
+
+# # Ensure the original script still has access to these variables
+# export PORT=42069
+
+# Run the Ponder dev command in background and redirect output to log file
+pnpm dev --disable-ui -vv > "$LOG_FILE" 2>&1 &
+PID=$!
+
+echo "Ponder started with PID: $PID"
+
+# Wait for health check to pass
+echo "Waiting for health check to pass (up to $HEALTH_CHECK_TIMEOUT seconds)..."
+health_check_start=$(date +%s)
+last_log_check=0
+
+while true; do
+  current_time=$(date +%s)
+
+  # Periodically show log progress (every 15 seconds) to prevent CI timeout
+  if [ $((current_time - last_log_check)) -ge 15 ]; then
+    echo "Still waiting for health check at $(date) (elapsed: $((current_time - health_check_start)) seconds)..."
+    echo "Recent log entries:"
+    tail -n 10 "$LOG_FILE"
+    last_log_check=$current_time
+  fi
+
+  # Check if the process is still running
+  if ! ps -p $PID > /dev/null; then
+    echo "Ponder process exited before health check passed"
+    wait $PID
+    EXIT_CODE=$?
+    echo "Exit code: $EXIT_CODE"
+    echo "Last 30 lines of log:"
+    tail -n 30 "$LOG_FILE"
+    rm -f "$LOG_FILE"
+    # Clean up env file
+    [ -f "$ENV_FILE" ] && rm -f "$ENV_FILE"
+    exit 1
+  fi
+
+  # Check for health ready message
+  if grep -q "Started returning 200 responses from /health endpoint" "$LOG_FILE"; then
+    echo "Health check passed! Ponder is up and running."
+    echo "Test successful - terminating Ponder"
+    # Force kill the Ponder process
+    kill -9 $PID 2>/dev/null || true
+    # Make sure we don't wait for the process to exit since we've force killed it
+    wait $PID 2>/dev/null || true
+    # Clean up the log file and env file
+    rm -f "$LOG_FILE"
+    [ -f "$ENV_FILE" ] && rm -f "$ENV_FILE"
+    # Explicitly exit with success code
+    echo "Exiting with success code 0"
+    exit 0
+  fi
+
+  # Check if we've reached the health check timeout
+  elapsed=$((current_time - health_check_start))
+
+  if [ $elapsed -ge $HEALTH_CHECK_TIMEOUT ]; then
+    echo "Health check timeout reached. Ponder did not become healthy."
+    kill -9 $PID 2>/dev/null || true
+    wait $PID 2>/dev/null || true
+    echo "Last 30 lines of log:"
+    tail -n 30 "$LOG_FILE"
+    rm -f "$LOG_FILE"
+    # Clean up env file
+    [ -f "$ENV_FILE" ] && rm -f "$ENV_FILE"
+    exit 1
+  fi
+
+  # Wait a bit before checking again
+  sleep 2
+done

--- a/.github/scripts/run_ensindexer_healthcheck.sh
+++ b/.github/scripts/run_ensindexer_healthcheck.sh
@@ -29,16 +29,16 @@ echo "Starting Ponder in the background from $(pwd)..."
 LOG_FILE=$(mktemp)
 echo "Logging output to $LOG_FILE"
 
-# # Create a temporary .env.local file for Ponder
-# ENV_FILE="$ENSINDEXER_DIR/.env.local"
-# echo "Creating temporary .env.local file at $ENV_FILE"
-# cat > "$ENV_FILE" << EOL
-# PORT=42069
-# # Add any other environment variables needed here
-# EOL
+# Create a temporary .env.local file for Ponder
+ENV_FILE="$ENSINDEXER_DIR/.env.local"
+echo "Creating temporary .env.local file at $ENV_FILE"
+cat > "$ENV_FILE" << EOL
+PORT=42069
+# Add any other environment variables needed here
+EOL
 
-# # Ensure the original script still has access to these variables
-# export PORT=42069
+# Ensure the original script still has access to these variables
+export PORT=42069
 
 # Run the Ponder dev command in background and redirect output to log file
 pnpm dev --disable-ui -vv > "$LOG_FILE" 2>&1 &

--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -53,17 +53,21 @@ jobs:
         if: needs.changed-packages.outputs.packages == 'true'
         run: pnpm packages:prepublish
 
-      # This will run the dev command in background, wait for
-      # RUNTIME_CHECK_TIMEOUT_SECONDS seconds, and then kill the process if it
-      # is still running. If the command does not throw an error within that
-      # time, the step will exit successfully. If it does throw an error,
-      # the step will exit and fail the CI pipeline. This runtime check uses
-      # a pglite database that only lives in the CI environment.
-      # It will be discarded after the CI run.
-      - name: Run Ponder runtime integrity checks
+      # This will run the dev command in background, and wait up to
+      # HEALTH_CHECK_TIMEOUT seconds. It will monitor the log output to
+      # ensure the app healthcheck is live. If the command does not
+      # print the log with the healthcheck message within that time, the step
+      # will exit with a failure.
+      # This runtime check uses a pglite database that only lives in the CI
+      # environment. It will be discarded after the CI run. The app will not
+      # check anything beyond the healthcheck as its job is to ensure the app
+      # starts successfully only. With the configured RPCs there is likely to
+      # be rate limits hit but we do not care for those.
+      - name: Run ENSIndexer runtime integrity checks
         env:
-          ACTIVE_PLUGINS: subgraph,basenames,lineanames
+          ACTIVE_PLUGINS: subgraph,basenames,lineanames,threedns
           RPC_URL_1: https://eth.drpc.org
+          RPC_URL_10: https://optimism.drpc.org
           RPC_URL_8453: https://base.drpc.org
           RPC_URL_59144: https://linea.drpc.org
           HEALTH_CHECK_TIMEOUT: 60

--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -61,25 +61,15 @@ jobs:
       # a pglite database that only lives in the CI environment.
       # It will be discarded after the CI run.
       - name: Run Ponder runtime integrity checks
-        working-directory: apps/ensindexer
         env:
           ACTIVE_PLUGINS: subgraph,basenames,lineanames
           RPC_URL_1: https://eth.drpc.org
           RPC_URL_8453: https://base.drpc.org
           RPC_URL_59144: https://linea.drpc.org
-          RUNTIME_CHECK_TIMEOUT_SECONDS: 10
+          HEALTH_CHECK_TIMEOUT: 60
         run: |
-          pnpm dev --disable-ui -vv &
-          PID=$!
-          sleep $RUNTIME_CHECK_TIMEOUT_SECONDS
-          if ps -p $PID > /dev/null; then
-            kill $PID
-            wait $PID || true
-            exit 0
-          else
-            wait $PID
-            exit $?
-          fi
+          chmod +x ./.github/scripts/run_ensindexer_healthcheck.sh
+          ./.github/scripts/run_ensindexer_healthcheck.sh
 
   unit-tests:
     runs-on: blacksmith-4vcpu-ubuntu-2204


### PR DESCRIPTION
… terminate with a failure

Resolves: https://github.com/namehash/ensnode/issues/695

The root cause of this is `pnpm dev` which runs the ponder `dev` command doesn’t exit if there’s issues it just hangs and waits for changes to hot reload. So the timeout was hitting and then it was passing. I think what we were trying to check here is the app starts with no issues so I’ve done this in a slightly different way. We now check for the app healthcheck to return a 200 meaning the app is up and running - the ci will then pass. If we don’t hit the healthcheck within the timeout then something is up. The goal here is to check the app boots and nothing more. We are not checking for errors beyond app start. I actually did a lot of tests locally and in ci and sometimes we do get errors because we’re using public rpcs and requests fail due to rate limits.

So you can see in the commits of this PR the 2 cases - pass and fail. First and last commit are the current ci which is failing as no port is configured and the current codebase requires it. The middle commit is when I hardcoded the port in the script, it passes. So the CI failing right now is actually the correct state of things.