### PR TITLE
chore (ensadmin): fix ENSNamespace handling in `Latest indexed registrations` panel

### DIFF
--- a/apps/ensadmin/src/components/identity/index.tsx
+++ b/apps/ensadmin/src/components/identity/index.tsx
@@ -9,9 +9,21 @@ import { useEffect, useState } from "react";
 import type { Address } from "viem";
 import { useEnsName } from "wagmi";
 
+//TODO: add descriptions for other fields
+//TODO: the tyoe might change after deciding where to handle possibly undefined values for ens URLs
 interface IdentityProps {
   address: Address;
-  chainId: SupportedChainId;
+  chainId: SupportedChainId; //TODO: We need to be more precise here. We shouldn't be passing in any possible supported chain Id (for example, we "support" optimism, base, etc..).
+  // Instead, more specifically this should be the ENS Deployment Chain Id for the connected ENSNode instance.
+  /**
+   * ENS related values
+   */
+  ens: {
+    /** ENS Web application base URL */
+    appBaseUrl: URL | undefined;
+    /** ENS metadata base URL */
+    metadataBaseUrl: URL | undefined;
+  };
   showAvatar?: boolean;
   showExternalLink?: boolean;
   className?: string;
@@ -19,71 +31,85 @@ interface IdentityProps {
 
 /**
  * Component to display an ENS name for an Ethereum address.
- * Falls back to a truncated address if no ENS name is found.
+ * It can display an avatar if available, a link to the ENS name, or a truncated address.
  */
 export function Identity({
-  address,
-  chainId,
-  showAvatar = false,
-  showExternalLink = true,
-  className = "",
-}: IdentityProps) {
+                           address,
+                           chainId,
+                           ens,
+                           showAvatar = false,
+                           showExternalLink = true,
+                           className = "",
+                         }: IdentityProps) {
   const [mounted, setMounted] = useState(false);
 
   // Use the ENS name hook from wagmi
-  const { data: ensName, isLoading } = useEnsName({
+  const { data: ensName, isLoading, isError } = useEnsName({
     address,
     chainId,
   });
+  //TODO: if the ENS deployment chain is the ens-test-env, we should not make use of the useEnsName hook at all and instead just always show the truncated address and not look up the primary name.
+  // We should document that we'll need to come back to this later after introducing a mechanism for ENSNode to optionally pass an RPC endpoint ENSAdmin for it to make lookups such as this.
 
   // Handle client-side rendering
   useEffect(() => {
     setMounted(true);
   }, []);
 
-  // Generate ENS app URL
-  const ensAppUrl = `https://app.ens.domains/${address}`;
-
   // Truncate address for display
   const truncatedAddress = `${address.slice(0, 6)}...${address.slice(-4)}`;
+
+  // If not mounted yet (server-side), or still loading, show a skeleton
+  if (!mounted || isLoading) {
+    return <IdentityPlaceholder showAvatar={showAvatar} className={className} />;
+  }
+
+  // If there is an error, show the truncated address
+  if (isError) {
+    return <span className="font-mono text-xs">{truncatedAddress}</span>;
+  }
+
+  // Get ENS app Name Preview URL
+  const ensAppNamePreviewUrl = ens.appBaseUrl && ensName ? new URL(ensName, ens.appBaseUrl) : undefined;
+
+  // Get ENS avatar URL
+  const ensAvatarUrl =
+      ens.metadataBaseUrl && ensName ? new URL(ensName, ens.metadataBaseUrl) : undefined;
 
   // Display name (ENS name or truncated address)
   const displayName = ensName || truncatedAddress;
 
-  // If not mounted yet (server-side), show a skeleton
-  if (!mounted) {
-    return <IdentityPlaceholder showAvatar={showAvatar} className={className} />;
-  }
-
   return (
-    <div className={cx("flex items-center gap-2", className)}>
-      {showAvatar && (
-        <Avatar className="h-6 w-6">
-          {ensName && (
-            <AvatarImage
-              src={`https://metadata.ens.domains/mainnet/avatar/${ensName}`}
-              alt={ensName}
-            />
-          )}
-          <AvatarFallback className="text-xs">
-            {displayName.slice(0, 2).toUpperCase()}
-          </AvatarFallback>
-        </Avatar>
-      )}
-
-      <a
-        href={ensAppUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="flex items-center gap-1 text-blue-600 hover:underline"
-        title={address}
-      >
-        <span className="font-medium">
-          {isLoading ? <Skeleton className="h-4 w-24" /> : displayName}
-        </span>
-        {showExternalLink && <ExternalLink size={14} className="inline-block" />}
-      </a>
-    </div>
+      <div className={cx("flex items-center gap-2", className)}>
+        {showAvatar && (
+            <Avatar className="h-6 w-6">
+              {ensAvatarUrl && ensName && (
+                  <AvatarImage
+                      src={ensAvatarUrl.toString()}
+                      alt={ensName}
+                  />
+              )}
+              <AvatarFallback className="text-xs">
+                {displayName.slice(0, 2).toUpperCase()}
+              </AvatarFallback>
+            </Avatar>
+        )}
+        {/*TODO: previously we linked to owners even if they didn't have a primary name set, should we keep doing it?*/}
+        {ensAppNamePreviewUrl ? (
+            <a
+                href={ensAppNamePreviewUrl.toString()}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1 text-blue-600 hover:underline"
+                title={address}
+            >
+              <span className={ensName ? "font-medium" : "font-mono text-xs"}>{displayName}</span>
+              {showExternalLink && <ExternalLink size={14} className="inline-block" />}
+            </a>
+        ) : (
+            <span className={ensName ? "font-medium" : "font-mono text-xs"}>{displayName}</span>
+        )}
+      </div>
   );
 }
 Identity.Placeholder = IdentityPlaceholder;
@@ -92,9 +118,9 @@ interface IdentityPlaceholderProps extends Pick<IdentityProps, "showAvatar" | "c
 
 function IdentityPlaceholder({ showAvatar = false, className = "" }: IdentityPlaceholderProps) {
   return (
-    <div className={cx("flex items-center gap-2", className)}>
-      {showAvatar && <Skeleton className="h-6 w-6 rounded-full" />}
-      <Skeleton className="h-4 w-24" />
-    </div>
+      <div className={cx("flex items-center gap-2", className)}>
+        {showAvatar && <Skeleton className="h-6 w-6 rounded-full" />}
+        <Skeleton className="h-4 w-24" />
+      </div>
   );
 }

--- a/apps/ensadmin/src/components/identity/index.tsx
+++ b/apps/ensadmin/src/components/identity/index.tsx
@@ -34,17 +34,21 @@ interface IdentityProps {
  * It can display an avatar if available, a link to the ENS name, or a truncated address.
  */
 export function Identity({
-                           address,
-                           chainId,
-                           ens,
-                           showAvatar = false,
-                           showExternalLink = true,
-                           className = "",
-                         }: IdentityProps) {
+  address,
+  chainId,
+  ens,
+  showAvatar = false,
+  showExternalLink = true,
+  className = "",
+}: IdentityProps) {
   const [mounted, setMounted] = useState(false);
 
   // Use the ENS name hook from wagmi
-  const { data: ensName, isLoading, isError } = useEnsName({
+  const {
+    data: ensName,
+    isLoading,
+    isError,
+  } = useEnsName({
     address,
     chainId,
   });
@@ -70,46 +74,42 @@ export function Identity({
   }
 
   // Get ENS app Name Preview URL
-  const ensAppNamePreviewUrl = ens.appBaseUrl && ensName ? new URL(ensName, ens.appBaseUrl) : undefined;
+  const ensAppNamePreviewUrl =
+    ens.appBaseUrl && ensName ? new URL(ensName, ens.appBaseUrl) : undefined;
 
   // Get ENS avatar URL
   const ensAvatarUrl =
-      ens.metadataBaseUrl && ensName ? new URL(ensName, ens.metadataBaseUrl) : undefined;
+    ens.metadataBaseUrl && ensName ? new URL(ensName, ens.metadataBaseUrl) : undefined;
 
   // Display name (ENS name or truncated address)
   const displayName = ensName || truncatedAddress;
 
   return (
-      <div className={cx("flex items-center gap-2", className)}>
-        {showAvatar && (
-            <Avatar className="h-6 w-6">
-              {ensAvatarUrl && ensName && (
-                  <AvatarImage
-                      src={ensAvatarUrl.toString()}
-                      alt={ensName}
-                  />
-              )}
-              <AvatarFallback className="text-xs">
-                {displayName.slice(0, 2).toUpperCase()}
-              </AvatarFallback>
-            </Avatar>
-        )}
-        {/*TODO: previously we linked to owners even if they didn't have a primary name set, should we keep doing it?*/}
-        {ensAppNamePreviewUrl ? (
-            <a
-                href={ensAppNamePreviewUrl.toString()}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center gap-1 text-blue-600 hover:underline"
-                title={address}
-            >
-              <span className={ensName ? "font-medium" : "font-mono text-xs"}>{displayName}</span>
-              {showExternalLink && <ExternalLink size={14} className="inline-block" />}
-            </a>
-        ) : (
-            <span className={ensName ? "font-medium" : "font-mono text-xs"}>{displayName}</span>
-        )}
-      </div>
+    <div className={cx("flex items-center gap-2", className)}>
+      {showAvatar && (
+        <Avatar className="h-6 w-6">
+          {ensAvatarUrl && ensName && <AvatarImage src={ensAvatarUrl.toString()} alt={ensName} />}
+          <AvatarFallback className="text-xs">
+            {displayName.slice(0, 2).toUpperCase()}
+          </AvatarFallback>
+        </Avatar>
+      )}
+      {/*TODO: previously we linked to owners even if they didn't have a primary name set, should we keep doing it?*/}
+      {ensAppNamePreviewUrl ? (
+        <a
+          href={ensAppNamePreviewUrl.toString()}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-1 text-blue-600 hover:underline"
+          title={address}
+        >
+          <span className={ensName ? "font-medium" : "font-mono text-xs"}>{displayName}</span>
+          {showExternalLink && <ExternalLink size={14} className="inline-block" />}
+        </a>
+      ) : (
+        <span className={ensName ? "font-medium" : "font-mono text-xs"}>{displayName}</span>
+      )}
+    </div>
   );
 }
 Identity.Placeholder = IdentityPlaceholder;
@@ -118,9 +118,9 @@ interface IdentityPlaceholderProps extends Pick<IdentityProps, "showAvatar" | "c
 
 function IdentityPlaceholder({ showAvatar = false, className = "" }: IdentityPlaceholderProps) {
   return (
-      <div className={cx("flex items-center gap-2", className)}>
-        {showAvatar && <Skeleton className="h-6 w-6 rounded-full" />}
-        <Skeleton className="h-4 w-24" />
-      </div>
+    <div className={cx("flex items-center gap-2", className)}>
+      {showAvatar && <Skeleton className="h-6 w-6 rounded-full" />}
+      <Skeleton className="h-4 w-24" />
+    </div>
   );
 }

--- a/apps/ensadmin/src/components/identity/utils.ts
+++ b/apps/ensadmin/src/components/identity/utils.ts
@@ -1,0 +1,44 @@
+import {ENSNamespaceId} from "@ensnode/datasources";
+
+/**
+ * Get ENS app URL for wallet address on a supported network.
+ * NOTE: not every ENS deployment has an ENS app URL.
+ * @param {ENSNamespaceId} chain - ENS Namespace identifier
+ * @returns ENS app URL for supported networks, otherwise undefined
+ */
+export function getEnsAppUrl(chain: ENSNamespaceId): URL | undefined {
+    switch (chain) {
+        case "mainnet":
+            return new URL(`https://app.ens.domains/`);
+        case "sepolia":
+            return new URL(`https://sepolia.app.ens.domains/`);
+        case "holesky":
+            return new URL(`https://holesky.app.ens.domains/`);
+        case "ens-test-env":
+            // ens-test-env cannot be served by app.ens.domains website
+            return undefined;
+    }
+}
+
+/**
+ * Get metadata URL for a given ENS deployment
+ * NOTE: not every ENS deployment has an ENS metadata URL.
+ * @param {ENSNamespaceId} chain - ENS Namespace identifier
+ * @returns metadata URL for supported networks, otherwise undefined
+ */
+export function getEnsMetadataUrl(chain: ENSNamespaceId): URL | undefined {
+    switch (chain) {
+        case "mainnet":
+            return new URL(`https://metadata.ens.domains/mainnet/avatar/`);
+        case "sepolia":
+            return new URL(`https://metadata.ens.domains/sepolia/avatar/`);
+        case "holesky":
+            // NOTE: there's no metadata api available on metadata.ens.domains website for the holesky network
+            return undefined;
+        case "ens-test-env":
+            // ens-test-env cannot be served by metadata.ens.domains website
+            return undefined;
+    }
+}
+
+//TODO: Should these functions be handling the errors and undefined results? Or maybe the <Identity /> component should handle it?

--- a/apps/ensadmin/src/components/identity/utils.ts
+++ b/apps/ensadmin/src/components/identity/utils.ts
@@ -1,4 +1,4 @@
-import {ENSNamespaceId} from "@ensnode/datasources";
+import { ENSNamespaceId } from "@ensnode/datasources";
 
 /**
  * Get ENS app URL for wallet address on a supported network.
@@ -7,17 +7,17 @@ import {ENSNamespaceId} from "@ensnode/datasources";
  * @returns ENS app URL for supported networks, otherwise undefined
  */
 export function getEnsAppUrl(chain: ENSNamespaceId): URL | undefined {
-    switch (chain) {
-        case "mainnet":
-            return new URL(`https://app.ens.domains/`);
-        case "sepolia":
-            return new URL(`https://sepolia.app.ens.domains/`);
-        case "holesky":
-            return new URL(`https://holesky.app.ens.domains/`);
-        case "ens-test-env":
-            // ens-test-env cannot be served by app.ens.domains website
-            return undefined;
-    }
+  switch (chain) {
+    case "mainnet":
+      return new URL(`https://app.ens.domains/`);
+    case "sepolia":
+      return new URL(`https://sepolia.app.ens.domains/`);
+    case "holesky":
+      return new URL(`https://holesky.app.ens.domains/`);
+    case "ens-test-env":
+      // ens-test-env cannot be served by app.ens.domains website
+      return undefined;
+  }
 }
 
 /**
@@ -27,18 +27,18 @@ export function getEnsAppUrl(chain: ENSNamespaceId): URL | undefined {
  * @returns metadata URL for supported networks, otherwise undefined
  */
 export function getEnsMetadataUrl(chain: ENSNamespaceId): URL | undefined {
-    switch (chain) {
-        case "mainnet":
-            return new URL(`https://metadata.ens.domains/mainnet/avatar/`);
-        case "sepolia":
-            return new URL(`https://metadata.ens.domains/sepolia/avatar/`);
-        case "holesky":
-            // NOTE: there's no metadata api available on metadata.ens.domains website for the holesky network
-            return undefined;
-        case "ens-test-env":
-            // ens-test-env cannot be served by metadata.ens.domains website
-            return undefined;
-    }
+  switch (chain) {
+    case "mainnet":
+      return new URL(`https://metadata.ens.domains/mainnet/avatar/`);
+    case "sepolia":
+      return new URL(`https://metadata.ens.domains/sepolia/avatar/`);
+    case "holesky":
+      // NOTE: there's no metadata api available on metadata.ens.domains website for the holesky network
+      return undefined;
+    case "ens-test-env":
+      // ens-test-env cannot be served by metadata.ens.domains website
+      return undefined;
+  }
 }
 
 //TODO: Should these functions be handling the errors and undefined results? Or maybe the <Identity /> component should handle it?

--- a/apps/ensadmin/src/components/recent-registrations/components.tsx
+++ b/apps/ensadmin/src/components/recent-registrations/components.tsx
@@ -1,22 +1,23 @@
 "use client";
 
 import { useENSRootDatasourceChainId, useIndexingStatusQuery } from "@/components/ensnode";
+import { getEnsAppUrl, getEnsMetadataUrl } from "@/components/identity/utils";
 import { globalIndexingStatusViewModel } from "@/components/indexing-status/view-models";
 import {
-    Duration,
-    FormattedDate,
-    getNameWrapperAddress,
-    RegistrationNameDisplay,
-    RelativeTime
+  Duration,
+  FormattedDate,
+  RegistrationNameDisplay,
+  RelativeTime,
+  getNameWrapperAddress,
 } from "@/components/recent-registrations/utils";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
-    Table,
-    TableBody,
-    TableCell,
-    TableHead,
-    TableHeader,
-    TableRow,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
 } from "@/components/ui/table";
 import { selectedEnsNodeUrl } from "@/lib/env";
 import { Clock, ExternalLink } from "lucide-react";
@@ -24,7 +25,6 @@ import { useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { Identity } from "../identity";
 import { useRecentRegistrations } from "./hooks";
-import {getEnsAppUrl, getEnsMetadataUrl} from "@/components/identity/utils";
 
 /**
  * Maximal number of latest registrations to be displayed in the panel
@@ -35,133 +35,136 @@ const MAX_NUMBER_OF_LATEST_REGISTRATIONS = 5;
  * Helper function to generate ENS app URL for a name
  */
 const getEnsAppUrlForName = (name: string) => {
-    // no explicit url encoding needed
-    return `https://app.ens.domains/${name}`;
+  // no explicit url encoding needed
+  return `https://app.ens.domains/${name}`;
 };
 
 export function RecentRegistrations() {
-    const searchParams = useSearchParams();
-    const recentRegistrationsQuery = useRecentRegistrations(
-        selectedEnsNodeUrl(searchParams),
-        MAX_NUMBER_OF_LATEST_REGISTRATIONS,
-    );
-    const indexingStatus = useIndexingStatusQuery(searchParams);
-    const indexedChainId = useENSRootDatasourceChainId(indexingStatus.data);
-    const namespaceId = indexingStatus.data ? indexingStatus.data.env.NAMESPACE : null; //TODO: decide on how to handle possible undefined data. Should all be handled individually like <currentIndexingDate>? Or maybe it could all be handled in a unified way?
-    const [isClient, setIsClient] = useState(false);
+  const searchParams = useSearchParams();
+  const recentRegistrationsQuery = useRecentRegistrations(
+    selectedEnsNodeUrl(searchParams),
+    MAX_NUMBER_OF_LATEST_REGISTRATIONS,
+  );
+  const indexingStatus = useIndexingStatusQuery(searchParams);
+  const indexedChainId = useENSRootDatasourceChainId(indexingStatus.data);
+  const namespaceId = indexingStatus.data ? indexingStatus.data.env.NAMESPACE : null; //TODO: decide on how to handle possible undefined data. Should all be handled individually like <currentIndexingDate>? Or maybe it could all be handled in a unified way?
+  const [isClient, setIsClient] = useState(false);
 
-    // console.log("test", indexingStatus);
+  // console.log("test", indexingStatus);
 
-    //TODO: establish the level where we would handle undefined results!!!
-    const ensAppUrl = getEnsAppUrl(namespaceId!);
-    const ensMetadataUrl = getEnsMetadataUrl(namespaceId!);
+  //TODO: establish the level where we would handle undefined results!!!
+  const ensAppUrl = getEnsAppUrl(namespaceId!);
+  const ensMetadataUrl = getEnsMetadataUrl(namespaceId!);
 
-    const nameWrapperAddress = indexingStatus.data && indexedChainId ? getNameWrapperAddress(indexingStatus.data.env.NAMESPACE, indexedChainId) : null;
-    //TODO: this might be moved --> placing it here requires loads of prop drilling! But otherwise, do we want to use a useQuery inside another Query? I very much doubt so
+  const nameWrapperAddress =
+    indexingStatus.data && indexedChainId
+      ? getNameWrapperAddress(indexingStatus.data.env.NAMESPACE, indexedChainId)
+      : null;
+  //TODO: this might be moved --> placing it here requires loads of prop drilling! But otherwise, do we want to use a useQuery inside another Query? I very much doubt so
 
-    console.log("NW address", nameWrapperAddress);
+  console.log("NW address", nameWrapperAddress);
 
-    useEffect(() => {
-        setIsClient(true);
-    }, []);
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
 
-    // Get the current indexing date from the indexing status
-    const currentIndexingDate = indexingStatus.data
-        ? globalIndexingStatusViewModel(
-            indexingStatus.data.runtime.networkIndexingStatusByChainId,
-            indexingStatus.data.env.NAMESPACE,
-        ).currentIndexingDate
-        : null;
+  // Get the current indexing date from the indexing status
+  const currentIndexingDate = indexingStatus.data
+    ? globalIndexingStatusViewModel(
+        indexingStatus.data.runtime.networkIndexingStatusByChainId,
+        indexingStatus.data.env.NAMESPACE,
+      ).currentIndexingDate
+    : null;
 
-    return (
-        <Card className="w-full">
-            <CardHeader>
-                <CardTitle className="flex justify-between items-center">
-                    <span>Latest indexed registrations</span>
-                    {currentIndexingDate && (
-                        <div className="flex items-center gap-1.5">
-                            <Clock size={16} className="text-blue-600" />
-                            <span className="text-sm font-medium">
+  return (
+    <Card className="w-full">
+      <CardHeader>
+        <CardTitle className="flex justify-between items-center">
+          <span>Latest indexed registrations</span>
+          {currentIndexingDate && (
+            <div className="flex items-center gap-1.5">
+              <Clock size={16} className="text-blue-600" />
+              <span className="text-sm font-medium">
                 Last indexed block on{" "}
-                                <FormattedDate
-                                    date={currentIndexingDate}
-                                    options={{
-                                        year: "numeric",
-                                        month: "short",
-                                        day: "numeric",
-                                    }}
-                                />
+                <FormattedDate
+                  date={currentIndexingDate}
+                  options={{
+                    year: "numeric",
+                    month: "short",
+                    day: "numeric",
+                  }}
+                />
               </span>
-                        </div>
-                    )}
-                </CardTitle>
-            </CardHeader>
-            <CardContent>
-                {recentRegistrationsQuery.isLoading ? (
-                    <RecentRegistrationsFallback />
-                ) : recentRegistrationsQuery.error ? (
-                    <div className="text-destructive">
-                        Error loading recent registrations: {(recentRegistrationsQuery.error as Error).message}
-                    </div>
-                ) : (
-                    <Table>
-                        <TableHeader>
-                            <TableRow>
-                                <TableHead>Name</TableHead>
-                                <TableHead>Registered</TableHead>
-                                <TableHead>Duration</TableHead>
-                                <TableHead>Owner</TableHead>
-                            </TableRow>
-                        </TableHeader>
-                        <TableBody>
-                            {isClient &&
-                                recentRegistrationsQuery.data?.map((registration) => (
-                                    <TableRow key={registration.name}>
-                                        <TableCell className="font-medium">
-                                            <RegistrationNameDisplay registration={registration} ensAppUrl={ensAppUrl} />
-                                        </TableCell>
-                                        <TableCell>
-                                            <RelativeTime date={registration.registeredAt} />
-                                        </TableCell>
-                                        <TableCell>
-                                            <Duration
-                                                beginsAt={registration.registeredAt}
-                                                endsAt={registration.expiresAt}
-                                            />
-                                        </TableCell>
-                                        <TableCell>
-                                            {indexedChainId ? (
-                                                <Identity
-                                                    address={registration.owner}
-                                                    chainId={indexedChainId}
-                                                    ens={{
-                                                        appBaseUrl: ensAppUrl,
-                                                        metadataBaseUrl: ensMetadataUrl,
-                                                    }}
-                                                    showAvatar={true}
-                                                />
-                                            ) : (
-                                                <Identity.Placeholder showAvatar={true} />
-                                            )}
-                                        </TableCell>
-                                    </TableRow>
-                                ))}
-                        </TableBody>
-                    </Table>
-                )}
-            </CardContent>
-        </Card>
-    );
+            </div>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {recentRegistrationsQuery.isLoading ? (
+          <RecentRegistrationsFallback />
+        ) : recentRegistrationsQuery.error ? (
+          <div className="text-destructive">
+            Error loading recent registrations: {(recentRegistrationsQuery.error as Error).message}
+          </div>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Registered</TableHead>
+                <TableHead>Duration</TableHead>
+                <TableHead>Owner</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {isClient &&
+                recentRegistrationsQuery.data?.map((registration) => (
+                  <TableRow key={registration.name}>
+                    <TableCell className="font-medium">
+                      <RegistrationNameDisplay registration={registration} ensAppUrl={ensAppUrl} />
+                    </TableCell>
+                    <TableCell>
+                      <RelativeTime date={registration.registeredAt} />
+                    </TableCell>
+                    <TableCell>
+                      <Duration
+                        beginsAt={registration.registeredAt}
+                        endsAt={registration.expiresAt}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      {indexedChainId ? (
+                        <Identity
+                          address={registration.owner}
+                          chainId={indexedChainId}
+                          ens={{
+                            appBaseUrl: ensAppUrl,
+                            metadataBaseUrl: ensMetadataUrl,
+                          }}
+                          showAvatar={true}
+                        />
+                      ) : (
+                        <Identity.Placeholder showAvatar={true} />
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  );
 }
 
 function RecentRegistrationsFallback() {
-    return (
-        <div className="animate-pulse space-y-4">
-            <div className="h-10 bg-muted rounded w-full"></div>
-            <div className="h-10 bg-muted rounded w-full"></div>
-            <div className="h-10 bg-muted rounded w-full"></div>
-            <div className="h-10 bg-muted rounded w-full"></div>
-            <div className="h-10 bg-muted rounded w-full"></div>
-        </div>
-    );
+  return (
+    <div className="animate-pulse space-y-4">
+      <div className="h-10 bg-muted rounded w-full"></div>
+      <div className="h-10 bg-muted rounded w-full"></div>
+      <div className="h-10 bg-muted rounded w-full"></div>
+      <div className="h-10 bg-muted rounded w-full"></div>
+      <div className="h-10 bg-muted rounded w-full"></div>
+    </div>
+  );
 }

--- a/apps/ensadmin/src/components/recent-registrations/components.tsx
+++ b/apps/ensadmin/src/components/recent-registrations/components.tsx
@@ -2,15 +2,21 @@
 
 import { useENSRootDatasourceChainId, useIndexingStatusQuery } from "@/components/ensnode";
 import { globalIndexingStatusViewModel } from "@/components/indexing-status/view-models";
-import { Duration, FormattedDate, RelativeTime } from "@/components/recent-registrations/utils";
+import {
+    Duration,
+    FormattedDate,
+    getNameWrapperAddress,
+    RegistrationNameDisplay,
+    RelativeTime
+} from "@/components/recent-registrations/utils";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
 } from "@/components/ui/table";
 import { selectedEnsNodeUrl } from "@/lib/env";
 import { Clock, ExternalLink } from "lucide-react";
@@ -18,6 +24,7 @@ import { useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { Identity } from "../identity";
 import { useRecentRegistrations } from "./hooks";
+import {getEnsAppUrl, getEnsMetadataUrl} from "@/components/identity/utils";
 
 /**
  * Maximal number of latest registrations to be displayed in the panel
@@ -28,125 +35,133 @@ const MAX_NUMBER_OF_LATEST_REGISTRATIONS = 5;
  * Helper function to generate ENS app URL for a name
  */
 const getEnsAppUrlForName = (name: string) => {
-  // no explicit url encoding needed
-  return `https://app.ens.domains/${name}`;
+    // no explicit url encoding needed
+    return `https://app.ens.domains/${name}`;
 };
 
 export function RecentRegistrations() {
-  const searchParams = useSearchParams();
-  const recentRegistrationsQuery = useRecentRegistrations(
-    selectedEnsNodeUrl(searchParams),
-    MAX_NUMBER_OF_LATEST_REGISTRATIONS,
-  );
-  const indexingStatus = useIndexingStatusQuery(searchParams);
-  const indexedChainId = useENSRootDatasourceChainId(indexingStatus.data);
-  const [isClient, setIsClient] = useState(false);
+    const searchParams = useSearchParams();
+    const recentRegistrationsQuery = useRecentRegistrations(
+        selectedEnsNodeUrl(searchParams),
+        MAX_NUMBER_OF_LATEST_REGISTRATIONS,
+    );
+    const indexingStatus = useIndexingStatusQuery(searchParams);
+    const indexedChainId = useENSRootDatasourceChainId(indexingStatus.data);
+    const namespaceId = indexingStatus.data ? indexingStatus.data.env.NAMESPACE : null; //TODO: decide on how to handle possible undefined data. Should all be handled individually like <currentIndexingDate>? Or maybe it could all be handled in a unified way?
+    const [isClient, setIsClient] = useState(false);
 
-  useEffect(() => {
-    setIsClient(true);
-  }, []);
+    // console.log("test", indexingStatus);
 
-  // Get the current indexing date from the indexing status
-  const currentIndexingDate = indexingStatus.data
-    ? globalIndexingStatusViewModel(
-        indexingStatus.data.runtime.networkIndexingStatusByChainId,
-        indexingStatus.data.env.NAMESPACE,
-      ).currentIndexingDate
-    : null;
+    //TODO: establish the level where we would handle undefined results!!!
+    const ensAppUrl = getEnsAppUrl(namespaceId!);
+    const ensMetadataUrl = getEnsMetadataUrl(namespaceId!);
 
-  return (
-    <Card className="w-full">
-      <CardHeader>
-        <CardTitle className="flex justify-between items-center">
-          <span>Latest indexed registrations</span>
-          {currentIndexingDate && (
-            <div className="flex items-center gap-1.5">
-              <Clock size={16} className="text-blue-600" />
-              <span className="text-sm font-medium">
+    const nameWrapperAddress = indexingStatus.data && indexedChainId ? getNameWrapperAddress(indexingStatus.data.env.NAMESPACE, indexedChainId) : null;
+    //TODO: this might be moved --> placing it here requires loads of prop drilling! But otherwise, do we want to use a useQuery inside another Query? I very much doubt so
+
+    console.log("NW address", nameWrapperAddress);
+
+    useEffect(() => {
+        setIsClient(true);
+    }, []);
+
+    // Get the current indexing date from the indexing status
+    const currentIndexingDate = indexingStatus.data
+        ? globalIndexingStatusViewModel(
+            indexingStatus.data.runtime.networkIndexingStatusByChainId,
+            indexingStatus.data.env.NAMESPACE,
+        ).currentIndexingDate
+        : null;
+
+    return (
+        <Card className="w-full">
+            <CardHeader>
+                <CardTitle className="flex justify-between items-center">
+                    <span>Latest indexed registrations</span>
+                    {currentIndexingDate && (
+                        <div className="flex items-center gap-1.5">
+                            <Clock size={16} className="text-blue-600" />
+                            <span className="text-sm font-medium">
                 Last indexed block on{" "}
-                <FormattedDate
-                  date={currentIndexingDate}
-                  options={{
-                    year: "numeric",
-                    month: "short",
-                    day: "numeric",
-                  }}
-                />
+                                <FormattedDate
+                                    date={currentIndexingDate}
+                                    options={{
+                                        year: "numeric",
+                                        month: "short",
+                                        day: "numeric",
+                                    }}
+                                />
               </span>
-            </div>
-          )}
-        </CardTitle>
-      </CardHeader>
-      <CardContent>
-        {recentRegistrationsQuery.isLoading ? (
-          <RecentRegistrationsFallback />
-        ) : recentRegistrationsQuery.error ? (
-          <div className="text-destructive">
-            Error loading recent registrations: {(recentRegistrationsQuery.error as Error).message}
-          </div>
-        ) : (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Name</TableHead>
-                <TableHead>Registered</TableHead>
-                <TableHead>Duration</TableHead>
-                <TableHead>Owner</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {isClient &&
-                recentRegistrationsQuery.data?.map((registration) => (
-                  <TableRow key={registration.name}>
-                    <TableCell className="font-medium">
-                      <a
-                        href={getEnsAppUrlForName(registration.name)}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="flex items-center gap-1 text-blue-600 hover:underline w-fit"
-                      >
-                        {registration.name}
-                        <ExternalLink size={14} className="inline-block" />
-                      </a>
-                    </TableCell>
-                    <TableCell>
-                      <RelativeTime date={registration.registeredAt} />
-                    </TableCell>
-                    <TableCell>
-                      <Duration
-                        beginsAt={registration.registeredAt}
-                        endsAt={registration.expiresAt}
-                      />
-                    </TableCell>
-                    <TableCell>
-                      {indexedChainId ? (
-                        <Identity
-                          address={registration.owner}
-                          chainId={indexedChainId}
-                          showAvatar={true}
-                        />
-                      ) : (
-                        <Identity.Placeholder showAvatar={true} />
-                      )}
-                    </TableCell>
-                  </TableRow>
-                ))}
-            </TableBody>
-          </Table>
-        )}
-      </CardContent>
-    </Card>
-  );
+                        </div>
+                    )}
+                </CardTitle>
+            </CardHeader>
+            <CardContent>
+                {recentRegistrationsQuery.isLoading ? (
+                    <RecentRegistrationsFallback />
+                ) : recentRegistrationsQuery.error ? (
+                    <div className="text-destructive">
+                        Error loading recent registrations: {(recentRegistrationsQuery.error as Error).message}
+                    </div>
+                ) : (
+                    <Table>
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead>Name</TableHead>
+                                <TableHead>Registered</TableHead>
+                                <TableHead>Duration</TableHead>
+                                <TableHead>Owner</TableHead>
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {isClient &&
+                                recentRegistrationsQuery.data?.map((registration) => (
+                                    <TableRow key={registration.name}>
+                                        <TableCell className="font-medium">
+                                            <RegistrationNameDisplay registration={registration} ensAppUrl={ensAppUrl} />
+                                        </TableCell>
+                                        <TableCell>
+                                            <RelativeTime date={registration.registeredAt} />
+                                        </TableCell>
+                                        <TableCell>
+                                            <Duration
+                                                beginsAt={registration.registeredAt}
+                                                endsAt={registration.expiresAt}
+                                            />
+                                        </TableCell>
+                                        <TableCell>
+                                            {indexedChainId ? (
+                                                <Identity
+                                                    address={registration.owner}
+                                                    chainId={indexedChainId}
+                                                    ens={{
+                                                        appBaseUrl: ensAppUrl,
+                                                        metadataBaseUrl: ensMetadataUrl,
+                                                    }}
+                                                    showAvatar={true}
+                                                />
+                                            ) : (
+                                                <Identity.Placeholder showAvatar={true} />
+                                            )}
+                                        </TableCell>
+                                    </TableRow>
+                                ))}
+                        </TableBody>
+                    </Table>
+                )}
+            </CardContent>
+        </Card>
+    );
 }
 
 function RecentRegistrationsFallback() {
-  return (
-    <div className="animate-pulse space-y-4">
-      <div className="h-10 bg-muted rounded w-full"></div>
-      <div className="h-10 bg-muted rounded w-full"></div>
-      <div className="h-10 bg-muted rounded w-full"></div>
-      <div className="h-10 bg-muted rounded w-full"></div>
-      <div className="h-10 bg-muted rounded w-full"></div>
-    </div>
-  );
+    return (
+        <div className="animate-pulse space-y-4">
+            <div className="h-10 bg-muted rounded w-full"></div>
+            <div className="h-10 bg-muted rounded w-full"></div>
+            <div className="h-10 bg-muted rounded w-full"></div>
+            <div className="h-10 bg-muted rounded w-full"></div>
+            <div className="h-10 bg-muted rounded w-full"></div>
+        </div>
+    );
 }

--- a/apps/ensadmin/src/components/recent-registrations/utils.tsx
+++ b/apps/ensadmin/src/components/recent-registrations/utils.tsx
@@ -1,22 +1,18 @@
+import { Registration } from "@/components/recent-registrations/types";
+import { Datasource, ENSNamespaceId, getENSNamespace } from "@ensnode/datasources";
 import { formatDistanceStrict, formatDistanceToNow, intlFormat } from "date-fns";
 import { millisecondsInSecond } from "date-fns/constants";
+import { ExternalLink } from "lucide-react";
 import { useEffect, useState } from "react";
-import {Address, getAddress} from "viem";
-import {
-  Datasource,
-  ENSNamespaceId,
-  getENSNamespace
-} from "@ensnode/datasources";
-import {Registration} from "@/components/recent-registrations/types";
-import {ExternalLink} from "lucide-react";
+import { Address, getAddress } from "viem";
 
 /**
  * Client-only date formatter component
  */
 export function FormattedDate({
-                                date,
-                                options,
-                              }: {
+  date,
+  options,
+}: {
   date: Date;
   options: Intl.DateTimeFormatOptions;
 }) {
@@ -46,9 +42,9 @@ export function RelativeTime({ date }: { date: Date }) {
  * Client-only duration component
  */
 export function Duration({
-                           beginsAt,
-                           endsAt,
-                         }: {
+  beginsAt,
+  endsAt,
+}: {
   beginsAt: Date;
   endsAt: Date;
 }) {
@@ -84,12 +80,12 @@ export function unixTimestampToDate(timestamp: UnixTimestampInSeconds): Date {
  */
 //TODO: improve name and description
 //TODO: refactor the code
-function truncateLeftmostLabelIfItContainsAddress(name:string) : string {
+function truncateLeftmostLabelIfItContainsAddress(name: string): string {
   const leftmostLabel = name.split(".")[0];
 
   //if name's label is an address (ex. [ec93f85a766b60d85571efc48e4b818c800218452f9ac738f796a8fc94079a57].eth) truncate it
-  if (leftmostLabel.startsWith("[") && leftmostLabel.endsWith("]")){
-    return `${leftmostLabel.slice(0, 6)}...${name.slice(-3)}${name.split(".").slice(1).join(".")}`
+  if (leftmostLabel.startsWith("[") && leftmostLabel.endsWith("]")) {
+    return `${leftmostLabel.slice(0, 6)}...${name.slice(-3)}${name.split(".").slice(1).join(".")}`;
   }
 
   // otherwise return whole domain
@@ -113,22 +109,22 @@ interface RegistrationNameDisplayProps {
 //TODO: for now this handles the case of undefined ENS app URLs - may change depending on other TODOs
 export function RegistrationNameDisplay({ registration, ensAppUrl }: RegistrationNameDisplayProps) {
   const ensAppRegistrationPreviewUrl = ensAppUrl
-      ? new URL(registration.name, ensAppUrl)
-      : undefined;
+    ? new URL(registration.name, ensAppUrl)
+    : undefined;
 
   const displayName = truncateLeftmostLabelIfItContainsAddress(registration.name);
 
   if (ensAppRegistrationPreviewUrl) {
     return (
-        <a
-            href={ensAppRegistrationPreviewUrl.toString()}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-1 text-blue-600 hover:underline"
-        >
-          {displayName}
-          <ExternalLink size={14} className="inline-block"/>
-        </a>
+      <a
+        href={ensAppRegistrationPreviewUrl.toString()}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center gap-1 text-blue-600 hover:underline"
+      >
+        {displayName}
+        <ExternalLink size={14} className="inline-block" />
+      </a>
     );
   }
 
@@ -144,16 +140,15 @@ export function RegistrationNameDisplay({ registration, ensAppUrl }: Registratio
  */
 //TODO: where to use it? I don't like the prop-drilling that would be required to pass the address from <RecentRegistrations /> to getEffectiveOwner, but what's a better way to do it?
 //TODO: make sure it actually works! make sure we take the root datasource! --> Investigate how the Datasource is built once again, maybe I omitted sth earlier?
-export function getNameWrapperAddress(namespaceId: ENSNamespaceId, chainId: number): Address{
+export function getNameWrapperAddress(namespaceId: ENSNamespaceId, chainId: number): Address {
   const datasources = Object.values(getENSNamespace(namespaceId)) as Datasource[];
   const datasource = datasources.find((datasource) => datasource.chain.id === chainId);
 
   if (!datasource) {
     throw new Error(
-        `No Datasources within the "${namespaceId}" namespace are defined for Chain ID "${chainId}".`,
+      `No Datasources within the "${namespaceId}" namespace are defined for Chain ID "${chainId}".`,
     );
   }
 
   return getAddress(datasource.contracts.NameWrapper.address);
 }
-

--- a/apps/ensadmin/src/components/recent-registrations/utils.tsx
+++ b/apps/ensadmin/src/components/recent-registrations/utils.tsx
@@ -1,14 +1,22 @@
 import { formatDistanceStrict, formatDistanceToNow, intlFormat } from "date-fns";
 import { millisecondsInSecond } from "date-fns/constants";
 import { useEffect, useState } from "react";
+import {Address, getAddress} from "viem";
+import {
+  Datasource,
+  ENSNamespaceId,
+  getENSNamespace
+} from "@ensnode/datasources";
+import {Registration} from "@/components/recent-registrations/types";
+import {ExternalLink} from "lucide-react";
 
 /**
  * Client-only date formatter component
  */
 export function FormattedDate({
-  date,
-  options,
-}: {
+                                date,
+                                options,
+                              }: {
   date: Date;
   options: Intl.DateTimeFormatOptions;
 }) {
@@ -38,9 +46,9 @@ export function RelativeTime({ date }: { date: Date }) {
  * Client-only duration component
  */
 export function Duration({
-  beginsAt,
-  endsAt,
-}: {
+                           beginsAt,
+                           endsAt,
+                         }: {
   beginsAt: Date;
   endsAt: Date;
 }) {
@@ -70,3 +78,82 @@ export function unixTimestampToDate(timestamp: UnixTimestampInSeconds): Date {
 
   return date;
 }
+
+/**
+ * Truncates a name's leftmost label if it's made of an address
+ */
+//TODO: improve name and description
+//TODO: refactor the code
+function truncateLeftmostLabelIfItContainsAddress(name:string) : string {
+  const leftmostLabel = name.split(".")[0];
+
+  //if name's label is an address (ex. [ec93f85a766b60d85571efc48e4b818c800218452f9ac738f796a8fc94079a57].eth) truncate it
+  if (leftmostLabel.startsWith("[") && leftmostLabel.endsWith("]")){
+    return `${leftmostLabel.slice(0, 6)}...${name.slice(-3)}${name.split(".").slice(1).join(".")}`
+  }
+
+  // otherwise return whole domain
+  return name;
+}
+
+interface RegistrationNameDisplayProps {
+  // NOTE: not every ENS namespace has an ENS app URL
+  ensAppUrl: URL | undefined;
+
+  registration: Registration;
+}
+
+/**
+ * Component to display an ENS registration.
+ * It can display a link to the ENS name, or just the name if the ENS namespace has no dedicated ENS App.
+ */
+
+//TODO: consider a different name
+//TODO: should probably be moved to /identity
+//TODO: for now this handles the case of undefined ENS app URLs - may change depending on other TODOs
+export function RegistrationNameDisplay({ registration, ensAppUrl }: RegistrationNameDisplayProps) {
+  const ensAppRegistrationPreviewUrl = ensAppUrl
+      ? new URL(registration.name, ensAppUrl)
+      : undefined;
+
+  const displayName = truncateLeftmostLabelIfItContainsAddress(registration.name);
+
+  if (ensAppRegistrationPreviewUrl) {
+    return (
+        <a
+            href={ensAppRegistrationPreviewUrl.toString()}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1 text-blue-600 hover:underline"
+        >
+          {displayName}
+          <ExternalLink size={14} className="inline-block"/>
+        </a>
+    );
+  }
+
+  return <span>{displayName}</span>;
+}
+
+/**
+ Get an Address object of the NameWrapper contract from the root datasource of a specific namespace.
+
+ @param chainId the chain ID
+ @param namespaceId - the namespace identifier within which to find a root datasource
+ @returns the viem#Address object
+ */
+//TODO: where to use it? I don't like the prop-drilling that would be required to pass the address from <RecentRegistrations /> to getEffectiveOwner, but what's a better way to do it?
+//TODO: make sure it actually works! make sure we take the root datasource! --> Investigate how the Datasource is built once again, maybe I omitted sth earlier?
+export function getNameWrapperAddress(namespaceId: ENSNamespaceId, chainId: number): Address{
+  const datasources = Object.values(getENSNamespace(namespaceId)) as Datasource[];
+  const datasource = datasources.find((datasource) => datasource.chain.id === chainId);
+
+  if (!datasource) {
+    throw new Error(
+        `No Datasources within the "${namespaceId}" namespace are defined for Chain ID "${chainId}".`,
+    );
+  }
+
+  return getAddress(datasource.contracts.NameWrapper.address);
+}
+

--- a/apps/ensadmin/src/components/recent-registrations/utils.tsx
+++ b/apps/ensadmin/src/components/recent-registrations/utils.tsx
@@ -149,6 +149,6 @@ export function getNameWrapperAddress(namespaceId: ENSNamespaceId, chainId: numb
       `No Datasources within the "${namespaceId}" namespace are defined for Chain ID "${chainId}".`,
     );
   }
-
+  //TODO: make sure that this will be a root datasource, otherwise there is no guarantee of NameWrapper existing
   return getAddress(datasource.contracts.NameWrapper.address);
 }


### PR DESCRIPTION
* Aims to solve Issue #793
* Heavily based on PR #476

Quick recap of goals:
- [ ] Link registered domains to the correct ENS App (depending on the namespace of the connected ENSNode)
- [ ] Get correct Avatar images of owners (also depending on the namespace of the connected ENSNode)
- [ ] Correct the `getEffectiveOwner` function so that it relies on correct NameWrapper address