### PR TITLE
fix: move dnsPacketBytes to dns-helpers and document

### DIFF
--- a/apps/ensindexer/src/handlers/NameWrapper.ts
+++ b/apps/ensindexer/src/handlers/NameWrapper.ts
@@ -1,11 +1,12 @@
 import { type Context } from "ponder:registry";
 import schema from "ponder:schema";
 import { checkPccBurned } from "@ensdomains/ensjs/utils";
-import { type Node, PluginName } from "@ensnode/utils";
-import { decodeDNSPacketBytes, uint256ToHex32 } from "@ensnode/utils/subname-helpers";
 import { type Address, type Hex, hexToBytes, namehash } from "viem";
 
+import { type Node, PluginName, uint256ToHex32 } from "@ensnode/utils";
+
 import { makeSharedEventValues, upsertAccount } from "@/lib/db-helpers";
+import { decodeDNSPacketBytes } from "@/lib/dns-helpers";
 import { makeEventId } from "@/lib/ids";
 import { bigintMax } from "@/lib/lib-helpers";
 import { EventWithArgs } from "@/lib/ponder-helpers";

--- a/apps/ensindexer/src/handlers/Registrar.ts
+++ b/apps/ensindexer/src/handlers/Registrar.ts
@@ -2,13 +2,19 @@ import { type Context } from "ponder:registry";
 import schema from "ponder:schema";
 import { type Address, namehash } from "viem";
 
+import {
+  type Label,
+  type LabelHash,
+  PluginName,
+  isLabelIndexable,
+  makeSubdomainNode,
+} from "@ensnode/utils";
+
 import { makeSharedEventValues, upsertAccount, upsertRegistration } from "@/lib/db-helpers";
 import { labelByLabelHash } from "@/lib/graphnode-helpers";
 import { makeRegistrationId } from "@/lib/ids";
 import type { EventWithArgs } from "@/lib/ponder-helpers";
 import type { RegistrarManagedName } from "@/lib/types";
-import { Label, type LabelHash, PluginName } from "@ensnode/utils";
-import { isLabelIndexable, makeSubdomainNode } from "@ensnode/utils/subname-helpers";
 
 const GRACE_PERIOD_SECONDS = 7776000n; // 90 days in seconds
 

--- a/apps/ensindexer/src/handlers/Registry.ts
+++ b/apps/ensindexer/src/handlers/Registry.ts
@@ -3,17 +3,21 @@ import schema from "ponder:schema";
 import { encodeLabelhash } from "@ensdomains/ensjs/utils";
 import { type Address, zeroAddress } from "viem";
 
+import {
+  type LabelHash,
+  type Node,
+  PluginName,
+  REVERSE_ROOT_NODES,
+  isLabelIndexable,
+  makeSubdomainNode,
+  maybeHealLabelByReverseAddress,
+} from "@ensnode/utils";
+
 import { makeSharedEventValues, upsertAccount, upsertResolver } from "@/lib/db-helpers";
 import { labelByLabelHash } from "@/lib/graphnode-helpers";
 import { makeResolverId } from "@/lib/ids";
 import { type EventWithArgs, healReverseAddresses } from "@/lib/ponder-helpers";
 import { recursivelyRemoveEmptyDomainFromParentSubdomainCount } from "@/lib/subgraph-helpers";
-import { type LabelHash, type Node, PluginName, REVERSE_ROOT_NODES } from "@ensnode/utils";
-import {
-  isLabelIndexable,
-  makeSubdomainNode,
-  maybeHealLabelByReverseAddress,
-} from "@ensnode/utils/subname-helpers";
 
 /**
  * makes a set of shared handlers for a Registry contract

--- a/apps/ensindexer/src/handlers/Resolver.ts
+++ b/apps/ensindexer/src/handlers/Resolver.ts
@@ -4,11 +4,10 @@ import { Node, PluginName } from "@ensnode/utils";
 import { type Address, Hash, type Hex, hexToBytes } from "viem";
 
 import { makeSharedEventValues, upsertAccount, upsertResolver } from "@/lib/db-helpers";
-import { decodeTXTData, parseRRSet } from "@/lib/dns-helpers";
+import { decodeDNSPacketBytes, decodeTXTData, parseRRSet } from "@/lib/dns-helpers";
 import { makeResolverId } from "@/lib/ids";
 import { hasNullByte, uniq } from "@/lib/lib-helpers";
 import type { EventWithArgs } from "@/lib/ponder-helpers";
-import { decodeDNSPacketBytes } from "@ensnode/utils/subname-helpers";
 
 /**
  * makes a set of shared handlers for Resolver contracts

--- a/apps/ensindexer/src/handlers/ThreeDNSToken.ts
+++ b/apps/ensindexer/src/handlers/ThreeDNSToken.ts
@@ -1,14 +1,15 @@
 import { Context } from "ponder:registry";
 import schema from "ponder:schema";
-
 import { encodeLabelhash } from "@ensdomains/ensjs/utils";
-import { LabelHash, Node, PluginName } from "@ensnode/utils";
+import { Address, Hex, hexToBigInt, hexToBytes, labelhash, zeroAddress, zeroHash } from "viem";
+
 import {
-  decodeDNSPacketBytes,
+  type LabelHash,
+  type Node,
+  PluginName,
   isLabelIndexable,
   makeSubdomainNode,
-} from "@ensnode/utils/subname-helpers";
-import { Address, Hex, hexToBigInt, hexToBytes, labelhash, zeroAddress, zeroHash } from "viem";
+} from "@ensnode/utils";
 
 import {
   makeSharedEventValues,
@@ -17,6 +18,7 @@ import {
   upsertRegistration,
   upsertResolver,
 } from "@/lib/db-helpers";
+import { decodeDNSPacketBytes } from "@/lib/dns-helpers";
 import { labelByLabelHash } from "@/lib/graphnode-helpers";
 import { makeRegistrationId, makeResolverId } from "@/lib/ids";
 import { parseLabelAndNameFromOnChainMetadata } from "@/lib/plugin-helpers";

--- a/apps/ensindexer/src/lib/dns-helpers.ts
+++ b/apps/ensindexer/src/lib/dns-helpers.ts
@@ -1,5 +1,110 @@
 import dnsPacket, { Answer } from "dns-packet";
-import { Hex } from "viem";
+import { Hex, bytesToHex, bytesToString, stringToBytes } from "viem";
+
+import { type Label, type Name, isLabelIndexable } from "@ensnode/utils";
+
+/**
+ * Given a Buffer representing a DNS Packet that encodes a domain name, decodes the domain name into
+ * [Label, Name] where the first return parameter is the first Label in the Name, and the second is
+ * the full domain name. If decoding fails, [null, null] is returned.
+ *
+ * ex: if the input DNS Packet represents `example.eth`, the output will be ['example', 'example.eth']
+ *
+ * ---
+ *
+ * DNS Packet Format for Domain Names:
+ * - Domain names are encoded as a sequence of labels
+ * - Each label begins with a length byte (1 byte) indicating how many bytes follow for that label
+ * - The bytes after the length byte represent the characters in the label
+ * - Labels are concatenated with no separators
+ * - The sequence ends with a zero-length byte (0x00)
+ *
+ * Example: "example.eth" is encoded as:
+ * [0x07, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 0x03, 'e', 't', 'h', 0x00]
+ * Where 0x07 is the length of "example", 0x03 is the length of "eth", and 0x00 marks the end
+ *
+ * The decoding process:
+ * 1. Read the length byte
+ * 2. Extract the label using that length
+ * 3. Append a dot if not the first label
+ * 4. Repeat until a zero-length byte is encountered
+ *
+ * ---
+ *
+ * NOTE: there seems to be a bug in ensjs#bytesToPacket, which we were originally using for this
+ * implementation, regarding malformed names.
+ *
+ * For example, in this tx `0x4ece50ae828f2a0f27f45d086e85a55e6284bff31a0a89daca9df4b1b1f5cb75` the
+ * `name` input is `8436.eth` (it should have been just `8436`, as the `.eth` is inferred).
+ *
+ * This operates against a name that actually looks like `[fb1d24d5dc41613d5b4874e6cccb06ecf442f6f1773c3771c4fcce1161985a18].eth`
+ * which results in a namehash of `0xfb1d24d5dc41613d5b4874e6cccb06ecf442f6f1773c3771c4fcce1161985a18`
+ * and the NameWrapper emits an event with the packet bytes of `08383433362E6574680365746800`.
+ * when ensjs#bytesToPacket sees these bytes, it returns a name of `8436.eth.eth`, which is incorrect.
+ *
+ * The original subgraph logic handled this case correctly, it seems, and so we re-implement it here.
+ * https://github.com/ensdomains/ens-subgraph/blob/c844791/src/nameWrapper.ts#L30
+ *
+ * More information about this discussion can be found in this thread:
+ * https://github.com/namehash/ensnode/issues/36
+ *
+ * TODO: replace this function with ensjs#bytesToPacket when it correctly handles these cases. See
+ * ensnode commit hash bace0ab55077d9f5cd37bd9d6638c4acb16334a8 for an example implementation.
+ *
+ * @returns [(first) Label, Name] if decoding succeeded, otherwise [null, null]
+ */
+export function decodeDNSPacketBytes(buf: Uint8Array): [Label, Name] | [null, null] {
+  // buffer is empty, bail
+  if (buf.length === 0) return [null, null];
+
+  let offset = 0;
+  let list = new Uint8Array(0);
+  let dot = stringToBytes(".");
+  let len = buf[offset++];
+  let hex = bytesToHex(buf);
+  let firstLabel = "";
+
+  // if the length of the first label is 0, this packet doesn't represent anything, so bail
+  if (len === 0) return [null, null]; // NOTE: we return [null, null] instead of ["", "."]
+
+  // while there are more labels to decode...
+  while (len) {
+    // grab the characters that represent that label
+    const label = hex.slice((offset + 1) * 2, (offset + 1 + len) * 2);
+    const labelBytes = Buffer.from(label, "hex");
+
+    // if the decoded label is not indexable, bail
+    if (!isLabelIndexable(labelBytes.toString())) return [null, null];
+
+    if (offset > 1) {
+      // if this is not the first label, append a dot to the current list of labels
+      list = concatUint8Arrays(list, dot);
+    } else {
+      // this is the first decoded label, set firstLabel
+      firstLabel = labelBytes.toString();
+    }
+
+    // add the decoded label to the list of decoded labels
+    list = concatUint8Arrays(list, labelBytes);
+
+    // forward offset to the character that represents the length of the next label
+    offset += len;
+    // decode that length and iterate
+    len = buf[offset++];
+
+    // NOTE: if this is the last label, the final 0x00 sets `len` to 0 and therefore breaks the loop
+  }
+
+  // finally, return the firstLabel and the set of labels and dots as a string
+  return [firstLabel, bytesToString(list)];
+}
+
+function concatUint8Arrays(a: Uint8Array, b: Uint8Array): Uint8Array {
+  const concatenatedArray = new Uint8Array(a.length + b.length);
+  concatenatedArray.set(a);
+  concatenatedArray.set(b, a.length);
+  return concatenatedArray;
+}
 
 /**
  * parses an RRSet encoded as Hex string into a set of Answer records.

--- a/apps/ensindexer/src/plugins/basenames/handlers/Registrar.ts
+++ b/apps/ensindexer/src/plugins/basenames/handlers/Registrar.ts
@@ -1,7 +1,6 @@
 import { ponder } from "ponder:registry";
 
-import { type LabelHash, PluginName } from "@ensnode/utils";
-import { uint256ToHex32 } from "@ensnode/utils/subname-helpers";
+import { type LabelHash, PluginName, uint256ToHex32 } from "@ensnode/utils";
 
 import { makeRegistrarHandlers } from "@/handlers/Registrar";
 import { ENSIndexerPluginHandlerArgs } from "@/lib/plugin-helpers";

--- a/apps/ensindexer/src/plugins/lineanames/handlers/Registrar.ts
+++ b/apps/ensindexer/src/plugins/lineanames/handlers/Registrar.ts
@@ -1,7 +1,6 @@
 import { ponder } from "ponder:registry";
 
-import { type LabelHash, PluginName } from "@ensnode/utils";
-import { uint256ToHex32 } from "@ensnode/utils/subname-helpers";
+import { type LabelHash, PluginName, uint256ToHex32 } from "@ensnode/utils";
 
 import { makeRegistrarHandlers } from "@/handlers/Registrar";
 import { ENSIndexerPluginHandlerArgs } from "@/lib/plugin-helpers";

--- a/apps/ensindexer/src/plugins/subgraph/handlers/Registrar.ts
+++ b/apps/ensindexer/src/plugins/subgraph/handlers/Registrar.ts
@@ -1,6 +1,5 @@
 import { ponder } from "ponder:registry";
-import { type LabelHash } from "@ensnode/utils";
-import { uint256ToHex32 } from "@ensnode/utils/subname-helpers";
+import { type LabelHash, uint256ToHex32 } from "@ensnode/utils";
 
 import { makeRegistrarHandlers } from "@/handlers/Registrar";
 import { ENSIndexerPluginHandlerArgs } from "@/lib/plugin-helpers";

--- a/apps/ensindexer/src/plugins/subgraph/handlers/Registry.ts
+++ b/apps/ensindexer/src/plugins/subgraph/handlers/Registry.ts
@@ -1,8 +1,7 @@
 import { type Context, ponder } from "ponder:registry";
 import schema from "ponder:schema";
 
-import { Node, PluginName, ROOT_NODE } from "@ensnode/utils";
-import { makeSubdomainNode } from "@ensnode/utils/subname-helpers";
+import { type Node, PluginName, ROOT_NODE, makeSubdomainNode } from "@ensnode/utils";
 
 import { makeRegistryHandlers } from "@/handlers/Registry";
 import { ENSIndexerPluginHandlerArgs } from "@/lib/plugin-helpers";

--- a/apps/ensindexer/test/dns-helpers.test.ts
+++ b/apps/ensindexer/test/dns-helpers.test.ts
@@ -57,6 +57,10 @@ describe("dns-helpers", () => {
       expect(decodeDNSPacketBytes(toBytes(""))).toEqual([null, null]);
     });
 
+    it.only("should return [null, null] for malformed dns packet", () => {
+      expect(decodeDNSPacketBytes(new Uint8Array([0x00]))).toEqual([null, null]);
+    });
+
     it("should return [null, null] for labels with unindexable characters", () => {
       expect(decodeDNSPacketBytes(toBytes("test\0"))).toEqual([null, null]);
       expect(decodeDNSPacketBytes(toBytes("test."))).toEqual([null, null]);

--- a/apps/ensindexer/test/dns-helpers.test.ts
+++ b/apps/ensindexer/test/dns-helpers.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { decodeTXTData, parseRRSet } from "@/lib/dns-helpers";
+import { decodeDNSPacketBytes, decodeTXTData, parseRRSet } from "@/lib/dns-helpers";
 import { ENSDeployments } from "@ensnode/ens-deployments";
-import { TxtAnswer } from "dns-packet";
-import { decodeEventLog, zeroHash } from "viem";
+import dnsPacket, { TxtAnswer } from "dns-packet";
+import { decodeEventLog, hexToBytes, toBytes, zeroHash } from "viem";
 
 // Example TXT `record` representing key: 'com.twitter', value: '0xTko'
 // via: https://optimistic.etherscan.io/tx/0xf32db67e7bf2118ea2c3dd8f40fc48d18e83a4a2317fbbddce8f741e30a1e8d7#eventlog
@@ -48,6 +48,31 @@ describe("dns-helpers", () => {
 
     it("returns null if no records", () => {
       expect(decodeTXTData([])).toBe(null);
+    });
+  });
+
+  describe("decodeDNSPacketBytes", () => {
+    it.only("should return [null, null] for empty buffer", () => {
+      expect(decodeDNSPacketBytes(new Uint8Array())).toEqual([null, null]);
+    });
+
+    it("should return [null, null] for labels with unindexable characters", () => {
+      expect(decodeDNSPacketBytes(toBytes("test\0"))).toEqual([null, null]);
+      expect(decodeDNSPacketBytes(toBytes("test."))).toEqual([null, null]);
+      expect(decodeDNSPacketBytes(toBytes("test["))).toEqual([null, null]);
+      expect(decodeDNSPacketBytes(toBytes("test]"))).toEqual([null, null]);
+
+      // TODO: based on the definition of `isLabelIndexable` the empty label ("")
+      // is not indexable, however this test case returns ["", ""] instead of [null, null]
+      // expect(decodeDNSPacketBytes(toBytes(""))).toEqual([null, null]);
+    });
+
+    it("should handle previously bugged name", () => {
+      // this `name` from tx 0x2138cdf5fbaeabc9cc2cd65b0a30e4aea47b3961f176d4775869350c702bd401
+      expect(decodeDNSPacketBytes(hexToBytes("0x0831323333333232310365746800"))).toEqual([
+        "12333221",
+        "12333221.eth",
+      ]);
     });
   });
 });

--- a/apps/ensindexer/test/dns-helpers.test.ts
+++ b/apps/ensindexer/test/dns-helpers.test.ts
@@ -52,12 +52,12 @@ describe("dns-helpers", () => {
   });
 
   describe("decodeDNSPacketBytes", () => {
-    it.only("should return [null, null] for empty buffer", () => {
+    it("should return [null, null] for empty buffer", () => {
       expect(decodeDNSPacketBytes(new Uint8Array())).toEqual([null, null]);
       expect(decodeDNSPacketBytes(toBytes(""))).toEqual([null, null]);
     });
 
-    it.only("should return [null, null] for malformed dns packet", () => {
+    it("should return [null, null] for malformed dns packet", () => {
       expect(decodeDNSPacketBytes(new Uint8Array([0x00]))).toEqual([null, null]);
     });
 

--- a/apps/ensindexer/test/dns-helpers.test.ts
+++ b/apps/ensindexer/test/dns-helpers.test.ts
@@ -54,6 +54,7 @@ describe("dns-helpers", () => {
   describe("decodeDNSPacketBytes", () => {
     it.only("should return [null, null] for empty buffer", () => {
       expect(decodeDNSPacketBytes(new Uint8Array())).toEqual([null, null]);
+      expect(decodeDNSPacketBytes(toBytes(""))).toEqual([null, null]);
     });
 
     it("should return [null, null] for labels with unindexable characters", () => {
@@ -61,10 +62,6 @@ describe("dns-helpers", () => {
       expect(decodeDNSPacketBytes(toBytes("test."))).toEqual([null, null]);
       expect(decodeDNSPacketBytes(toBytes("test["))).toEqual([null, null]);
       expect(decodeDNSPacketBytes(toBytes("test]"))).toEqual([null, null]);
-
-      // TODO: based on the definition of `isLabelIndexable` the empty label ("")
-      // is not indexable, however this test case returns ["", ""] instead of [null, null]
-      // expect(decodeDNSPacketBytes(toBytes(""))).toEqual([null, null]);
     });
 
     it("should handle previously bugged name", () => {

--- a/packages/ensnode-utils/package.json
+++ b/packages/ensnode-utils/package.json
@@ -14,8 +14,7 @@
     "dist"
   ],
   "exports": {
-    ".": "./src/index.ts",
-    "./subname-helpers": "./src/subname-helpers.ts"
+    ".": "./src/index.ts"
   },
   "publishConfig": {
     "access": "public",
@@ -23,10 +22,6 @@
       ".": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
-      },
-      "./subname-helpers": {
-        "types": "./dist/subname-helpers.d.ts",
-        "default": "./dist/subname-helpers.js"
       }
     },
     "main": "./dist/index.js",

--- a/packages/ensnode-utils/src/index.ts
+++ b/packages/ensnode-utils/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./constants";
 export * from "./types";
 export * from "./cache";
+export * from "./subname-helpers";

--- a/packages/ensnode-utils/src/subname-helpers.test.ts
+++ b/packages/ensnode-utils/src/subname-helpers.test.ts
@@ -1,16 +1,7 @@
-import {
-  Address,
-  IntegerOutOfRangeError,
-  hexToBytes,
-  labelhash,
-  namehash,
-  toBytes,
-  zeroHash,
-} from "viem";
+import { Address, IntegerOutOfRangeError, labelhash, namehash, zeroHash } from "viem";
 import { describe, expect, it } from "vitest";
 
 import {
-  decodeDNSPacketBytes,
   isLabelIndexable,
   makeSubdomainNode,
   maybeHealLabelByReverseAddress,
@@ -37,33 +28,6 @@ describe("isLabelIndexable", () => {
 
   it("should return false for unhealable lablelhash", () => {
     expect(isLabelIndexable(null)).toBe(false);
-  });
-});
-
-describe("decodeDNSPacketBytes", () => {
-  // TODO: undo the skip when the decodeDNSPacketBytes implementation can be fixed
-  // related discussion: https://github.com/namehash/ensnode/pull/43#discussion_r1924255145
-  it.skip('should return ["", "."] for empty buffer', () => {
-    expect(decodeDNSPacketBytes(new Uint8Array())).toEqual(["", "."]);
-  });
-
-  it("should return [null, null] for labels with unindexable characters", () => {
-    expect(decodeDNSPacketBytes(toBytes("test\0"))).toEqual([null, null]);
-    expect(decodeDNSPacketBytes(toBytes("test."))).toEqual([null, null]);
-    expect(decodeDNSPacketBytes(toBytes("test["))).toEqual([null, null]);
-    expect(decodeDNSPacketBytes(toBytes("test]"))).toEqual([null, null]);
-
-    // TODO: based on the definition of `isLabelIndexable` the empty label ("")
-    // is not indexable, however this test case returns ["", ""] instead of [null, null]
-    // expect(decodeDNSPacketBytes(toBytes(""))).toEqual([null, null]);
-  });
-
-  it("should handle previously bugged name", () => {
-    // this `name` from tx 0x2138cdf5fbaeabc9cc2cd65b0a30e4aea47b3961f176d4775869350c702bd401
-    expect(decodeDNSPacketBytes(hexToBytes("0x0831323333333232310365746800"))).toEqual([
-      "12333221",
-      "12333221.eth",
-    ]);
   });
 });
 

--- a/packages/ensnode-utils/src/subname-helpers.ts
+++ b/packages/ensnode-utils/src/subname-helpers.ts
@@ -1,17 +1,7 @@
-import {
-  Address,
-  bytesToHex,
-  bytesToString,
-  concat,
-  isAddress,
-  isHash,
-  keccak256,
-  stringToBytes,
-  toHex,
-} from "viem";
+import { Address, concat, isAddress, isHash, keccak256, toHex } from "viem";
 
 import { labelhash } from "viem/ens";
-import type { Label, LabelHash, Name, Node } from "./types";
+import type { Label, LabelHash, Node } from "./types";
 
 /**
  * Implements one step of the namehash algorithm, combining `labelHash` with `node` to produce
@@ -139,63 +129,3 @@ export const isLabelIndexable = (label: Label | null): label is Label => {
 
   return true;
 };
-
-/**
- * NOTE: there seems to be a bug in ensjs#bytesToPacket regarding malformed names, which we were
- * originally using for this function.
- *
- * For example, in this tx `0x4ece50ae828f2a0f27f45d086e85a55e6284bff31a0a89daca9df4b1b1f5cb75` the
- * `name` input is `8436.eth` (it should have been just `8436`, as the `.eth` is inferred).
- *
- * This operates against a name that actually looks like `[fb1d24d5dc41613d5b4874e6cccb06ecf442f6f1773c3771c4fcce1161985a18].eth`
- * which results in a namehash of `0xfb1d24d5dc41613d5b4874e6cccb06ecf442f6f1773c3771c4fcce1161985a18`
- * and the NameWrapper emits an event with the packet bytes of `08383433362E6574680365746800`.
- * when ensjs#bytesToPacket sees these bytes, it returns a name of `8436.eth.eth`, which is incorrect.
- *
- * The original subgraph logic handled this case correctly, it seems, and so we re-implement it here.
- * https://github.com/ensdomains/ens-subgraph/blob/c844791/src/nameWrapper.ts#L30
- *
- * More information about this discussion can be found in this thread:
- * https://github.com/namehash/ensnode/issues/36
- *
- * TODO: replace this function with ensjs#bytesToPacket when it correctly handles these cases. See
- * ensnode commit hash bace0ab55077d9f5cd37bd9d6638c4acb16334a8 for an example implementation.
- *
- */
-export function decodeDNSPacketBytes(buf: Uint8Array): [Label | null, Name | null] {
-  let offset = 0;
-  let list = new Uint8Array(0);
-  let dot = stringToBytes(".");
-  let len = buf[offset++];
-  let hex = bytesToHex(buf);
-  let firstLabel = "";
-  if (len === 0) {
-    return [firstLabel, "."];
-  }
-
-  while (len) {
-    const label = hex.slice((offset + 1) * 2, (offset + 1 + len) * 2);
-    const labelBytes = Buffer.from(label, "hex");
-
-    if (!isLabelIndexable(labelBytes.toString())) {
-      return [null, null];
-    }
-
-    if (offset > 1) {
-      list = concatUint8Arrays(list, dot);
-    } else {
-      firstLabel = labelBytes.toString();
-    }
-    list = concatUint8Arrays(list, labelBytes);
-    offset += len;
-    len = buf[offset++];
-  }
-  return [firstLabel, bytesToString(list)];
-}
-
-function concatUint8Arrays(a: Uint8Array, b: Uint8Array): Uint8Array {
-  const concatenatedArray = new Uint8Array(a.length + b.length);
-  concatenatedArray.set(a);
-  concatenatedArray.set(b, a.length);
-  return concatenatedArray;
-}

--- a/packages/ensnode-utils/tsup.config.ts
+++ b/packages/ensnode-utils/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/subname-helpers.ts"],
+  entry: ["src/index.ts"],
   platform: "browser",
   format: ["esm"],
   target: "es2022",


### PR DESCRIPTION
closes #41 

i don't think these helpers need to be in ensnode/utils, especially because we were having trouble with the Buffer typings, since ensnode utils specifies browser libs and whatnot. so for simplicity and the tightness of the ensnode/utils lib, i've removed the dnspacketbytes lib and just exported all of the subname helpers from the root index — it's much cleaner now and especially on the consumer end where all imports come from `@ensnode/utils` rather than some some `@ensnode/utils/subname-helpers`

no changeset necessary, imo