### PR TITLE
Production Tracing

### DIFF
--- a/apps/ensindexer/src/api/lib/instrumentation.ts
+++ b/apps/ensindexer/src/api/lib/instrumentation.ts
@@ -2,10 +2,8 @@ import packageJson from "@/../package.json";
 import { ProtocolTraceExporter } from "@/api/lib/protocol-tracing";
 
 import { DiagConsoleLogger, DiagLogLevel, diag } from "@opentelemetry/api";
-// import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-proto";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
 import { resourceFromAttributes } from "@opentelemetry/resources";
-// import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 import { NodeSDK } from "@opentelemetry/sdk-node";
 import {
   BatchSpanProcessor,
@@ -15,7 +13,7 @@ import {
 import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from "@opentelemetry/semantic-conventions";
 
 // Something broken with OpenTelemetry? enable debug logging with OTEL_DEBUG=anything
-if (!!process.env.OTEL_DEBUG) {
+if (process.env.OTEL_DEBUG) {
   diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.ALL);
 }
 
@@ -24,8 +22,8 @@ const spanProcessors: SpanProcessor[] = [
   new SimpleSpanProcessor(ProtocolTraceExporter.singleton()),
 ];
 
-if (!!process.env.OTEL_EXPORTER_OTLP_ENDPOINT) {
-  // only export spans to collector iff OTEL_EXPORTER_OTLP_ENDPOINT is defined
+// only export spans to OTel Collector iff OTEL_EXPORTER_OTLP_ENDPOINT is defined
+if (process.env.OTEL_EXPORTER_OTLP_ENDPOINT) {
   spanProcessors.push(
     new BatchSpanProcessor(new OTLPTraceExporter(), {
       scheduledDelayMillis: process.env.NODE_ENV === "development" ? 1_000 : undefined,
@@ -39,8 +37,6 @@ export const sdk = new NodeSDK({
     [ATTR_SERVICE_VERSION]: packageJson.version,
   }),
   spanProcessors,
-  // TODO: metrics, once OTel Collector is set up
-  // metricReader: new PeriodicExportingMetricReader({ exporter: new OTLPMetricExporter() }),
   // NOTE: avoiding auto-instrumentation for now as it adds complexity and can be quite noisy
   instrumentations: [],
 });


### PR DESCRIPTION
enabled configurable debug logging and reporting to production collector. if there's no `OTEL_EXPORTER_OTLP_ENDPOINT` env var, there's no exporting, so it should be safe to merge and run in our blue/green environments