### PR TITLE
fix: strip null bytes from text changed events

### DIFF
--- a/.changeset/little-cycles-deny.md
+++ b/.changeset/little-cycles-deny.md
@@ -1,0 +1,5 @@
+---
+"ensindexer": minor
+---
+
+now explicitly strips null bytes from resolver text values rather than relying on ponder's default behavior

--- a/apps/ensindexer/src/lib/lib-helpers.ts
+++ b/apps/ensindexer/src/lib/lib-helpers.ts
@@ -1,5 +1,7 @@
 export const uniq = <T>(arr: T[]): T[] => [...new Set(arr)];
 
+export const bigintMax = (...args: bigint[]): bigint => args.reduce((a, b) => (a > b ? a : b));
+
 export const hasNullByte = (value: string) => value.indexOf("\u0000") !== -1;
 
-export const bigintMax = (...args: bigint[]): bigint => args.reduce((a, b) => (a > b ? a : b));
+export const stripNullBytes = (value: string) => value.replaceAll("\u0000", "");

--- a/apps/ensindexer/test/lib-helpers.test.ts
+++ b/apps/ensindexer/test/lib-helpers.test.ts
@@ -1,10 +1,16 @@
-import { bigintMax, hasNullByte, uniq } from "@/lib/lib-helpers";
+import { bigintMax, hasNullByte, stripNullBytes, uniq } from "@/lib/lib-helpers";
 import { describe, expect, it } from "vitest";
 
 describe("helpers", () => {
   describe("uniq", () => {
     it("should return unique elements from an array", () => {
       expect(uniq([1, 2, 2, 3, 4, 4])).toEqual([1, 2, 3, 4]);
+    });
+  });
+
+  describe("bigintMax", () => {
+    it("should return the maximum bigint value", () => {
+      expect(bigintMax(1n, 2n, 3n)).toBe(3n);
     });
   });
 
@@ -18,9 +24,11 @@ describe("helpers", () => {
     });
   });
 
-  describe("bigintMax", () => {
-    it("should return the maximum bigint value", () => {
-      expect(bigintMax(1n, 2n, 3n)).toBe(3n);
+  describe("stripNullBytes", () => {
+    it("should remove null bytes", () => {
+      expect(stripNullBytes("hello\u0000world")).toBe("helloworld");
+      expect(stripNullBytes("\0")).toBe("");
+      expect(stripNullBytes("x\0y\0z\0")).toBe("xyz");
     });
   });
 });


### PR DESCRIPTION
closes https://github.com/namehash/ensnode/issues/718