### PR TITLE
fix(ensindexer): use lazy-loaded config

### DIFF
--- a/apps/ensindexer/ponder.config.ts
+++ b/apps/ensindexer/ponder.config.ts
@@ -21,7 +21,7 @@ export const ALL_PLUGINS = [
   threednsPlugin,
 ] as const;
 
-export type MergedPonderConfig = MergedTypes<(typeof ALL_PLUGINS)[number]["config"]> & {
+export type MergedPonderConfig = MergedTypes<(typeof ALL_PLUGINS)[number]["config"]["loader"]> & {
   /**
    * NOTE: we inject additional values (ones that change the behavior of the indexing logic) into the
    * Ponder config in order to alter the ponder-generated build id when these additional options change.
@@ -43,7 +43,7 @@ const activePlugins = ALL_PLUGINS.filter((plugin) => config.plugins.includes(plu
 
 // combine each plugins' config into a MergedPonderConfig
 const ponderConfig = activePlugins.reduce(
-  (memo, plugin) => mergePonderConfigs(memo, plugin.config),
+  (memo, plugin) => mergePonderConfigs(memo, plugin.config.loader),
   {},
 ) as MergedPonderConfig;
 

--- a/apps/ensindexer/src/plugins/basenames/basenames.plugin.ts
+++ b/apps/ensindexer/src/plugins/basenames/basenames.plugin.ts
@@ -16,38 +16,47 @@ import { PluginName } from "@ensnode/utils";
  */
 export const pluginName = PluginName.Basenames;
 
-// contruct a unique contract namespace for this plugin
+// construct a unique contract namespace for this plugin
 const namespace = makePluginNamespace(pluginName);
 
-// extract the chain and contract configs for Basenames Datasource in order to build ponder config
-const deployment = getENSDeployment(appConfig.ensDeploymentChain);
-const { chain, contracts } = deployment[DatasourceName.Basenames];
+export const config = {
+  /**
+   * Load the plugin configuration lazily to prevent premature execution of
+   * nested factory functions, i.e. to ensure that the plugin configuration
+   * is only built when the plugin is activated.
+   */
+  get loader() {
+    // extract the chain and contract configs for Basenames Datasource in order to build ponder config
+    const deployment = getENSDeployment(appConfig.ensDeploymentChain);
+    const { chain, contracts } = deployment[DatasourceName.Basenames];
 
-export const config = createConfig({
-  networks: networksConfigForChain(chain.id),
-  contracts: {
-    [namespace("Registry")]: {
-      network: networkConfigForContract(chain, contracts.Registry),
-      abi: contracts.Registry.abi,
-    },
-    [namespace("BaseRegistrar")]: {
-      network: networkConfigForContract(chain, contracts.BaseRegistrar),
-      abi: contracts.BaseRegistrar.abi,
-    },
-    [namespace("EARegistrarController")]: {
-      network: networkConfigForContract(chain, contracts.EARegistrarController),
-      abi: contracts.EARegistrarController.abi,
-    },
-    [namespace("RegistrarController")]: {
-      network: networkConfigForContract(chain, contracts.RegistrarController),
-      abi: contracts.RegistrarController.abi,
-    },
-    Resolver: {
-      network: networkConfigForContract(chain, contracts.Resolver),
-      abi: contracts.Resolver.abi,
-    },
+    return createConfig({
+      networks: networksConfigForChain(chain.id),
+      contracts: {
+        [namespace("Registry")]: {
+          network: networkConfigForContract(chain, contracts.Registry),
+          abi: contracts.Registry.abi,
+        },
+        [namespace("BaseRegistrar")]: {
+          network: networkConfigForContract(chain, contracts.BaseRegistrar),
+          abi: contracts.BaseRegistrar.abi,
+        },
+        [namespace("EARegistrarController")]: {
+          network: networkConfigForContract(chain, contracts.EARegistrarController),
+          abi: contracts.EARegistrarController.abi,
+        },
+        [namespace("RegistrarController")]: {
+          network: networkConfigForContract(chain, contracts.RegistrarController),
+          abi: contracts.RegistrarController.abi,
+        },
+        Resolver: {
+          network: networkConfigForContract(chain, contracts.Resolver),
+          abi: contracts.Resolver.abi,
+        },
+      },
+    });
   },
-});
+};
 
 export const activate = activateHandlers({
   pluginName,

--- a/apps/ensindexer/src/plugins/lineanames/lineanames.plugin.ts
+++ b/apps/ensindexer/src/plugins/lineanames/lineanames.plugin.ts
@@ -16,38 +16,47 @@ import { PluginName } from "@ensnode/utils";
  */
 export const pluginName = PluginName.Lineanames;
 
-// contruct a unique contract namespace for this plugin
+// construct a unique contract namespace for this plugin
 const namespace = makePluginNamespace(pluginName);
 
-// extract the chain and contract configs for Lineanames Datasource in order to build ponder config
-const deployment = getENSDeployment(appConfig.ensDeploymentChain);
-const { chain, contracts } = deployment[DatasourceName.Lineanames];
+export const config = {
+  /**
+   * Load the plugin configuration lazily to prevent premature execution of
+   * nested factory functions, i.e. to ensure that the plugin configuration
+   * is only built when the plugin is activated.
+   */
+  get loader() {
+    // extract the chain and contract configs for Lineanames Datasource in order to build ponder config
+    const deployment = getENSDeployment(appConfig.ensDeploymentChain);
+    const { chain, contracts } = deployment[DatasourceName.Lineanames];
 
-export const config = createConfig({
-  networks: networksConfigForChain(chain.id),
-  contracts: {
-    [namespace("Registry")]: {
-      network: networkConfigForContract(chain, contracts.Registry),
-      abi: contracts.Registry.abi,
-    },
-    [namespace("BaseRegistrar")]: {
-      network: networkConfigForContract(chain, contracts.BaseRegistrar),
-      abi: contracts.BaseRegistrar.abi,
-    },
-    [namespace("EthRegistrarController")]: {
-      network: networkConfigForContract(chain, contracts.EthRegistrarController),
-      abi: contracts.EthRegistrarController.abi,
-    },
-    [namespace("NameWrapper")]: {
-      network: networkConfigForContract(chain, contracts.NameWrapper),
-      abi: contracts.NameWrapper.abi,
-    },
-    Resolver: {
-      network: networkConfigForContract(chain, contracts.Resolver),
-      abi: contracts.Resolver.abi,
-    },
+    return createConfig({
+      networks: networksConfigForChain(chain.id),
+      contracts: {
+        [namespace("Registry")]: {
+          network: networkConfigForContract(chain, contracts.Registry),
+          abi: contracts.Registry.abi,
+        },
+        [namespace("BaseRegistrar")]: {
+          network: networkConfigForContract(chain, contracts.BaseRegistrar),
+          abi: contracts.BaseRegistrar.abi,
+        },
+        [namespace("EthRegistrarController")]: {
+          network: networkConfigForContract(chain, contracts.EthRegistrarController),
+          abi: contracts.EthRegistrarController.abi,
+        },
+        [namespace("NameWrapper")]: {
+          network: networkConfigForContract(chain, contracts.NameWrapper),
+          abi: contracts.NameWrapper.abi,
+        },
+        Resolver: {
+          network: networkConfigForContract(chain, contracts.Resolver),
+          abi: contracts.Resolver.abi,
+        },
+      },
+    });
   },
-});
+};
 
 export const activate = activateHandlers({
   pluginName,

--- a/apps/ensindexer/src/plugins/subgraph/subgraph.plugin.ts
+++ b/apps/ensindexer/src/plugins/subgraph/subgraph.plugin.ts
@@ -16,46 +16,55 @@ import { PluginName } from "@ensnode/utils";
  */
 export const pluginName = PluginName.Subgraph;
 
-// contruct a unique contract namespace for this plugin
+// construct a unique contract namespace for this plugin
 const namespace = makePluginNamespace(pluginName);
 
-// extract the chain and contract configs for root Datasource in order to build ponder config
-const deployment = getENSDeployment(appConfig.ensDeploymentChain);
-const { chain, contracts } = deployment[DatasourceName.Root];
+export const config = {
+  /**
+   * Load the plugin configuration lazily to prevent premature execution of
+   * nested factory functions, i.e. to ensure that the plugin configuration
+   * is only built when the plugin is activated.
+   */
+  get loader() {
+    // extract the chain and contract configs for root Datasource in order to build ponder config
+    const deployment = getENSDeployment(appConfig.ensDeploymentChain);
+    const { chain, contracts } = deployment[DatasourceName.Root];
 
-export const config = createConfig({
-  networks: networksConfigForChain(chain.id),
-  contracts: {
-    [namespace("RegistryOld")]: {
-      network: networkConfigForContract(chain, contracts.RegistryOld),
-      abi: contracts.Registry.abi,
-    },
-    [namespace("Registry")]: {
-      network: networkConfigForContract(chain, contracts.Registry),
-      abi: contracts.Registry.abi,
-    },
-    [namespace("BaseRegistrar")]: {
-      network: networkConfigForContract(chain, contracts.BaseRegistrar),
-      abi: contracts.BaseRegistrar.abi,
-    },
-    [namespace("EthRegistrarControllerOld")]: {
-      network: networkConfigForContract(chain, contracts.EthRegistrarControllerOld),
-      abi: contracts.EthRegistrarControllerOld.abi,
-    },
-    [namespace("EthRegistrarController")]: {
-      network: networkConfigForContract(chain, contracts.EthRegistrarController),
-      abi: contracts.EthRegistrarController.abi,
-    },
-    [namespace("NameWrapper")]: {
-      network: networkConfigForContract(chain, contracts.NameWrapper),
-      abi: contracts.NameWrapper.abi,
-    },
-    Resolver: {
-      network: networkConfigForContract(chain, contracts.Resolver),
-      abi: contracts.Resolver.abi,
-    },
+    return createConfig({
+      networks: networksConfigForChain(chain.id),
+      contracts: {
+        [namespace("RegistryOld")]: {
+          network: networkConfigForContract(chain, contracts.RegistryOld),
+          abi: contracts.Registry.abi,
+        },
+        [namespace("Registry")]: {
+          network: networkConfigForContract(chain, contracts.Registry),
+          abi: contracts.Registry.abi,
+        },
+        [namespace("BaseRegistrar")]: {
+          network: networkConfigForContract(chain, contracts.BaseRegistrar),
+          abi: contracts.BaseRegistrar.abi,
+        },
+        [namespace("EthRegistrarControllerOld")]: {
+          network: networkConfigForContract(chain, contracts.EthRegistrarControllerOld),
+          abi: contracts.EthRegistrarControllerOld.abi,
+        },
+        [namespace("EthRegistrarController")]: {
+          network: networkConfigForContract(chain, contracts.EthRegistrarController),
+          abi: contracts.EthRegistrarController.abi,
+        },
+        [namespace("NameWrapper")]: {
+          network: networkConfigForContract(chain, contracts.NameWrapper),
+          abi: contracts.NameWrapper.abi,
+        },
+        Resolver: {
+          network: networkConfigForContract(chain, contracts.Resolver),
+          abi: contracts.Resolver.abi,
+        },
+      },
+    });
   },
-});
+};
 
 export const activate = activateHandlers({
   pluginName,

--- a/apps/ensindexer/src/plugins/threedns/threedns.plugin.ts
+++ b/apps/ensindexer/src/plugins/threedns/threedns.plugin.ts
@@ -15,36 +15,46 @@ import { PluginName } from "@ensnode/utils";
  */
 export const pluginName = PluginName.ThreeDNS;
 
-// contruct a unique contract namespace for this plugin
+// construct a unique contract namespace for this plugin
 const namespace = makePluginNamespace(pluginName);
 
-const deployment = getENSDeployment(appConfig.ensDeploymentChain);
-const { chain: optimism, contracts: optimismContracts } =
-  deployment[DatasourceName.ThreeDNSOptimism];
-const { chain: base, contracts: baseContracts } = deployment[DatasourceName.ThreeDNSBase];
+export const config = {
+  /**
+   * Load the plugin configuration lazily to prevent premature execution of
+   * nested factory functions, i.e. to ensure that the plugin configuration
+   * is only built when the plugin is activated.
+   */
+  get loader() {
+    // extract the chain and contract configs for root Datasource in order to build ponder config
+    const deployment = getENSDeployment(appConfig.ensDeploymentChain);
+    const { chain: optimism, contracts: optimismContracts } =
+      deployment[DatasourceName.ThreeDNSOptimism];
+    const { chain: base, contracts: baseContracts } = deployment[DatasourceName.ThreeDNSBase];
 
-export const config = createConfig({
-  networks: {
-    ...networksConfigForChain(optimism.id),
-    ...networksConfigForChain(base.id),
-  },
-  contracts: {
-    [namespace("ThreeDNSToken")]: {
-      network: {
-        ...networkConfigForContract(optimism, optimismContracts.ThreeDNSToken),
-        ...networkConfigForContract(base, baseContracts.ThreeDNSToken),
+    return createConfig({
+      networks: {
+        ...networksConfigForChain(optimism.id),
+        ...networksConfigForChain(base.id),
       },
-      abi: optimismContracts.ThreeDNSToken.abi,
-    },
-    [namespace("Resolver")]: {
-      network: {
-        ...networkConfigForContract(optimism, optimismContracts.Resolver),
-        ...networkConfigForContract(base, baseContracts.Resolver),
+      contracts: {
+        [namespace("ThreeDNSToken")]: {
+          network: {
+            ...networkConfigForContract(optimism, optimismContracts.ThreeDNSToken),
+            ...networkConfigForContract(base, baseContracts.ThreeDNSToken),
+          },
+          abi: optimismContracts.ThreeDNSToken.abi,
+        },
+        [namespace("Resolver")]: {
+          network: {
+            ...networkConfigForContract(optimism, optimismContracts.Resolver),
+            ...networkConfigForContract(base, baseContracts.Resolver),
+          },
+          abi: optimismContracts.Resolver.abi,
+        },
       },
-      abi: optimismContracts.Resolver.abi,
-    },
+    });
   },
-});
+};
 
 export const activate = activateHandlers({
   pluginName,


### PR DESCRIPTION
This change prevents premature execution of plugin-specific config factories.

Before this change, running ENSIndexer service with `ENS_DEPLOYMENT_CHAIN` env var set to other valid value than `mainnet` would cause application runtime error. The problem was caused due to all plugin config files being unconditionally executed from `ponder.config.ts` file. For example, the `basenames` plugin would not find a required datasource loaded when `ENS_DEPLOYMENT_CHAIN` was set to either `sepolia`, `holesky`, or `ens-test-env`.

```
ensindexer  | 9:08:53 AM ERROR build      Error while executing 'ponder.config.ts':
ensindexer  | TypeError: Cannot destructure property 'chain' of 'deployment[__vite_ssr_import_3__.DatasourceName.Basenames]' as it is undefined.
ensindexer  |     at /app/apps/ensindexer/src/plugins/basenames/basenames.plugin.ts:24:9
ensindexer  |   22 | // extract the chain and contract configs for Basenames Datasource in order to build ponder config
ensindexer  |   23 | const deployment = getENSDeployment(appConfig.ensDeploymentChain);
ensindexer  | > 24 | const { chain, contracts } = deployment[DatasourceName.Basenames];
ensindexer  |      |         ^
ensindexer  |   25 |
ensindexer  |   26 | export const config = createConfig({
ensindexer  |   27 |   networks: networksConfigForChain(chain.id),
ensindexer  | 9:08:53 AM WARN  process    Failed intial build, starting shutdown sequence
Cleaning up...
 ELIFECYCLE  Command failed with exit code 1.
```

The fix was to make the plugin config object construction logic lazy-evaluated and only called during plugin activation phase (by when all required datasources must be available).