### PR TITLE
rename ACTIVE_PLUGINS to PLUGINS

### DIFF
--- a/.changeset/smart-wolves-flow.md
+++ b/.changeset/smart-wolves-flow.md
@@ -1,0 +1,5 @@
+---
+"ensindexer": minor
+---
+
+ACTIVE_PLUGINS is now PLUGINS

--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -71,7 +71,7 @@ jobs:
           # against forked repositories. Using GitHub Repository Secrets won't work,
           # as secrets can only be provided to workflows running against
           # the very repository they were defined on.
-          ACTIVE_PLUGINS: subgraph,basenames,lineanames,threedns
+          PLUGINS: subgraph,basenames,lineanames,threedns
           RPC_URL_1: https://eth.drpc.org
           RPC_URL_10: https://optimism.drpc.org
           RPC_URL_8453: https://base.drpc.org

--- a/apps/ensadmin/src/components/ensnode/types.ts
+++ b/apps/ensadmin/src/components/ensnode/types.ts
@@ -16,7 +16,7 @@ export namespace EnsNode {
   export interface Metadata extends Omit<PonderMetadata.MetadataMiddlewareResponse, "env"> {
     // override the `env` field to include the fields required by the ENSAdmin client
     env: {
-      ACTIVE_PLUGINS: Array<PluginName>;
+      PLUGINS: Array<PluginName>;
       DATABASE_SCHEMA: string;
       NAMESPACE: ENSNamespaceId;
     };

--- a/apps/ensadmin/src/components/indexing-status/view-models.test.ts
+++ b/apps/ensadmin/src/components/indexing-status/view-models.test.ts
@@ -30,7 +30,7 @@ describe("View Models", () => {
   describe("ensNodeEnvViewModel", () => {
     it("should return the correct view model", () => {
       const result = ensNodeEnvViewModel({
-        ACTIVE_PLUGINS: [PluginName.Subgraph],
+        PLUGINS: [PluginName.Subgraph],
         DATABASE_SCHEMA: "public",
         NAMESPACE: "ens-test-env",
       });

--- a/apps/ensadmin/src/components/indexing-status/view-models.ts
+++ b/apps/ensadmin/src/components/indexing-status/view-models.ts
@@ -149,7 +149,7 @@ export function ensNodeDepsViewModel(deps: EnsNode.Metadata["deps"]) {
 
 export function ensNodeEnvViewModel(env: EnsNode.Metadata["env"]) {
   return [
-    { label: "Active Plugins", value: env.ACTIVE_PLUGINS },
+    { label: "Active Plugins", value: env.PLUGINS },
     { label: "ENS Namespace", value: env.NAMESPACE },
     { label: "Database Schema", value: env.DATABASE_SCHEMA },
   ] as const;

--- a/apps/ensindexer/.env.local.example
+++ b/apps/ensindexer/.env.local.example
@@ -51,8 +51,8 @@ NAMESPACE=mainnet
 # Plugin Configuration
 # Identify which indexer plugins to activate (see `src/plugins` for available plugins)
 # This is a comma separated list of one or more available plugin names (case-sensitive).
-# NOTE: for subgraph-compatible indexing, the only valid configuration is `ACTIVE_PLUGINS=subgraph`
-ACTIVE_PLUGINS=subgraph,basenames,lineanames,threedns
+# NOTE: for subgraph-compatible indexing, the only valid configuration is `PLUGINS=subgraph`
+PLUGINS=subgraph,basenames,lineanames,threedns
 
 # Unknown label healing
 # This is the URL of the ENSRainbow server that ENSIndexer will use to heal unknown labels.

--- a/apps/ensindexer/src/api/index.ts
+++ b/apps/ensindexer/src/api/index.ts
@@ -69,7 +69,7 @@ app.get(
       version: packageJson.version,
     },
     env: {
-      ACTIVE_PLUGINS: config.plugins.join(","),
+      PLUGINS: config.plugins.join(","),
       DATABASE_SCHEMA: config.ponderDatabaseSchema,
       NAMESPACE: config.namespace,
     },

--- a/apps/ensindexer/src/config/config.schema.ts
+++ b/apps/ensindexer/src/config/config.schema.ts
@@ -93,19 +93,19 @@ const PluginsSchema = z.coerce
     z
       .array(
         z.enum(PluginName, {
-          error: `ACTIVE_PLUGINS must be a comma separated list with at least one valid plugin name. Valid plugins are: ${Object.values(
+          error: `PLUGINS must be a comma separated list with at least one valid plugin name. Valid plugins are: ${Object.values(
             PluginName,
           ).join(", ")}`,
         }),
       )
       .min(1, {
-        error: `ACTIVE_PLUGINS must be a comma separated list with at least one valid plugin name. Valid plugins are: ${Object.values(
+        error: `PLUGINS must be a comma separated list with at least one valid plugin name. Valid plugins are: ${Object.values(
           PluginName,
         ).join(", ")}`,
       }),
   )
   .refine((arr) => arr.length === uniq(arr).length, {
-    error: "ACTIVE_PLUGINS cannot contain duplicate values",
+    error: "PLUGINS cannot contain duplicate values",
   });
 
 const HealReverseAddressesSchema = makeEnvStringBoolSchema("HEAL_REVERSE_ADDRESSES") //

--- a/apps/ensindexer/src/config/index.ts
+++ b/apps/ensindexer/src/config/index.ts
@@ -8,7 +8,7 @@ const environment = {
   ponderDatabaseSchema: process.env.DATABASE_SCHEMA,
   databaseUrl: process.env.DATABASE_URL,
   namespace: process.env.NAMESPACE,
-  plugins: process.env.ACTIVE_PLUGINS,
+  plugins: process.env.PLUGINS,
   ensRainbowEndpointUrl: process.env.ENSRAINBOW_URL,
   ensNodePublicUrl: process.env.ENSNODE_PUBLIC_URL,
   ensAdminUrl: process.env.ENSADMIN_URL,

--- a/apps/ensindexer/src/config/validations.ts
+++ b/apps/ensindexer/src/config/validations.ts
@@ -91,12 +91,12 @@ export function invariant_globalBlockrange(
         message: `ENSIndexer's behavior when indexing _multiple networks_ with a _specific blockrange_ is considered undefined (for now). If you're using this feature, you're likely interested in snapshotting at a specific END_BLOCK, and may have unintentially activated plugins that source events from multiple chains. The config currently is:
 
   NAMESPACE=${config.namespace}
-  ACTIVE_PLUGINS=${config.plugins.join(",")}
+  PLUGINS=${config.plugins.join(",")}
   START_BLOCK=${globalBlockrange.startBlock || "n/a"}
   END_BLOCK=${globalBlockrange.endBlock || "n/a"}
 
   The usage you're most likely interested in is:
-    NAMESPACE=(mainnet|sepolia|holesky) ACTIVE_PLUGINS=subgraph END_BLOCK=x pnpm run start
+    NAMESPACE=(mainnet|sepolia|holesky) PLUGINS=subgraph END_BLOCK=x pnpm run start
   which runs just the 'subgraph' plugin with a specific end block, suitable for snapshotting ENSNode and comparing to Subgraph snapshots.
 
   In the future, indexing multiple networks with network-specific blockrange constraints may be possible.`,

--- a/apps/ensindexer/src/lib/plugin-helpers.ts
+++ b/apps/ensindexer/src/lib/plugin-helpers.ts
@@ -62,7 +62,7 @@ export interface ENSIndexerPlugin<
 
   /**
    * A list of DatasourceNames this plugin requires access to, necessary for determining whether
-   * a set of ACTIVE_PLUGINS are valid for a given ENS Namespace
+   * a set of PLUGINS are valid for a given ENS Namespace
    */
   requiredDatasources: DatasourceName[];
 

--- a/apps/ensindexer/test/config.test.ts
+++ b/apps/ensindexer/test/config.test.ts
@@ -13,7 +13,7 @@ const BASE_ENV = {
   ENSNODE_PUBLIC_URL: "http://localhost:42069",
   ENSADMIN_URL: "https://admin.ensnode.io",
   DATABASE_SCHEMA: "ensnode",
-  ACTIVE_PLUGINS: "subgraph",
+  PLUGINS: "subgraph",
   HEAL_REVERSE_ADDRESSES: "true",
   PORT: "3000",
   ENSRAINBOW_URL: "https://api.ensrainbow.io",
@@ -308,51 +308,51 @@ describe("config", () => {
   });
 
   describe(".plugins", () => {
-    it("returns the ACTIVE_PLUGINS if it is a valid array", async () => {
-      vi.stubEnv("ACTIVE_PLUGINS", "subgraph,basenames");
+    it("returns the PLUGINS if it is a valid array", async () => {
+      vi.stubEnv("PLUGINS", "subgraph,basenames");
       vi.stubEnv("RPC_URL_8453", VALID_RPC_URL);
       const config = await getConfig();
       expect(config.plugins).toEqual(["subgraph", "basenames"]);
     });
 
     it("returns a single plugin if only one is provided", async () => {
-      vi.stubEnv("ACTIVE_PLUGINS", "basenames");
+      vi.stubEnv("PLUGINS", "basenames");
       vi.stubEnv("RPC_URL_8453", VALID_RPC_URL);
       const config = await getConfig();
       expect(config.plugins).toEqual(["basenames"]);
     });
 
-    it("throws if ACTIVE_PLUGINS is an empty string", async () => {
-      vi.stubEnv("ACTIVE_PLUGINS", "");
+    it("throws if PLUGINS is an empty string", async () => {
+      vi.stubEnv("PLUGINS", "");
       await expect(getConfig()).rejects.toThrow(
-        /ACTIVE_PLUGINS must be a comma separated list with at least one valid plugin name/i,
+        /PLUGINS must be a comma separated list with at least one valid plugin name/i,
       );
     });
 
-    it("throws if ACTIVE_PLUGINS consists only of commas or whitespace", async () => {
-      vi.stubEnv("ACTIVE_PLUGINS", " ,,  ,");
+    it("throws if PLUGINS consists only of commas or whitespace", async () => {
+      vi.stubEnv("PLUGINS", " ,,  ,");
       await expect(getConfig()).rejects.toThrow(
-        /ACTIVE_PLUGINS must be a comma separated list with at least one valid plugin name/i,
+        /PLUGINS must be a comma separated list with at least one valid plugin name/i,
       );
     });
 
-    it("throws if ACTIVE_PLUGINS consists of non-existent plugins", async () => {
-      vi.stubEnv("ACTIVE_PLUGINS", "some,nonexistent,plugins");
+    it("throws if PLUGINS consists of non-existent plugins", async () => {
+      vi.stubEnv("PLUGINS", "some,nonexistent,plugins");
       await expect(getConfig()).rejects.toThrow(
-        /ACTIVE_PLUGINS must be a comma separated list with at least one valid plugin name/i,
+        /PLUGINS must be a comma separated list with at least one valid plugin name/i,
       );
     });
 
-    it("throws if ACTIVE_PLUGINS is not set (undefined)", async () => {
-      vi.stubEnv("ACTIVE_PLUGINS", undefined);
+    it("throws if PLUGINS is not set (undefined)", async () => {
+      vi.stubEnv("PLUGINS", undefined);
       await expect(getConfig()).rejects.toThrow(
-        /ACTIVE_PLUGINS must be a comma separated list with at least one valid plugin name/i,
+        /PLUGINS must be a comma separated list with at least one valid plugin name/i,
       );
     });
 
-    it("throws if ACTIVE_PLUGINS contains duplicate values", async () => {
-      vi.stubEnv("ACTIVE_PLUGINS", "subgraph,basenames,subgraph");
-      await expect(getConfig()).rejects.toThrow(/ACTIVE_PLUGINS cannot contain duplicate values/i);
+    it("throws if PLUGINS contains duplicate values", async () => {
+      vi.stubEnv("PLUGINS", "subgraph,basenames,subgraph");
+      await expect(getConfig()).rejects.toThrow(/PLUGINS cannot contain duplicate values/i);
     });
   });
 
@@ -453,7 +453,7 @@ describe("config", () => {
   describe("isSubgraphCompatible", () => {
     // start in subgraph-compatible state
     beforeEach(() => {
-      vi.stubEnv("ACTIVE_PLUGINS", "subgraph");
+      vi.stubEnv("PLUGINS", "subgraph");
       vi.stubEnv("HEAL_REVERSE_ADDRESSES", "false");
       vi.stubEnv("INDEX_ADDITIONAL_RESOLVER_RECORDS", "false");
     });
@@ -463,15 +463,15 @@ describe("config", () => {
       expect(config.isSubgraphCompatible).toBe(true);
     });
 
-    it("is false when ACTIVE_PLUGINS does not include subgraph", async () => {
-      vi.stubEnv("ACTIVE_PLUGINS", "basenames");
+    it("is false when PLUGINS does not include subgraph", async () => {
+      vi.stubEnv("PLUGINS", "basenames");
       vi.stubEnv("RPC_URL_8453", VALID_RPC_URL);
       const config = await getConfig();
       expect(config.isSubgraphCompatible).toBe(false);
     });
 
-    it("is false when ACTIVE_PLUGINS includes subgraph along with other plugins", async () => {
-      vi.stubEnv("ACTIVE_PLUGINS", "subgraph,basenames");
+    it("is false when PLUGINS includes subgraph along with other plugins", async () => {
+      vi.stubEnv("PLUGINS", "subgraph,basenames");
       vi.stubEnv("RPC_URL_8453", VALID_RPC_URL);
       const config = await getConfig();
       expect(config.isSubgraphCompatible).toBe(false);
@@ -487,17 +487,17 @@ describe("config", () => {
   describe("additional checks", () => {
     it("requires available datasources", async () => {
       vi.stubEnv("NAMESPACE", "ens-test-env");
-      vi.stubEnv("ACTIVE_PLUGINS", "basenames");
+      vi.stubEnv("PLUGINS", "basenames");
       await expect(getConfig()).rejects.toThrow(/specifies dependent datasources/i);
     });
 
     it("requires rpc url for indexed chains", async () => {
-      vi.stubEnv("ACTIVE_PLUGINS", "subgraph,basenames");
+      vi.stubEnv("PLUGINS", "subgraph,basenames");
       await expect(getConfig()).rejects.toThrow(/RPC_URL_\d+ is not specified/i);
     });
 
     it("cannot constrain blockrange with multiple networks", async () => {
-      vi.stubEnv("ACTIVE_PLUGINS", "subgraph,basenames");
+      vi.stubEnv("PLUGINS", "subgraph,basenames");
       vi.stubEnv("RPC_URL_8453", VALID_RPC_URL);
       vi.stubEnv("END_BLOCK", "1");
       await expect(getConfig()).rejects.toThrow(/multiple networks/i);

--- a/terraform/modules/ensindexer/main.tf
+++ b/terraform/modules/ensindexer/main.tf
@@ -69,7 +69,7 @@ locals {
       value = var.database_schema
     },
     {
-      name  = "ACTIVE_PLUGINS"
+      name  = "PLUGINS"
       value = var.active_plugins
     },
     {


### PR DESCRIPTION
closes #731

- renamed ACTIVE_PLUGINS to PLUGINS
- kept 'active plugins' terminology within comments and variable names when the set of plugins is indeed the filtered set of active plugins