### PR TITLE
fix(ci): use inline values for the `test-ci` workflow

### DIFF
--- a/.changeset/hip-melons-arrive.md
+++ b/.changeset/hip-melons-arrive.md
@@ -1,0 +1,6 @@
+---
+"@ensnode/ens-deployments": patch
+"@ensnode/ensnode-sdk": patch
+---
+
+Fix references across monorepo dependencies.

--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -65,6 +65,12 @@ jobs:
       # be rate limits hit but we do not care for those.
       - name: Run ENSIndexer runtime integrity checks
         env:
+          # Note on managing below configuration with GitHub:
+          # If we decide to have these inline values replaced with GitHub managed ones,
+          # we’d need to use GitHub Repository Variables to allow workflow runs
+          # against forked repositories. Using GitHub Repository Secrets won't work,
+          # as secrets can only be provided to workflows running against
+          # the very repository they were defined on.
           ACTIVE_PLUGINS: subgraph,basenames,lineanames,threedns
           RPC_URL_1: https://eth.drpc.org
           RPC_URL_10: https://optimism.drpc.org

--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -71,8 +71,8 @@ jobs:
           RPC_URL_8453: https://base.drpc.org
           RPC_URL_59144: https://linea.drpc.org
           HEALTH_CHECK_TIMEOUT: 60
-          ENSRAINBOW_URL: ${{ secrets.ENSRAINBOW_URL }}
-          ENSNODE_PUBLIC_URL: ${{ secrets.ENSNODE_PUBLIC_URL }}
+          ENSRAINBOW_URL: https://api.ensrainbow.io
+          ENSNODE_PUBLIC_URL: http://localhost:42069
         run: |
           chmod +x ./.github/scripts/run_ensindexer_healthcheck.sh
           ./.github/scripts/run_ensindexer_healthcheck.sh

--- a/packages/ens-deployments/package.json
+++ b/packages/ens-deployments/package.json
@@ -35,7 +35,7 @@
     "lint:ci": "biome ci"
   },
   "peerDependencies": {
-    "viem": "^catalog:"
+    "viem": "catalog:"
   },
   "devDependencies": {
     "@biomejs/biome": "catalog:",

--- a/packages/ensnode-sdk/package.json
+++ b/packages/ensnode-sdk/package.json
@@ -40,7 +40,7 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
-    "viem": "^catalog:"
+    "viem": "catalog:"
   },
   "devDependencies": {
     "@biomejs/biome": "catalog:",


### PR DESCRIPTION
Solves an issue where secret value would not be provided when running the workflow for a branch from forked repo.

Example failed workflow run:
https://github.com/namehash/ensnode/actions/runs/15565570790/job/43843278971

Also, this PR fixes references across monorepo dependencies:
```
 WARN  Issues with peer dependencies found
.
├─┬ @ensnode/ensrainbow-sdk 0.27.0
│ └── ✕ missing peer viem@^2.22.13
└─┬ @ensnode/utils 0.27.0
  └── ✕ missing peer viem@^catalog:
✕ Conflicting peer dependencies:
  viem  
  ```

The PR replaces PNPM `catalog` references, as these were not always properly resolved during package build process. Example for `^catalog:` reference not being replace, while all `catalog:` references were replaced correctly for this particular `package.json` file:
https://github.com/namehash/ensnode/blob/v0.27.0/packages/ensnode-utils/package.json#L38-L49

NPM code preview:
https://www.npmjs.com/package/@ensnode/utils?activeTab=code
<details>
<summary>Preview</summary>

![image](https://github.com/user-attachments/assets/198aaad1-83eb-4b7a-bd5e-8f6f05d08eb7)
</details> 

Related to #776 