### PR TITLE
fix: rename ENSNamespace to ENSNamespaceId, and DatasourceMap to ENSNamespace

### DIFF
--- a/apps/ensadmin/src/components/ensnode/types.ts
+++ b/apps/ensadmin/src/components/ensnode/types.ts
@@ -1,4 +1,4 @@
-import type { ENSNamespace } from "@ensnode/datasources";
+import type { ENSNamespaceId } from "@ensnode/datasources";
 import { PluginName } from "@ensnode/ensnode-sdk";
 import type * as PonderMetadata from "@ensnode/ponder-metadata";
 
@@ -18,7 +18,7 @@ export namespace EnsNode {
     env: {
       ACTIVE_PLUGINS: Array<PluginName>;
       DATABASE_SCHEMA: string;
-      NAMESPACE: ENSNamespace;
+      NAMESPACE: ENSNamespaceId;
     };
   }
 

--- a/apps/ensadmin/src/components/indexing-status/view-models.ts
+++ b/apps/ensadmin/src/components/indexing-status/view-models.ts
@@ -1,6 +1,6 @@
 import type { EnsNode } from "@/components/ensnode";
 import { getChainById } from "@/lib/chains";
-import { type ENSNamespace } from "@ensnode/datasources";
+import { type ENSNamespaceId } from "@ensnode/datasources";
 import { fromUnixTime } from "date-fns";
 /**
  * Basic information about a block and its date.
@@ -49,7 +49,7 @@ export interface GlobalIndexingStatusViewModel {
  */
 export function globalIndexingStatusViewModel(
   networkIndexingStatus: Record<number, EnsNode.NetworkIndexingStatus>,
-  namespace: ENSNamespace,
+  namespace: ENSNamespaceId,
 ): GlobalIndexingStatusViewModel {
   const indexingStartDatesAcrossNetworks = Object.values(networkIndexingStatus).map(
     (status) => status.firstBlockToIndex.timestamp,

--- a/apps/ensadmin/src/lib/chains.ts
+++ b/apps/ensadmin/src/lib/chains.ts
@@ -1,21 +1,21 @@
-import { Datasource, type ENSNamespace, getDatasourceMap } from "@ensnode/datasources";
+import { Datasource, type ENSNamespaceId, getENSNamespace } from "@ensnode/datasources";
 import { type Chain } from "viem";
 
 /**
  * Get a chain object by ID within the context of a specific namespace.
  *
- * @param namespace - the namespace identifier within which to find a chain
+ * @param namespaceId - the namespace identifier within which to find a chain
  * @param chainId the chain ID
  * @returns the viem#Chain object
  * @throws if no Datasources are defined for chainId within the selected namespace
  */
-export const getChainById = (namespace: ENSNamespace, chainId: number): Chain => {
-  const datasources = Object.values(getDatasourceMap(namespace)) as Datasource[];
+export const getChainById = (namespaceId: ENSNamespaceId, chainId: number): Chain => {
+  const datasources = Object.values(getENSNamespace(namespaceId)) as Datasource[];
   const datasource = datasources.find((datasource) => datasource.chain.id === chainId);
 
   if (!datasource) {
     throw new Error(
-      `No Datasources within the "${namespace}" namespace are defined for Chain ID "${chainId}".`,
+      `No Datasources within the "${namespaceId}" namespace are defined for Chain ID "${chainId}".`,
     );
   }
 

--- a/apps/ensindexer/.env.local.example
+++ b/apps/ensindexer/.env.local.example
@@ -45,7 +45,7 @@ DATABASE_SCHEMA=production
 DATABASE_URL=postgresql://dbuser:abcd1234@localhost:5432/my_database
 
 # ENS Namespace Configuration
-# An ENS namespace's identifier (see `@ensnode/datasources` for available options).
+# An ENS namespace's Identifier (see `@ensnode/datasources` for available options).
 NAMESPACE=mainnet
 
 # Plugin Configuration

--- a/apps/ensindexer/src/config/config.schema.ts
+++ b/apps/ensindexer/src/config/config.schema.ts
@@ -18,7 +18,7 @@ import {
   DEFAULT_RPC_RATE_LIMIT,
 } from "@/lib/lib-config";
 import { uniq } from "@/lib/lib-helpers";
-import { ENSNamespaces } from "@ensnode/datasources";
+import { ENSNamespaceIds } from "@ensnode/datasources";
 import { PluginName } from "@ensnode/ensnode-sdk";
 
 const chainIdSchema = z.number().int().min(1);
@@ -56,9 +56,9 @@ const RpcConfigSchema = z.object({
 });
 
 const ENSNamespaceSchema = z
-  .enum(ENSNamespaces, {
+  .enum(ENSNamespaceIds, {
     error: (issue) => {
-      return `Invalid NAMESPACE. Supported ENS namespaces are: ${Object.keys(ENSNamespaces).join(", ")}`;
+      return `Invalid NAMESPACE. Supported ENS namespaces are: ${Object.keys(ENSNamespaceIds).join(", ")}`;
     },
   })
   .default(DEFAULT_NAMESPACE);

--- a/apps/ensindexer/src/config/types.ts
+++ b/apps/ensindexer/src/config/types.ts
@@ -1,5 +1,5 @@
 import { Blockrange } from "@/lib/types";
-import type { ENSNamespace, ENSNamespaces } from "@ensnode/datasources";
+import type { ENSNamespaceId, ENSNamespaceIds } from "@ensnode/datasources";
 import type { PluginName } from "@ensnode/ensnode-sdk";
 
 /**
@@ -32,9 +32,9 @@ export interface ENSIndexerConfig {
   /**
    * The ENS namespace that ENSNode operates in the context of, defaulting to 'mainnet' (DEFAULT_NAMESPACE).
    *
-   * See {@link ENSNamespaces} for available namespace identifiers.
+   * See {@link ENSNamespaceIds} for available namespace identifiers.
    */
-  namespace: ENSNamespace;
+  namespace: ENSNamespaceId;
 
   /**
    * An ENSAdmin url, defaulting to the public instance https://admin.ensnode.io (DEFAULT_ENSADMIN_URL).

--- a/apps/ensindexer/src/config/validations.ts
+++ b/apps/ensindexer/src/config/validations.ts
@@ -4,7 +4,7 @@ import { z } from "zod/v4";
 
 import type { ENSIndexerConfig } from "@/config/types";
 import { uniq } from "@/lib/lib-helpers";
-import { getDatasourceMapAsFullyDefinedAtCompileTime } from "@/lib/plugin-helpers";
+import { getENSNamespaceAsFullyDefinedAtCompileTime } from "@/lib/plugin-helpers";
 import { getPlugin } from "@/plugins";
 
 // type alias to highlight the input param of Zod's check() method
@@ -16,7 +16,7 @@ export function invariant_requiredDatasources(
 ) {
   const { value: config } = ctx;
 
-  const datasources = getDatasourceMapAsFullyDefinedAtCompileTime(config.namespace);
+  const datasources = getENSNamespaceAsFullyDefinedAtCompileTime(config.namespace);
   const availableDatasourceNames = Object.keys(datasources) as DatasourceName[];
   const activePluginNames = config.plugins;
 
@@ -49,7 +49,7 @@ export function invariant_rpcConfigsSpecifiedForIndexedChains(
 ) {
   const { value: config } = ctx;
 
-  const datasources = getDatasourceMapAsFullyDefinedAtCompileTime(config.namespace);
+  const datasources = getENSNamespaceAsFullyDefinedAtCompileTime(config.namespace);
 
   for (const pluginName of config.plugins) {
     const datasourceNames = getPlugin(pluginName).requiredDatasources;
@@ -76,7 +76,7 @@ export function invariant_globalBlockrange(
   const { globalBlockrange } = config;
 
   if (globalBlockrange.startBlock !== undefined || globalBlockrange.endBlock !== undefined) {
-    const datasources = getDatasourceMapAsFullyDefinedAtCompileTime(config.namespace);
+    const datasources = getENSNamespaceAsFullyDefinedAtCompileTime(config.namespace);
     const indexedChainIds = uniq(
       config.plugins
         .flatMap((pluginName) => getPlugin(pluginName).requiredDatasources)
@@ -111,7 +111,7 @@ export function invariant_validContractConfigs(
 ) {
   const { value: config } = ctx;
 
-  const datasources = getDatasourceMapAsFullyDefinedAtCompileTime(config.namespace);
+  const datasources = getENSNamespaceAsFullyDefinedAtCompileTime(config.namespace);
   for (const datasourceName of Object.keys(datasources) as DatasourceName[]) {
     const { contracts } = datasources[datasourceName];
 

--- a/apps/ensindexer/src/plugins/basenames/lib/registrar-helpers.ts
+++ b/apps/ensindexer/src/plugins/basenames/lib/registrar-helpers.ts
@@ -1,16 +1,16 @@
 import type { RegistrarManagedName } from "@/lib/types";
-import type { ENSNamespace } from "@ensnode/datasources";
+import type { ENSNamespaceId } from "@ensnode/datasources";
 
 /**
  * Get registrar managed name for `basenames` plugin for selected ENS namespace.
  *
- * @param namespace
+ * @param namespaceId
  * @param pluginName
  * @returns registrar managed name
  * @throws an error when no registrar managed name could be returned
  */
-export function getRegistrarManagedName(namespace: ENSNamespace): RegistrarManagedName {
-  switch (namespace) {
+export function getRegistrarManagedName(namespaceId: ENSNamespaceId): RegistrarManagedName {
+  switch (namespaceId) {
     case "mainnet":
       return "base.eth";
     case "sepolia":
@@ -18,7 +18,7 @@ export function getRegistrarManagedName(namespace: ENSNamespace): RegistrarManag
     case "holesky":
     case "ens-test-env":
       throw new Error(
-        `No registrar managed name is known for the Basenames plugin within the "${namespace}" namespace.`,
+        `No registrar managed name is known for the Basenames plugin within the "${namespaceId}" namespace.`,
       );
   }
 }

--- a/apps/ensindexer/src/plugins/lineanames/lib/registrar-helpers.ts
+++ b/apps/ensindexer/src/plugins/lineanames/lib/registrar-helpers.ts
@@ -1,16 +1,16 @@
 import type { RegistrarManagedName } from "@/lib/types";
-import type { ENSNamespace } from "@ensnode/datasources";
+import type { ENSNamespaceId } from "@ensnode/datasources";
 
 /**
  * Get registrar managed name for `lineanames` plugin for selected ENS namespace.
  *
- * @param namespace
+ * @param namespaceId
  * @param pluginName
  * @returns registrar managed name
  * @throws an error when no registrar managed name could be returned
  */
-export function getRegistrarManagedName(namespace: ENSNamespace): RegistrarManagedName {
-  switch (namespace) {
+export function getRegistrarManagedName(namespaceId: ENSNamespaceId): RegistrarManagedName {
+  switch (namespaceId) {
     case "mainnet":
       return "linea.eth";
     case "sepolia":
@@ -18,7 +18,7 @@ export function getRegistrarManagedName(namespace: ENSNamespace): RegistrarManag
     case "holesky":
     case "ens-test-env":
       throw new Error(
-        `No registrar managed name is known for the Linea Names plugin within the "${namespace}" namespace.`,
+        `No registrar managed name is known for the Linea Names plugin within the "${namespaceId}" namespace.`,
       );
   }
 }

--- a/packages/datasources/README.md
+++ b/packages/datasources/README.md
@@ -38,7 +38,7 @@ const vitaliksResolverAddress = await publicClient.readContract({
 
 ## Documentation
 
-### getDatasource(namespace: ENSNamespace, datasourceName: DatasourceName)
+### getDatasource(namespaceId: ENSNamespaceId, datasourceName: DatasourceName)
 
 The primary export of `@ensnode/datasources` is `getDatasource` which returns a selected `Datasource` within the selected ENS namespace.
 
@@ -55,7 +55,7 @@ const { chain, contracts } = getDatasource('holesky', 'ensroot');
 const { chain, contracts } = getDatasource('mainnet', 'threedns-base');
 ```
 
-The available `ENSNamespace`s are:
+The available `ENSNamespaceId`s are:
 - `mainnet`
 - `sepolia`
 - `holesky`
@@ -66,11 +66,11 @@ The available `ENSNamespace`s are:
 Each ENS namespace my provide **Datasource** entries for any of the possible **DatasourceName**s:
 
 The available `DatasourceName`s are:
-- `ensroot` — ENS Root Contracts
-- `basenames` — Basenames
-- `lineanames` — Linea Names
-- `threedns-optimism` — 3DNS (on Optimism)
-- `threedns-base` — 3DNS (on Base)
+- `ensroot` — ENS Root Contracts, guaranteed to exist
+- `basenames` — Basenames, optional
+- `lineanames` — Linea Names, optional
+- `threedns-optimism` — 3DNS (on Optimism), optional
+- `threedns-base` — 3DNS (on Base), optional
 
 A `Datasource` will only be available within an ENS namespace if it is defined, and typescript will enforce that a valid DatasourceName is used within `getDatasource(...)`.
 

--- a/packages/datasources/src/ens-test-env.ts
+++ b/packages/datasources/src/ens-test-env.ts
@@ -2,9 +2,9 @@ import { Address } from "viem";
 import { anvil } from "viem/chains";
 
 import { ResolverConfig } from "./lib/resolver";
-import { type DatasourceMap, DatasourceNames } from "./lib/types";
+import { DatasourceNames, type ENSNamespace } from "./lib/types";
 
-// ABIs for Root Datasource
+// ABIs for ENSRoot Datasource
 import { BaseRegistrar as root_BaseRegistrar } from "./abis/root/BaseRegistrar";
 import { EthRegistrarController as root_EthRegistrarController } from "./abis/root/EthRegistrarController";
 import { EthRegistrarControllerOld as root_EthRegistrarControllerOld } from "./abis/root/EthRegistrarControllerOld";
@@ -17,7 +17,7 @@ const deploymentAddresses = getENSTestEnvDeploymentAddresses();
 const EMPTY_ADDRESS = "" as Address;
 
 /**
- * Datasources for the ens-test-env ENS namespace
+ * The ens-test-env ENSNamespace
  *
  * 'ens-test-env' represents an ENS namespace running on a local Anvil chain for development of
  * ENS apps and running test suites against a deterministic deployment of the ENS protocol.
@@ -38,7 +38,7 @@ const EMPTY_ADDRESS = "" as Address;
  */
 export default {
   /**
-   * Root Datasource
+   * ENSRoot Datasource
    *
    * Addresses and Start Blocks from ens-test-env
    * https://github.com/ensdomains/ens-test-env/
@@ -86,4 +86,4 @@ export default {
   /**
    * The 'ens-test-env' ENS namespace does not have any other Datasources.
    */
-} satisfies DatasourceMap;
+} satisfies ENSNamespace;

--- a/packages/datasources/src/holesky.ts
+++ b/packages/datasources/src/holesky.ts
@@ -1,9 +1,9 @@
 import { holesky } from "viem/chains";
 
 import { ResolverConfig } from "./lib/resolver";
-import { type DatasourceMap, DatasourceNames } from "./lib/types";
+import { DatasourceNames, type ENSNamespace } from "./lib/types";
 
-// ABIs for Root Datasource
+// ABIs for ENSRoot Datasource
 import { BaseRegistrar as root_BaseRegistrar } from "./abis/root/BaseRegistrar";
 import { EthRegistrarController as root_EthRegistrarController } from "./abis/root/EthRegistrarController";
 import { EthRegistrarControllerOld as root_EthRegistrarControllerOld } from "./abis/root/EthRegistrarControllerOld";
@@ -11,11 +11,11 @@ import { NameWrapper as root_NameWrapper } from "./abis/root/NameWrapper";
 import { Registry as root_Registry } from "./abis/root/Registry";
 
 /**
- * Datasources for the Holesky ENS namespace
+ * The Holesky ENSNamespace
  */
 export default {
   /**
-   * Root Datasource
+   * ENSRoot Datasource
    *
    * Addresses and Start Blocks from ENS Holesky Subgraph Manifest
    * https://ipfs.io/ipfs/Qmd94vseLpkUrSFvJ3GuPubJSyHz8ornhNrwEAt6pjcbex
@@ -62,4 +62,4 @@ export default {
   /**
    * The Holesky ENS namespace has no known Datasource for Basenames or Lineanames.
    */
-} satisfies DatasourceMap;
+} satisfies ENSNamespace;

--- a/packages/datasources/src/index.ts
+++ b/packages/datasources/src/index.ts
@@ -1,4 +1,4 @@
-import { DatasourceMap, DatasourceNames, ENSNamespace } from "./lib/types";
+import { DatasourceNames, ENSNamespace, ENSNamespaceId } from "./lib/types";
 
 import ensTestEnv from "./ens-test-env";
 import holesky from "./holesky";
@@ -7,46 +7,46 @@ import sepolia from "./sepolia";
 
 export * from "./lib/types";
 
-// internal map ENSNamespace -> DatasourceMap
-const ENSNamespaceToDatasourceMap = {
+// internal map ENSNamespaceId -> ENSNamespace
+const ENSNamespacesById = {
   mainnet,
   sepolia,
   holesky,
   "ens-test-env": ensTestEnv,
-} as const satisfies Record<ENSNamespace, DatasourceMap>;
+} as const satisfies Record<ENSNamespaceId, ENSNamespace>;
 
 /**
- * Returns the DatasourceMap within the specified namespace.
+ * Returns the ENSNamespace for a specified `namespaceId`.
  *
- * @param namespace - The ENSNamespace identifier (e.g. 'mainnet', 'sepolia', 'holesky', 'ens-test-env')
- * @returns The DatasourceMap for the specified namespace
+ * @param namespaceId - The ENSNamespace identifier (e.g. 'mainnet', 'sepolia', 'holesky', 'ens-test-env')
+ * @returns the ENSNamespace
  */
-export const getDatasourceMap = <T extends ENSNamespace>(
-  namespace: T,
-): (typeof ENSNamespaceToDatasourceMap)[T] => ENSNamespaceToDatasourceMap[namespace];
+export const getENSNamespace = <T extends ENSNamespaceId>(
+  namespaceId: T,
+): (typeof ENSNamespacesById)[T] => ENSNamespacesById[namespaceId];
 
 /**
- * Returns the `datasourceName` Datasource within the specified `namespace` namespace.
+ * Returns the `datasourceName` Datasource within the specified `namespaceId` namespace.
  *
  * NOTE: the typescript typechecker _will_ enforce validity. i.e. using an invalid `datasourceName`
- * within the specified `namespace` will be a type error.
+ * within the specified `namespaceId` will be a type error.
  *
- * @param namespace - The ENSNamespace identifier (e.g. 'mainnet', 'sepolia', 'holesky', 'ens-test-env')
+ * @param namespaceId - The ENSNamespace identifier (e.g. 'mainnet', 'sepolia', 'holesky', 'ens-test-env')
  * @param datasourceName - The name of the Datasource to retrieve
  * @returns The Datasource object for the given name within the specified namespace
  */
 export const getDatasource = <
-  N extends ENSNamespace,
-  D extends keyof ReturnType<typeof getDatasourceMap<N>>,
+  N extends ENSNamespaceId,
+  D extends keyof ReturnType<typeof getENSNamespace<N>>,
 >(
-  namespace: N,
+  namespaceId: N,
   datasourceName: D,
-) => getDatasourceMap(namespace)[datasourceName];
+) => getENSNamespace(namespaceId)[datasourceName];
 
 /**
  * Returns the chain id for the ENS Root Datasource within the selected namespace.
  *
  * @returns the chain ID that hosts the ENS Root
  */
-export const getENSRootChainId = (namespace: ENSNamespace) =>
-  getDatasource(namespace, DatasourceNames.ENSRoot).chain.id;
+export const getENSRootChainId = (namespaceId: ENSNamespaceId) =>
+  getDatasource(namespaceId, DatasourceNames.ENSRoot).chain.id;

--- a/packages/datasources/src/lib/types.ts
+++ b/packages/datasources/src/lib/types.ts
@@ -1,7 +1,7 @@
 import type { Abi, Address, Chain } from "viem";
 
 /**
- * ENSNamespaces encodes the set of well-known ENS namespaces.
+ * ENSNamespaceIds encodes the set of identifiers for well-known ENS namespaces.
  *
  * Each ENS namespace is a single, unified set of ENS names with a distinct onchain root
  * Registry (the ensroot Datasource) and the capability of spanning from that root Registry across
@@ -26,7 +26,7 @@ import type { Abi, Address, Chain } from "viem";
  * protocol changes, running deterministic test suites, and local development.
  * https://github.com/ensdomains/ens-test-env
  */
-export const ENSNamespaces = {
+export const ENSNamespaceIds = {
   Mainnet: "mainnet",
   Sepolia: "sepolia",
   Holesky: "holesky",
@@ -34,9 +34,9 @@ export const ENSNamespaces = {
 } as const;
 
 /**
- * ENSNamespace is the derived string union of possible ENSNamespace values.
+ * ENSNamespaceId is the derived string union of possible ENS namespace identifiers.
  */
-export type ENSNamespace = (typeof ENSNamespaces)[keyof typeof ENSNamespaces];
+export type ENSNamespaceId = (typeof ENSNamespaceIds)[keyof typeof ENSNamespaceIds];
 
 /**
  * A Datasource describes a set of contracts on a given chain that interact with the ENS protocol.
@@ -95,9 +95,10 @@ export type ContractConfig =
     };
 
 /**
- * DatasourceMap encodes the set of known Datasources within an ENS namespace, keyed by DatasourceName.
+ * ENSNamespace encodes a set of known Datasources, together constituting an ENS namespace.
+ *
  * The ENSRoot Datasource is required, and all others are optional.
  */
-export type DatasourceMap = {
+export type ENSNamespace = {
   [DatasourceNames.ENSRoot]: Datasource;
 } & Partial<Record<Exclude<DatasourceName, "ensroot">, Datasource>>;

--- a/packages/datasources/src/mainnet.ts
+++ b/packages/datasources/src/mainnet.ts
@@ -1,8 +1,8 @@
 import { base, linea, mainnet, optimism } from "viem/chains";
 
-import { type DatasourceMap, DatasourceNames } from "./lib/types";
+import { DatasourceNames, type ENSNamespace } from "./lib/types";
 
-// ABIs for Root Datasource
+// ABIs for ENSRoot Datasource
 import { BaseRegistrar as root_BaseRegistrar } from "./abis/root/BaseRegistrar";
 import { EthRegistrarController as root_EthRegistrarController } from "./abis/root/EthRegistrarController";
 import { EthRegistrarControllerOld as root_EthRegistrarControllerOld } from "./abis/root/EthRegistrarControllerOld";
@@ -24,11 +24,11 @@ import { ThreeDNSToken } from "./abis/threedns/ThreeDNSToken";
 import { ResolverConfig } from "./lib/resolver";
 
 /**
- * Datasources for the Mainnet ENS namespace
+ * The Mainnet ENSNamespace
  */
 export default {
   /**
-   * Root Datasource
+   * ENSRoot Datasource
    *
    * Addresses and Start Blocks from ENS Mainnet Subgraph Manifest
    * https://ipfs.io/ipfs/Qmd94vseLpkUrSFvJ3GuPubJSyHz8ornhNrwEAt6pjcbex
@@ -216,4 +216,4 @@ export default {
       },
     },
   },
-} satisfies DatasourceMap;
+} satisfies ENSNamespace;

--- a/packages/datasources/src/sepolia.ts
+++ b/packages/datasources/src/sepolia.ts
@@ -1,9 +1,9 @@
 import { baseSepolia, lineaSepolia, sepolia } from "viem/chains";
 
 import { ResolverConfig } from "./lib/resolver";
-import { type DatasourceMap, DatasourceNames } from "./lib/types";
+import { DatasourceNames, type ENSNamespace } from "./lib/types";
 
-// ABIs for Root Datasource
+// ABIs for ENSRoot Datasource
 import { BaseRegistrar as root_BaseRegistrar } from "./abis/root/BaseRegistrar";
 import { EthRegistrarController as root_EthRegistrarController } from "./abis/root/EthRegistrarController";
 import { EthRegistrarControllerOld as root_EthRegistrarControllerOld } from "./abis/root/EthRegistrarControllerOld";
@@ -23,11 +23,11 @@ import { NameWrapper as linea_NameWrapper } from "./abis/lineanames/NameWrapper"
 import { Registry as linea_Registry } from "./abis/lineanames/Registry";
 
 /**
- * Datasources for the Sepolia ENS namespace
+ * The Sepolia ENSNamespace
  */
 export default {
   /**
-   * Root Datasource
+   * ENSRoot Datasource
    *
    * Addresses and Start Blocks from ENS Sepolia Subgraph Manifest
    * https://ipfs.io/ipfs/QmdDtoN9QCRsBUsyoiiUUMQPPmPp5jimUQe81828UyWLtg
@@ -173,4 +173,4 @@ export default {
       },
     },
   },
-} satisfies DatasourceMap;
+} satisfies ENSNamespace;


### PR DESCRIPTION
- don't think it needs a changelog, is bundled with previous rename, also is internal
- keeping the public-facing configuration value as `namespace` for clarity/readability
- internally using `namespaceId` where appropriate
- updated all docs i could find