### PR TITLE
improved bullet styles for docs

### DIFF
--- a/docs/ensnode.io/src/content/docs/docs/concepts/what-is-ensnode.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/concepts/what-is-ensnode.mdx
@@ -45,6 +45,7 @@ ENSNode version 1 (`V1`), discussed here, prioritizes equivalency with the [ENS 
    - `@ponder/client` for efficent client-side live queries
 
 4. **Self-hostable Decentralization Approach**
+
    - Self-hostable infrastructure
    - Bring-your-own Postgres
    - Bring-your-own ENSRainbow

--- a/docs/ensnode.io/src/content/docs/docs/concepts/what-is-the-ens-subgraph.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/concepts/what-is-the-ens-subgraph.mdx
@@ -45,11 +45,11 @@ This server is running [Graph Node version 0.33.0](https://github.com/graphproto
 
 ## NameHash Labs Hosted ENS Subgraphs
 
-Our Graph Node instance indexes the ENS Subgraph. The live status can be monitored with [the indexing status API endpoint](https://graphnode.namehashlabs.org:8030/graphql/playground?query=%7B%0A%20%20indexingStatuses%20%7B%0A%20%20%20%20subgraph%0A%20%20%20%20health%0A%20%20%20%20historyBlocks%0A%20%20%20%20paused%0A%20%20%20%20synced%0A%20%20%20%20chains%20%7B%0A%20%20%20%20%20%20network%0A%20%20%20%20%20%20chainHeadBlock%20%7B%0A%20%20%20%20%20%20%20%20number%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20latestBlock%20%7B%0A%20%20%20%20%20%20%20%20number%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D).
-Subgraph Id: QmVsj1tYQ84DZH3NHAbZKjQ5agQ5Gt6VusUBf67CU32FWP
+Our Graph Node instance indexes the ENS Subgraph. The live status can be monitored with [the indexing status API endpoint](https://graphnode.namehashlabs.org:8030/graphql/playground?query=%7B%0A%20%20indexingStatuses%20%7B%0A%20%20%20%20subgraph%0A%20%20%20%20health%0A%20%20%20%20historyBlocks%0A%20%20%20%20paused%0A%20%20%20%20synced%0A%20%20%20%20chains%20%7B%0A%20%20%20%20%20%20network%0A%20%20%20%20%20%20chainHeadBlock%20%7B%0A%20%20%20%20%20%20%20%20number%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20latestBlock%20%7B%0A%20%20%20%20%20%20%20%20number%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D). Subgraph ID: `QmVsj1tYQ84DZH3NHAbZKjQ5agQ5Gt6VusUBf67CU32FWP`
 
-- As of the time of writing this wiki page:
-  - This is the latest version of the ENS Subgraph, published [Feb 15, 2024](https://github.com/graphprotocol/ens-subgraph/commit/c8447914e8743671fb4b20cffe5a0a97020b3cee).
+As of the time of writing this wiki page:
+
+- This is the latest version of the ENS Subgraph, published [Feb 15, 2024](https://github.com/graphprotocol/ens-subgraph/commit/c8447914e8743671fb4b20cffe5a0a97020b3cee).
 - The subgraph is fully synced with the latest block on mainnet.
 - [Interactive GraphiQL Explorer](https://graphnode.namehashlabs.org:8000/subgraphs/name/namehash/ens-subgraph-2/graphql)
 

--- a/docs/ensnode.io/src/styles/starlight.css
+++ b/docs/ensnode.io/src/styles/starlight.css
@@ -8,8 +8,7 @@
 @theme {
   /* Reference global design tokens */
   --font-sans: var(--font-primary);
-  --font-mono: ui-monospace, "SFMono-Regular", "Consolas", "Liberation Mono",
-    "Menlo", monospace;
+  --font-mono: ui-monospace, "SFMono-Regular", "Consolas", "Liberation Mono", "Menlo", monospace;
 
   /* Accent colors based on global primary */
   --color-accent-50: #f0f8fb;

--- a/docs/ensnode.io/src/styles/starlight.css
+++ b/docs/ensnode.io/src/styles/starlight.css
@@ -8,7 +8,8 @@
 @theme {
   /* Reference global design tokens */
   --font-sans: var(--font-primary);
-  --font-mono: ui-monospace, "SFMono-Regular", "Consolas", "Liberation Mono", "Menlo", monospace;
+  --font-mono: ui-monospace, "SFMono-Regular", "Consolas", "Liberation Mono",
+    "Menlo", monospace;
 
   /* Accent colors based on global primary */
   --color-accent-50: #f0f8fb;
@@ -151,13 +152,24 @@ a[rel="prev"]:hover {
   display: inline;
 }
 
-/* List styles using Tailwind @apply */
 .sl-markdown-content ul {
-  @apply list-disc list-inside space-y-1 ml-4 mb-4 text-gray-700;
+  list-style: disc;
+  color: var(--sl-color-text);
 }
 
+.sl-markdown-content ol {
+  list-style: decimal;
+  color: var(--sl-color-text);
+}
+
+.sl-markdown-content ol li::marker,
 .sl-markdown-content ul li::marker {
-  @apply text-accent-500;
+  color: var(--sl-color-accent);
+}
+
+/* Nested ul inside ol li should have small top margin */
+.sl-markdown-content ol li ul {
+  margin-top: 0.25rem;
 }
 
 /* Pagination styles */


### PR DESCRIPTION
The previous PR made way to actually improve the bullet styles the way we want them. The styles now look much better across the docs:

![CleanShot 2025-06-16 at 12 53 50@2x](https://github.com/user-attachments/assets/18b5e2df-f79e-41c4-9dba-d379b424f219)
![CleanShot 2025-06-16 at 13 01 09@2x](https://github.com/user-attachments/assets/d56ae917-3d07-46b7-b73d-5e7cd12ec90c)
![CleanShot 2025-06-16 at 13 01 18@2x](https://github.com/user-attachments/assets/aa227545-4573-46b1-95bf-cd5bce73e21b)
![CleanShot 2025-06-16 at 13 01 56@2x](https://github.com/user-attachments/assets/acbb885b-fb16-4889-a214-2d43fba77cc1)
