### PR TITLE
docs: add comments about NameWrapper's usage of registrar managed name

### DIFF
--- a/apps/ensindexer/src/handlers/NameWrapper.ts
+++ b/apps/ensindexer/src/handlers/NameWrapper.ts
@@ -171,9 +171,13 @@ export const makeNameWrapperHandlers = ({
       await upsertAccount(context, owner);
 
       await context.db.update(schema.domain, { id: node }).set((domain) => ({
-        // null expiry date if the domain is not a direct child of the registrar managed name
+        // when a WrappedDomain is Unwrapped, reset any PCC-materialized expiryDate on the Domain entity
+        // i.e if the domain in question normally has an expiry date (is a direct subname of a
+        // Registrar that implements expiries), keep the domain's expiry date, otherwise, set its
+        // expiry to null because it does not expire.
         // via https://github.com/ensdomains/ens-subgraph/blob/c844791/src/nameWrapper.ts#L123
-        expiryDate: domain.parentId !== registrarManagedNode ? null : domain.expiryDate,
+        // NOTE: undefined = no change, null = null
+        expiryDate: domain.parentId === registrarManagedNode ? undefined : null,
         wrappedOwnerId: null,
       }));
 


### PR DESCRIPTION
closes https://github.com/namehash/ensnode/issues/534

adds discussion for why that value is used in NameWrapper

changeset not necessary for internal comments