### PR TITLE
feat: chain-scope resolver ids for non-subgraph plugins

### DIFF
--- a/.changeset/blue-kings-flash.md
+++ b/.changeset/blue-kings-flash.md
@@ -1,0 +1,5 @@
+---
+"ensindexer": minor
+---
+
+Resolver ids are now chain-scoped for non-subgraph plugins to avoid collisions between resolver contracts with the same address on multiple chains

--- a/apps/ensindexer/src/handlers/Registry.ts
+++ b/apps/ensindexer/src/handlers/Registry.ts
@@ -186,7 +186,7 @@ export const makeRegistryHandlers = ({ pluginName }: { pluginName: PluginName })
     }) {
       const { node, resolver: resolverAddress } = event.args;
 
-      const resolverId = makeResolverId(resolverAddress, node);
+      const resolverId = makeResolverId(pluginName, context.network.chainId, resolverAddress, node);
 
       const isZeroResolver = resolverAddress === zeroAddress;
 

--- a/apps/ensindexer/src/handlers/Resolver.ts
+++ b/apps/ensindexer/src/handlers/Resolver.ts
@@ -32,7 +32,7 @@ export const makeResolverHandlers = ({ pluginName }: { pluginName: PluginName })
       const { a: address, node } = event.args;
       await upsertAccount(context, address);
 
-      const id = makeResolverId(event.log.address, node);
+      const id = makeResolverId(pluginName, context.network.chainId, event.log.address, node);
       await upsertResolver(context, {
         id,
         domainId: node,
@@ -63,7 +63,7 @@ export const makeResolverHandlers = ({ pluginName }: { pluginName: PluginName })
     }) {
       const { node, coinType, newAddress } = event.args;
 
-      const id = makeResolverId(event.log.address, node);
+      const id = makeResolverId(pluginName, context.network.chainId, event.log.address, node);
       const resolver = await upsertResolver(context, {
         id,
         domainId: node,
@@ -94,7 +94,7 @@ export const makeResolverHandlers = ({ pluginName }: { pluginName: PluginName })
       const { node, name } = event.args;
       if (hasNullByte(name)) return;
 
-      const id = makeResolverId(event.log.address, node);
+      const id = makeResolverId(pluginName, context.network.chainId, event.log.address, node);
       await upsertResolver(context, {
         id,
         domainId: node,
@@ -117,7 +117,7 @@ export const makeResolverHandlers = ({ pluginName }: { pluginName: PluginName })
       event: EventWithArgs<{ node: Node; contentType: bigint }>;
     }) {
       const { node, contentType } = event.args;
-      const id = makeResolverId(event.log.address, node);
+      const id = makeResolverId(pluginName, context.network.chainId, event.log.address, node);
 
       // upsert resolver
       await upsertResolver(context, {
@@ -142,7 +142,7 @@ export const makeResolverHandlers = ({ pluginName }: { pluginName: PluginName })
       event: EventWithArgs<{ node: Node; x: Hex; y: Hex }>;
     }) {
       const { node, x, y } = event.args;
-      const id = makeResolverId(event.log.address, node);
+      const id = makeResolverId(pluginName, context.network.chainId, event.log.address, node);
 
       // upsert resolver
       await upsertResolver(context, {
@@ -173,7 +173,7 @@ export const makeResolverHandlers = ({ pluginName }: { pluginName: PluginName })
       }>;
     }) {
       const { node, key, value } = event.args;
-      const id = makeResolverId(event.log.address, node);
+      const id = makeResolverId(pluginName, context.network.chainId, event.log.address, node);
       const resolver = await upsertResolver(context, {
         id,
         domainId: node,
@@ -206,7 +206,7 @@ export const makeResolverHandlers = ({ pluginName }: { pluginName: PluginName })
       event: EventWithArgs<{ node: Node; hash: Hash }>;
     }) {
       const { node, hash } = event.args;
-      const id = makeResolverId(event.log.address, node);
+      const id = makeResolverId(pluginName, context.network.chainId, event.log.address, node);
       await upsertResolver(context, {
         id,
         domainId: node,
@@ -230,7 +230,7 @@ export const makeResolverHandlers = ({ pluginName }: { pluginName: PluginName })
       event: EventWithArgs<{ node: Node; interfaceID: Hex; implementer: Hex }>;
     }) {
       const { node, interfaceID, implementer } = event.args;
-      const id = makeResolverId(event.log.address, node);
+      const id = makeResolverId(pluginName, context.network.chainId, event.log.address, node);
       await upsertResolver(context, {
         id,
         domainId: node,
@@ -259,7 +259,7 @@ export const makeResolverHandlers = ({ pluginName }: { pluginName: PluginName })
       }>;
     }) {
       const { node, owner, target, isAuthorised } = event.args;
-      const id = makeResolverId(event.log.address, node);
+      const id = makeResolverId(pluginName, context.network.chainId, event.log.address, node);
 
       await upsertResolver(context, {
         id,
@@ -286,7 +286,7 @@ export const makeResolverHandlers = ({ pluginName }: { pluginName: PluginName })
       event: EventWithArgs<{ node: Node; newVersion: bigint }>;
     }) {
       const { node, newVersion } = event.args;
-      const id = makeResolverId(event.log.address, node);
+      const id = makeResolverId(pluginName, context.network.chainId, event.log.address, node);
 
       // materialize the Domain's resolvedAddress field iff exists and is set to this Resolver
       const domain = await context.db.find(schema.domain, { id: node });

--- a/apps/ensindexer/src/handlers/ThreeDNSToken.ts
+++ b/apps/ensindexer/src/handlers/ThreeDNSToken.ts
@@ -82,6 +82,8 @@ export const makeThreeDNSTokenHandlers = ({ pluginName }: { pluginName: PluginNa
         // in ThreeDNS there's a hard-coded Resolver that all domains use, so we link them together
         // during creation
         const resolverId = makeResolverId(
+          pluginName,
+          context.network.chainId,
           // not sure why inferred type is Address | undefined, but we know this exists
           context.contracts["threedns/ThreeDNSResolver"].address!,
           node,

--- a/apps/ensindexer/src/lib/ids.ts
+++ b/apps/ensindexer/src/lib/ids.ts
@@ -1,9 +1,35 @@
 import { type LabelHash, type Node, PluginName } from "@ensnode/utils";
 import type { Address } from "viem";
 
-// NOTE: subgraph uses lowercase address here, viem provides us checksummed, so we lowercase it
-export const makeResolverId = (address: Address, node: Node) =>
-  [address.toLowerCase(), node].join("-");
+/**
+ * Makes a unique, chain-scoped resolver ID.
+ * For Subgraph plugin events, no chainId prefix is used (subgraph-compat).
+ *
+ * @example Subgraph plugin: `${address}-${node}`
+ * @example All other plugins (chain-scoped): `${chainId}-${address}-${node}`
+ *
+ * @param pluginName the plugin name
+ * @param chainId the chain ID
+ * @param address the resolver contract address
+ * @param node the ENS node
+ * @returns a unique resolver ID
+ */
+
+export const makeResolverId = (
+  pluginName: PluginName,
+  chainId: number,
+  address: Address,
+  node: Node,
+) =>
+  [
+    // null out chainId prefix iff subgraph plugin, otherwise include for chain-scoping
+    pluginName === PluginName.Subgraph ? null : chainId,
+    // NOTE: subgraph uses lowercase address here, viem provides us checksummed, so we lowercase it
+    address.toLowerCase(),
+    node,
+  ]
+    .filter(Boolean)
+    .join("-");
 
 /**
  * Makes a unique, chain-scoped event ID.

--- a/apps/ensindexer/test/ids.test.ts
+++ b/apps/ensindexer/test/ids.test.ts
@@ -8,10 +8,26 @@ const OTHER_PLUGIN_NAME = "other" as PluginName;
 
 describe("ids", () => {
   describe("makeResolverId", () => {
-    it("should match snapshot", () => {
-      expect(makeResolverId(zeroAddress, namehash("vitalik.eth"))).toEqual(
+    it("should construct subgraph-compatible resolver id", () => {
+      expect(
+        makeResolverId(PluginName.Subgraph, CHAIN_ID, zeroAddress, namehash("vitalik.eth")),
+      ).toEqual(
         "0x0000000000000000000000000000000000000000-0xee6c4522aab0003e8d14cd40a6af439055fd2577951148c14b6cea9a53475835",
       );
+    });
+
+    it("should construct chain-scoped resolver id", () => {
+      expect(
+        makeResolverId(OTHER_PLUGIN_NAME, CHAIN_ID, zeroAddress, namehash("vitalik.eth")),
+      ).toEqual(
+        "1337-0x0000000000000000000000000000000000000000-0xee6c4522aab0003e8d14cd40a6af439055fd2577951148c14b6cea9a53475835",
+      );
+    });
+
+    it("should lowercase address", () => {
+      expect(
+        makeResolverId(PluginName.Subgraph, CHAIN_ID, "0xCAFE", namehash("vitalik.eth")),
+      ).toEqual("0xcafe-0xee6c4522aab0003e8d14cd40a6af439055fd2577951148c14b6cea9a53475835");
     });
   });
 


### PR DESCRIPTION
closes https://github.com/namehash/ensnode/issues/682