### PR TITLE
fix: include ensrainbow building in manual build workflow

### DIFF
--- a/.github/workflows/build_ensnode.yml
+++ b/.github/workflows/build_ensnode.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        app: [ensindexer, ensadmin]
+        app: [ensindexer, ensadmin, ensrainbow]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
closes https://github.com/namehash/ensnode/issues/646