### PR TITLE
refactor(ensindexer): improve ENSIndexerConfig

### DIFF
--- a/.changeset/ninety-actors-share.md
+++ b/.changeset/ninety-actors-share.md
@@ -1,0 +1,5 @@
+---
+"ensindexer": minor
+---
+
+Update ENSIndexerConfig to include `ensDeployment` object.

--- a/apps/ensindexer/src/config/config.schema.ts
+++ b/apps/ensindexer/src/config/config.schema.ts
@@ -1,7 +1,7 @@
 import { parse as parseConnectionString } from "pg-connection-string";
 import { prettifyError, z } from "zod/v4";
 
-import { derive_isSubgraphCompatible } from "@/config/derived-params";
+import { derive_ensDeployment, derive_isSubgraphCompatible } from "@/config/derived-params";
 import { ENSIndexerConfig, ENSIndexerEnvironment } from "@/config/types";
 import {
   invariant_globalBlockrange,
@@ -178,6 +178,7 @@ const ENSIndexerConfigSchema = z
   // inject derived config params
   // NOTE: all invariants were enforced by that time so we can
   //    safely project parsed config parameters into derived ones
+  .transform(derive_ensDeployment)
   .transform(derive_isSubgraphCompatible);
 
 /**

--- a/apps/ensindexer/src/config/config.schema.ts
+++ b/apps/ensindexer/src/config/config.schema.ts
@@ -1,6 +1,7 @@
 import { parse as parseConnectionString } from "pg-connection-string";
 import { prettifyError, z } from "zod/v4";
 
+import { derive_isSubgraphCompatible } from "@/config/derived-params";
 import { ENSIndexerConfig, ENSIndexerEnvironment } from "@/config/types";
 import {
   invariant_globalBlockrange,
@@ -154,29 +155,6 @@ const DatabaseUrlSchema = z.union(
   },
 );
 
-const derive_isSubgraphCompatible = <
-  CONFIG extends Pick<
-    ENSIndexerConfig,
-    "plugins" | "healReverseAddresses" | "indexAdditionalResolverRecords"
-  >,
->(
-  config: CONFIG,
-): CONFIG & { isSubgraphCompatible: boolean } => {
-  // 1. only the subgraph plugin is active
-  const onlySubgraphPluginActivated =
-    config.plugins.length === 1 && config.plugins[0] === PluginName.Subgraph;
-
-  // 2. healReverseAddresses = false
-  // 3. indexAdditionalResolverRecords = false
-  const indexingBehaviorIsSubgraphCompatible =
-    !config.healReverseAddresses && !config.indexAdditionalResolverRecords;
-
-  return {
-    ...config,
-    isSubgraphCompatible: onlySubgraphPluginActivated && indexingBehaviorIsSubgraphCompatible,
-  };
-};
-
 const ENSIndexerConfigSchema = z
   .object({
     ensDeploymentChain: EnsDeploymentChainSchema,
@@ -192,13 +170,15 @@ const ENSIndexerConfigSchema = z
     rpcConfigs: RpcConfigsSchema,
     databaseUrl: DatabaseUrlSchema,
   })
-  // inject ENSIndexerConfig.isSubgraphCompatible
-  .transform(derive_isSubgraphCompatible)
   // perform invariant checks
   .check(invariant_requiredDatasources)
   .check(invariant_rpcConfigsSpecifiedForIndexedChains)
   .check(invariant_globalBlockrange)
-  .check(invariant_validContractConfigs);
+  .check(invariant_validContractConfigs)
+  // inject derived config params
+  // NOTE: all invariants were enforced by that time so we can
+  //    safely project parsed config parameters into derived ones
+  .transform(derive_isSubgraphCompatible);
 
 /**
  * Builds the ENSIndexer configuration object from an ENSIndexerEnvironment object

--- a/apps/ensindexer/src/config/derived-params.ts
+++ b/apps/ensindexer/src/config/derived-params.ts
@@ -1,4 +1,5 @@
 import type { ENSIndexerConfig } from "@/config/types";
+import { type ENSDeploymentGlobalType, getENSDeployment } from "@ensnode/ens-deployments";
 import { PluginName } from "@ensnode/ensnode-sdk";
 
 /**
@@ -24,5 +25,19 @@ export const derive_isSubgraphCompatible = <
   return {
     ...config,
     isSubgraphCompatible: onlySubgraphPluginActivated && indexingBehaviorIsSubgraphCompatible,
+  };
+};
+
+/**
+ * Derived `ensDeployment` config param based on validated ENSIndexerConfig object.
+ */
+export const derive_ensDeployment = <CONFIG extends Pick<ENSIndexerConfig, "ensDeploymentChain">>(
+  config: CONFIG,
+): CONFIG & { ensDeployment: ENSDeploymentGlobalType } => {
+  const ensDeployment = getENSDeployment(config.ensDeploymentChain);
+
+  return {
+    ...config,
+    ensDeployment,
   };
 };

--- a/apps/ensindexer/src/config/derived-params.ts
+++ b/apps/ensindexer/src/config/derived-params.ts
@@ -1,0 +1,28 @@
+import type { ENSIndexerConfig } from "@/config/types";
+import { PluginName } from "@ensnode/ensnode-sdk";
+
+/**
+ * Derived `isSubgraphCompatible` config param based on validated ENSIndexerConfig object.
+ */
+export const derive_isSubgraphCompatible = <
+  CONFIG extends Pick<
+    ENSIndexerConfig,
+    "plugins" | "healReverseAddresses" | "indexAdditionalResolverRecords"
+  >,
+>(
+  config: CONFIG,
+): CONFIG & { isSubgraphCompatible: boolean } => {
+  // 1. only the subgraph plugin is active
+  const onlySubgraphPluginActivated =
+    config.plugins.length === 1 && config.plugins[0] === PluginName.Subgraph;
+
+  // 2. healReverseAddresses = false
+  // 3. indexAdditionalResolverRecords = false
+  const indexingBehaviorIsSubgraphCompatible =
+    !config.healReverseAddresses && !config.indexAdditionalResolverRecords;
+
+  return {
+    ...config,
+    isSubgraphCompatible: onlySubgraphPluginActivated && indexingBehaviorIsSubgraphCompatible,
+  };
+};

--- a/apps/ensindexer/src/config/types.ts
+++ b/apps/ensindexer/src/config/types.ts
@@ -36,7 +36,7 @@ export interface ENSIndexerConfig {
   /**
    * The ENS Deployment that ENSIndexer is targeting, defaulting to 'mainnet' (DEFAULT_ENS_DEPLOYMENT_CHAIN).
    *
-   * See {@link ensDeploymentChain} for available deployment chains.
+   * See {@link ENSDeploymentChain} for available deployment chains.
    */
   ensDeploymentChain: ENSDeploymentChain;
 

--- a/apps/ensindexer/src/config/types.ts
+++ b/apps/ensindexer/src/config/types.ts
@@ -1,5 +1,9 @@
 import { Blockrange } from "@/lib/types";
-import type { ENSDeployments } from "@ensnode/ens-deployments";
+import type {
+  ENSDeployment,
+  ENSDeploymentChain,
+  ENSDeploymentGlobalType,
+} from "@ensnode/ens-deployments";
 import type { PluginName } from "@ensnode/ensnode-sdk";
 
 /**
@@ -32,9 +36,16 @@ export interface ENSIndexerConfig {
   /**
    * The ENS Deployment that ENSIndexer is targeting, defaulting to 'mainnet' (DEFAULT_ENS_DEPLOYMENT_CHAIN).
    *
-   * See {@link ENSDeployments} for available deployments.
+   * See {@link ensDeploymentChain} for available deployment chains.
    */
-  ensDeploymentChain: keyof typeof ENSDeployments;
+  ensDeploymentChain: ENSDeploymentChain;
+
+  /**
+   * ENSDeployment configuration, based on the `ensDeploymentChain` value.
+   *
+   * See {@link ENSDeployment} for the deployment type.
+   */
+  ensDeployment: ENSDeploymentGlobalType;
 
   /**
    * An ENSAdmin url, defaulting to the public instance https://admin.ensnode.io (DEFAULT_ENSADMIN_URL).

--- a/apps/ensindexer/src/config/validations.ts
+++ b/apps/ensindexer/src/config/validations.ts
@@ -7,8 +7,13 @@ import { DatasourceName, getENSDeployment } from "@ensnode/ens-deployments";
 import { PluginName } from "@ensnode/ensnode-sdk";
 import { Address, isAddress } from "viem";
 
+// type alias to highlight the input param of Zod's check() method
+type ZodCheckFnInput<T> = z.core.ParsePayload<T>;
+
 // Invariant: specified plugins' datasources are available in the specified ensDeploymentChain's ENSDeployment
-export function invariant_requiredDatasources(ctx: z.core.ParsePayload<ENSIndexerConfig>) {
+export function invariant_requiredDatasources(
+  ctx: ZodCheckFnInput<Pick<ENSIndexerConfig, "ensDeploymentChain" | "plugins">>,
+) {
   const { value: config } = ctx;
 
   const deployment = getENSDeployment(config.ensDeploymentChain);
@@ -43,7 +48,7 @@ export function invariant_requiredDatasources(ctx: z.core.ParsePayload<ENSIndexe
 
 // Invariant: rpcConfig is specified for each indexed chain
 export function invariant_rpcConfigsSpecifiedForIndexedChains(
-  ctx: z.core.ParsePayload<ENSIndexerConfig>,
+  ctx: ZodCheckFnInput<Pick<ENSIndexerConfig, "ensDeploymentChain" | "plugins" | "rpcConfigs">>,
 ) {
   const { value: config } = ctx;
 
@@ -67,7 +72,11 @@ export function invariant_rpcConfigsSpecifiedForIndexedChains(
 }
 
 // Invariant: if a global blockrange is defined, only one network is indexed
-export function invariant_globalBlockrange(ctx: z.core.ParsePayload<ENSIndexerConfig>) {
+export function invariant_globalBlockrange(
+  ctx: ZodCheckFnInput<
+    Pick<ENSIndexerConfig, "globalBlockrange" | "ensDeploymentChain" | "plugins">
+  >,
+) {
   const { value: config } = ctx;
   const { globalBlockrange } = config;
 
@@ -102,7 +111,9 @@ export function invariant_globalBlockrange(ctx: z.core.ParsePayload<ENSIndexerCo
 }
 
 // Invariant: all contracts have a valid ContractConfig defined
-export function invariant_validContractConfigs(ctx: z.core.ParsePayload<ENSIndexerConfig>) {
+export function invariant_validContractConfigs(
+  ctx: ZodCheckFnInput<Pick<ENSIndexerConfig, "ensDeploymentChain">>,
+) {
   const { value: config } = ctx;
 
   const deployment = getENSDeployment(config.ensDeploymentChain);

--- a/apps/ensindexer/src/lib/lib-config.ts
+++ b/apps/ensindexer/src/lib/lib-config.ts
@@ -59,7 +59,7 @@ export function prettyPrintConfig(config: ENSIndexerConfig) {
         ]),
       ),
     } as ENSIndexerConfig,
-    null,
+    (key: string, value: unknown) => (key === "abi" ? `(truncated ABI output)` : value),
     2,
   );
 }

--- a/apps/ensindexer/src/plugins/basenames/basenames.plugin.ts
+++ b/apps/ensindexer/src/plugins/basenames/basenames.plugin.ts
@@ -1,13 +1,13 @@
 import { createConfig } from "ponder";
 
-import { default as appConfig } from "@/config";
+import appConfig from "@/config";
 import {
   activateHandlers,
   makePluginNamespace,
   networkConfigForContract,
   networksConfigForChain,
 } from "@/lib/plugin-helpers";
-import { DatasourceName, getENSDeployment } from "@ensnode/ens-deployments";
+import { DatasourceName } from "@ensnode/ens-deployments";
 import { PluginName } from "@ensnode/ensnode-sdk";
 
 /**
@@ -19,7 +19,7 @@ const pluginName = PluginName.Basenames;
 // construct a unique contract namespace for this plugin
 const namespace = makePluginNamespace(pluginName);
 
-export default {
+const basenamesPlugin = {
   /**
    * Activate the plugin handlers for indexing.
    */
@@ -39,9 +39,9 @@ export default {
    * is only built when the plugin is activated.
    */
   get config() {
+    const { ensDeployment } = appConfig;
     // extract the chain and contract configs for Basenames Datasource in order to build ponder config
-    const deployment = getENSDeployment(appConfig.ensDeploymentChain);
-    const { chain, contracts } = deployment[DatasourceName.Basenames];
+    const { chain, contracts } = ensDeployment[DatasourceName.Basenames];
 
     return createConfig({
       networks: networksConfigForChain(chain.id),
@@ -75,3 +75,5 @@ export default {
    */
   pluginName,
 };
+
+export default basenamesPlugin;

--- a/apps/ensindexer/src/plugins/lineanames/lineanames.plugin.ts
+++ b/apps/ensindexer/src/plugins/lineanames/lineanames.plugin.ts
@@ -1,13 +1,13 @@
 import { createConfig } from "ponder";
 
-import { default as appConfig } from "@/config";
+import appConfig from "@/config";
 import {
   activateHandlers,
   makePluginNamespace,
   networkConfigForContract,
   networksConfigForChain,
 } from "@/lib/plugin-helpers";
-import { DatasourceName, getENSDeployment } from "@ensnode/ens-deployments";
+import { DatasourceName } from "@ensnode/ens-deployments";
 import { PluginName } from "@ensnode/ensnode-sdk";
 
 /**
@@ -19,7 +19,7 @@ const pluginName = PluginName.Lineanames;
 // construct a unique contract namespace for this plugin
 const namespace = makePluginNamespace(pluginName);
 
-export default {
+const lineanamesPlugin = {
   /**
    * Activate the plugin handlers for indexing.
    */
@@ -40,9 +40,9 @@ export default {
    * is only built when the plugin is activated.
    */
   get config() {
+    const { ensDeployment } = appConfig;
     // extract the chain and contract configs for Lineanames Datasource in order to build ponder config
-    const deployment = getENSDeployment(appConfig.ensDeploymentChain);
-    const { chain, contracts } = deployment[DatasourceName.Lineanames];
+    const { chain, contracts } = ensDeployment[DatasourceName.Lineanames];
 
     return createConfig({
       networks: networksConfigForChain(chain.id),
@@ -76,3 +76,5 @@ export default {
    */
   pluginName,
 };
+
+export default lineanamesPlugin;

--- a/apps/ensindexer/src/plugins/subgraph/subgraph.plugin.ts
+++ b/apps/ensindexer/src/plugins/subgraph/subgraph.plugin.ts
@@ -1,13 +1,13 @@
 import { createConfig } from "ponder";
 
-import { default as appConfig } from "@/config";
+import appConfig from "@/config";
 import {
   activateHandlers,
   makePluginNamespace,
   networkConfigForContract,
   networksConfigForChain,
 } from "@/lib/plugin-helpers";
-import { DatasourceName, getENSDeployment } from "@ensnode/ens-deployments";
+import { DatasourceName } from "@ensnode/ens-deployments";
 import { PluginName } from "@ensnode/ensnode-sdk";
 
 /**
@@ -19,7 +19,7 @@ const pluginName = PluginName.Subgraph;
 // construct a unique contract namespace for this plugin
 const namespace = makePluginNamespace(pluginName);
 
-export default {
+const subgraphPlugin = {
   /**
    * Activate the plugin handlers for indexing.
    */
@@ -40,9 +40,9 @@ export default {
    * is only built when the plugin is activated.
    */
   get config() {
+    const { ensDeployment } = appConfig;
     // extract the chain and contract configs for root Datasource in order to build ponder config
-    const deployment = getENSDeployment(appConfig.ensDeploymentChain);
-    const { chain, contracts } = deployment[DatasourceName.Root];
+    const { chain, contracts } = ensDeployment[DatasourceName.Root];
 
     return createConfig({
       networks: networksConfigForChain(chain.id),
@@ -84,3 +84,5 @@ export default {
    */
   pluginName,
 };
+
+export default subgraphPlugin;

--- a/apps/ensindexer/src/plugins/threedns/threedns.plugin.ts
+++ b/apps/ensindexer/src/plugins/threedns/threedns.plugin.ts
@@ -1,13 +1,13 @@
 import { createConfig } from "ponder";
 
-import { default as appConfig } from "@/config";
+import appConfig from "@/config";
 import {
   activateHandlers,
   makePluginNamespace,
   networkConfigForContract,
   networksConfigForChain,
 } from "@/lib/plugin-helpers";
-import { DatasourceName, getENSDeployment } from "@ensnode/ens-deployments";
+import { DatasourceName } from "@ensnode/ens-deployments";
 import { PluginName } from "@ensnode/ensnode-sdk";
 
 /**
@@ -18,7 +18,7 @@ const pluginName = PluginName.ThreeDNS;
 // construct a unique contract namespace for this plugin
 const namespace = makePluginNamespace(pluginName);
 
-export default {
+const threednsPlugin = {
   /**
    * Activate the plugin handlers for indexing.
    */
@@ -34,11 +34,11 @@ export default {
    * is only built when the plugin is activated.
    */
   get config() {
+    const { ensDeployment } = appConfig;
     // extract the chain and contract configs for root Datasource in order to build ponder config
-    const deployment = getENSDeployment(appConfig.ensDeploymentChain);
     const { chain: optimism, contracts: optimismContracts } =
-      deployment[DatasourceName.ThreeDNSOptimism];
-    const { chain: base, contracts: baseContracts } = deployment[DatasourceName.ThreeDNSBase];
+      ensDeployment[DatasourceName.ThreeDNSOptimism];
+    const { chain: base, contracts: baseContracts } = ensDeployment[DatasourceName.ThreeDNSBase];
 
     return createConfig({
       networks: {
@@ -69,3 +69,5 @@ export default {
    */
   pluginName,
 };
+
+export default threednsPlugin;


### PR DESCRIPTION
This PR includes refactorings around `ENSIndexerConfig` that allow dropping unnecessary imports and replace them with new derived configuration parameters: `ensDeployment`.

Suggested review order:
1. `apps/ensindexer/src/plugins`: all plugins read the `ensDeployment` directly from the `appConfig` object.
2. `apps/ensindexer/src/plugins/basenames/basenames.plugin.ts`: `ensDeployment` includes some ABIs, which I figured will be best not to be shown due to their length
3. `apps/ensindexer/src/config/types.ts`: including `ensDeployment` config param
4. `apps/ensindexer/src/config/config.schema.ts`: moved all derive functionality into its own file
5. `apps/ensindexer/src/config/derived-params.ts`: derive functionality for `isSubgraphCompatible` (moved), and `ensDeployment` (newly added)

Resolves:
- #757 