### PR TITLE
wip: indexing status endpoint

### DIFF
--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -78,6 +78,7 @@ jobs:
           HEALTH_CHECK_TIMEOUT: 60
           ENSRAINBOW_URL: https://api.ensrainbow.io
           ENSNODE_PUBLIC_URL: http://localhost:42069
+          ENSINDEXER_PRIVATE_URL: http://localhost:42069
         run: |
           chmod +x ./.github/scripts/run_ensindexer_healthcheck.sh
           ./.github/scripts/run_ensindexer_healthcheck.sh

--- a/apps/ensindexer/.env.local.example
+++ b/apps/ensindexer/.env.local.example
@@ -71,6 +71,9 @@ ENSRAINBOW_URL=http://localhost:3223
 # for querying state about the ENSNode instance.
 ENSNODE_PUBLIC_URL=http://localhost:42069
 
+
+ENSINDEXER_PRIVATE_URL=http://localhost:42069
+
 # The ENSAdmin service URL
 # When the root route `/` of ENSIndexer receives a request, ENSIndexer redirects to this provided
 # ENSAdmin URL with an instruction for that ENSAdmin instance to connect back to the configured

--- a/apps/ensindexer/src/api/index.ts
+++ b/apps/ensindexer/src/api/index.ts
@@ -6,6 +6,7 @@ import { Hono, MiddlewareHandler } from "hono";
 import { cors } from "hono/cors";
 import { graphql as ponderGraphQL } from "ponder";
 
+import { indexingStatusMiddleware } from "@/api/lib/indexing-status";
 import { sdk } from "@/api/lib/instrumentation";
 import config from "@/config";
 import { makeApiDocumentationMiddleware } from "@/lib/api-documentation";
@@ -28,6 +29,8 @@ import ensNodeApi from "./handlers/ensnode-api";
 const schemaWithoutExtensions = filterSchemaExtensions(schema);
 
 const app = new Hono();
+
+app.get("/indexing-status", indexingStatusMiddleware);
 
 const ensNodeVersionResponseHeader: MiddlewareHandler = async (ctx, next) => {
   ctx.header("x-ensnode-version", packageJson.version);

--- a/apps/ensindexer/src/api/lib/indexing-status.ts
+++ b/apps/ensindexer/src/api/lib/indexing-status.ts
@@ -1,0 +1,398 @@
+import { publicClients } from "ponder:api";
+import { createMiddleware } from "hono/factory";
+import config from "../../../ponder.config.js";
+
+type BlockRef = { number: number; timestamp: number };
+
+type ChainIndexingConfig = {
+  // If all contracts, accounts, and block intervals are set to "latest",
+  // startBlock will be null.
+  startBlock: BlockRef | null;
+  // If all contracts, accounts, and block intervals are set to undefined,
+  // endBlock will be null.
+  endBlock: BlockRef | null;
+};
+
+type ChainIndexingStatus =
+  | {
+      status: "not_started";
+      config: ChainIndexingConfig;
+      latestBlock: BlockRef;
+    }
+  | {
+      status: "backfill";
+      config: ChainIndexingConfig;
+      latestSyncedBlock: BlockRef;
+      latestIndexedBlock: BlockRef;
+      latestBlock: BlockRef;
+    }
+  | {
+      status: "realtime";
+      config: ChainIndexingConfig;
+      latestSyncedBlock: BlockRef;
+      latestIndexedBlock: BlockRef;
+      latestBlock: BlockRef;
+    }
+  | {
+      status: "completed";
+      config: ChainIndexingConfig;
+      latestSyncedBlock: BlockRef;
+      latestIndexedBlock: BlockRef;
+      latestBlock: BlockRef;
+    };
+
+type IndexingStatus = { chains: Record<number, ChainIndexingStatus> };
+
+export const indexingStatusMiddleware = createMiddleware(async (c) => {
+  try {
+    const baseUrl = c.req.url.replace(/\/[^\/]*$/, "");
+    const [metricsText, statusJson] = await Promise.all([
+      fetch(`${baseUrl}/metrics`).then((r) => r.text()),
+      fetch(`${baseUrl}/status`).then((r) => r.json()),
+    ]);
+
+    const metrics = parsePrometheusMetrics(metricsText);
+    const status = statusJson as {
+      [chainName: string]: {
+        id: number;
+        block: { number: number; timestamp: number };
+      };
+    };
+
+    const settingsInfo = metrics.getMetricValues("ponder_settings_info");
+    const ordering = settingsInfo[0]?.labels.ordering;
+    if (ordering === undefined) {
+      throw new Error("No ordering metric found");
+    }
+
+    const chainResults = await Promise.all(
+      Object.entries(config.chains).map(async ([chainName, chainConfig]) => {
+        const chainId = (chainConfig as { id: number }).id;
+
+        const chainBlockConfig = await getChainConfig(chainName);
+
+        const latestBlock = await getLatestBlock(chainName);
+
+        const statusBlock = status[chainName]?.block;
+        if (statusBlock === undefined) {
+          throw new Error(`Chain ${chainName} found in config but not in status`);
+        }
+
+        const isCompleteNumber = metrics.getMetricValue("ponder_sync_is_complete", {
+          chain: chainName,
+        });
+        if (isCompleteNumber === undefined) {
+          throw new Error(`No ponder_sync_is_completed metric found for chain ${chainName}`);
+        }
+        const isComplete = isCompleteNumber === 1;
+
+        if (isComplete === true) {
+          return {
+            chainId,
+            result: {
+              status: "completed" as const,
+              config: chainBlockConfig,
+              latestSyncedBlock: statusBlock,
+              latestIndexedBlock: statusBlock,
+              latestBlock,
+            } satisfies ChainIndexingStatus,
+          };
+        }
+
+        const isRealtimeNumber = metrics.getMetricValue("ponder_sync_is_realtime", {
+          chain: chainName,
+        });
+        if (isRealtimeNumber === undefined) {
+          throw new Error(`No ponder_sync_is_realtime metric found for chain ${chainName}`);
+        }
+        const isRealtime = isRealtimeNumber === 1;
+
+        // The is_realtime metric reliably indicates that the backfill is complete,
+        // so take advantage of that here to simplify the logic below.
+        if (isRealtime === true) {
+          const latestSyncedBlockNumber = metrics.getMetricValue("ponder_sync_block", {
+            chain: chainName,
+          });
+          if (latestSyncedBlockNumber === undefined) {
+            throw new Error(`No ponder_sync_block metric found for realtime chain ${chainName}`);
+          }
+
+          // If the latest sync block number is the same as the latest indexed
+          // block number, use the latest indexed block as an optimization to
+          // avoid the extra RPC request.
+          const latestSyncedBlock =
+            latestSyncedBlockNumber === statusBlock.number
+              ? statusBlock
+              : await cachedGetBlockByNumber(chainName, latestSyncedBlockNumber);
+
+          return {
+            chainId,
+            result: {
+              status: "realtime" as const,
+              config: chainBlockConfig,
+              latestSyncedBlock,
+              latestIndexedBlock: statusBlock,
+              latestBlock,
+            } satisfies ChainIndexingStatus,
+          };
+        }
+
+        // If we're not in realtime yet and the startBlock is null ("latest"),
+        // the chain has not started yet.
+        if (chainBlockConfig.startBlock === null) {
+          return {
+            chainId,
+            result: {
+              status: "not_started" as const,
+              config: chainBlockConfig,
+              latestBlock,
+            } satisfies ChainIndexingStatus,
+          };
+        }
+
+        // In omnichain ordering, if the startBlock is the same as the
+        // status block, the chain has not started yet.
+        if (ordering === "omnichain" && chainBlockConfig.startBlock.number === statusBlock.number) {
+          return {
+            chainId,
+            result: {
+              status: "not_started" as const,
+              config: chainBlockConfig,
+              latestBlock,
+            } satisfies ChainIndexingStatus,
+          };
+        }
+
+        const historicalTotalBlocks = metrics.getMetricValue("ponder_historical_total_blocks", {
+          chain: chainName,
+        });
+        const historicalCachedBlocks = metrics.getMetricValue("ponder_historical_cached_blocks", {
+          chain: chainName,
+        });
+        if (historicalTotalBlocks === undefined || historicalCachedBlocks === undefined) {
+          throw new Error(
+            `No ponder_historical_total_blocks or ponder_historical_cached_blocks metric found for chain ${chainName}`,
+          );
+        }
+
+        const historicalCompletedBlocks =
+          metrics.getMetricValue("ponder_historical_completed_blocks", {
+            chain: chainName,
+          }) ?? 0;
+
+        const hasSyncBackfill = historicalTotalBlocks > 0;
+
+        // If the chain has a sync backfill but hasn't completed any blocks,
+        // the chain has not started yet.
+        if (hasSyncBackfill && historicalCompletedBlocks === 0) {
+          return {
+            chainId,
+            result: {
+              status: "not_started" as const,
+              config: chainBlockConfig,
+              latestBlock,
+            } satisfies ChainIndexingStatus,
+          };
+        }
+
+        // We can calculate the latest synced block number by adding
+        // the historical cached + completed blocks to the start block.
+        const latestSyncedBlockNumber =
+          chainBlockConfig.startBlock.number + historicalCachedBlocks + historicalCompletedBlocks;
+
+        // If the latest sync block number is the same as the latest indexed
+        // block number, use the latest indexed block as an optimization to
+        // avoid the extra RPC request.
+        const latestSyncedBlock =
+          latestSyncedBlockNumber === statusBlock.number
+            ? statusBlock
+            : await cachedGetBlockByNumber(chainName, latestSyncedBlockNumber);
+
+        return {
+          chainId,
+          result: {
+            status: "backfill" as const,
+            config: chainBlockConfig,
+            latestSyncedBlock,
+            latestIndexedBlock: statusBlock,
+            latestBlock,
+          } satisfies ChainIndexingStatus,
+        };
+      }),
+    );
+
+    const result = {
+      chains: Object.fromEntries(chainResults.map(({ chainId, result }) => [chainId, result])),
+    } satisfies IndexingStatus;
+
+    return c.json(result);
+  } catch (error) {
+    return c.json({ error: "Internal server error" }, 500);
+  }
+});
+
+async function getLatestBlock(chainName: string) {
+  const client = publicClients[chainName];
+  if (client === undefined) throw new Error(`Client not found for chain ${chainName}`);
+
+  const block = await client.getBlock({ blockTag: "latest" });
+
+  const blockRef = {
+    number: Number(block.number),
+    timestamp: Number(block.timestamp),
+  } satisfies BlockRef;
+
+  return blockRef;
+}
+
+const blockCache = new Map<string, Map<number, BlockRef>>();
+
+async function cachedGetBlockByNumber(chainName: string, blockNumber: number) {
+  let cache = blockCache.get(chainName);
+  if (!cache) {
+    cache = new Map<number, BlockRef>();
+    blockCache.set(chainName, cache);
+  }
+
+  const cachedBlockRef = cache.get(blockNumber);
+  if (cachedBlockRef) return cachedBlockRef;
+
+  const client = publicClients[chainName];
+  if (client === undefined) throw new Error(`Client not found for chain ${chainName}`);
+
+  const block = await client.getBlock({ blockNumber: BigInt(blockNumber) });
+
+  const blockRef = {
+    number: Number(block.number),
+    timestamp: Number(block.timestamp),
+  } satisfies BlockRef;
+
+  cache.set(blockNumber, blockRef);
+
+  return blockRef;
+}
+
+async function getChainConfig(chainName: string) {
+  let minStartBlock: number | null = null;
+  let maxEndBlock: number | null = null;
+
+  for (const source of [
+    ...Object.values(config.contracts ?? {}),
+    ...Object.values(config.accounts ?? {}),
+    ...Object.values(config.blocks ?? {}),
+  ]) {
+    const chain = (source as any).chain;
+    let startBlock: any;
+    let endBlock: any;
+
+    if (typeof chain === "string" && chain === chainName) {
+      startBlock = (source as any).startBlock;
+      endBlock = (source as any).endBlock;
+    } else if (typeof chain === "object" && chain?.[chainName]) {
+      startBlock = chain[chainName].startBlock;
+      endBlock = chain[chainName].endBlock;
+    }
+
+    if (typeof startBlock === "number") {
+      if (minStartBlock === null) {
+        minStartBlock = startBlock;
+      } else {
+        minStartBlock = Math.min(minStartBlock, startBlock);
+      }
+    }
+
+    if (typeof endBlock === "number") {
+      if (maxEndBlock === null) {
+        maxEndBlock = endBlock;
+      } else {
+        maxEndBlock = Math.max(maxEndBlock, endBlock);
+      }
+    }
+  }
+
+  return {
+    startBlock: minStartBlock ? await cachedGetBlockByNumber(chainName, minStartBlock) : null,
+    endBlock: maxEndBlock ? await cachedGetBlockByNumber(chainName, maxEndBlock) : null,
+  };
+}
+
+type PromLabels = Record<string, string>;
+type PromMetric = { name: string; labels: PromLabels; value: number };
+
+function parsePrometheusMetrics(text: string) {
+  const metrics: PromMetric[] = [];
+
+  for (const line of text.split("\n")) {
+    // Skip comments and empty lines
+    if (line.startsWith("#") || line.trim() === "") continue;
+
+    // Parse metric line: metric_name{label1="value1",label2="value2"} value
+    const metricMatch = line.match(/^([a-zA-Z_:][a-zA-Z0-9_:]*)\{([^}]*)\}\s+([0-9.-]+)$/);
+    if (metricMatch) {
+      const [, metricName, labelsStr, valueStr] = metricMatch;
+      if (metricName && labelsStr !== undefined && valueStr) {
+        const labels: PromLabels = {};
+
+        // Parse labels: label1="value1",label2="value2"
+        const labelMatches = labelsStr.matchAll(/([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*"([^"]*)"/g);
+        for (const labelMatch of labelMatches) {
+          const [, labelName, labelValue] = labelMatch;
+          if (labelName && labelValue !== undefined) {
+            labels[labelName] = labelValue;
+          }
+        }
+
+        const value = Number.parseFloat(valueStr);
+        if (!Number.isNaN(value)) {
+          metrics.push({ name: metricName, labels, value });
+        }
+      }
+    }
+
+    // Parse metric line without labels: metric_name value
+    const simpleMetricMatch = line.match(/^([a-zA-Z_:][a-zA-Z0-9_:]*)\s+([0-9.-]+)$/);
+    if (simpleMetricMatch) {
+      const [, metricName, valueStr] = simpleMetricMatch;
+      if (metricName && valueStr) {
+        const value = Number.parseFloat(valueStr);
+        if (!Number.isNaN(value)) {
+          metrics.push({ name: metricName, labels: {}, value });
+        }
+      }
+    }
+  }
+
+  return {
+    getMetricValue: (metricName: string, labels?: PromLabels): number | undefined => {
+      for (const metric of metrics) {
+        if (metric.name === metricName) {
+          if (!labels || Object.keys(labels).length === 0) {
+            return metric.value;
+          }
+
+          // Check if all provided labels match
+          const labelsMatch = Object.entries(labels).every(
+            ([key, value]) => metric.labels[key] === value,
+          );
+
+          if (labelsMatch) {
+            return metric.value;
+          }
+        }
+      }
+      return undefined;
+    },
+    getMetricValues: (metricName: string, labelFilter?: PromLabels): PromMetric[] => {
+      return metrics.filter((metric) => {
+        if (metric.name !== metricName) return false;
+
+        if (!labelFilter || Object.keys(labelFilter).length === 0) {
+          return true;
+        }
+
+        // Check if all provided labels match
+        return Object.entries(labelFilter).every(([key, value]) => metric.labels[key] === value);
+      });
+    },
+  };
+}

--- a/apps/ensindexer/src/api/lib/indexing-status.ts
+++ b/apps/ensindexer/src/api/lib/indexing-status.ts
@@ -1,9 +1,9 @@
 import { publicClients } from "ponder:api";
 import { createMiddleware } from "hono/factory";
 import config from "../../../ponder.config.js";
+import ensIndexerConfig from "../../config/index.js";
 
-// TODO: Provide through configuration / env var.
-const BASE_URL = "http://localhost:42069";
+const BASE_URL = ensIndexerConfig.ensIndexerPrivateUrl;
 
 type BlockRef = { number: number; timestamp: number };
 

--- a/apps/ensindexer/src/api/lib/indexing-status.ts
+++ b/apps/ensindexer/src/api/lib/indexing-status.ts
@@ -309,37 +309,6 @@ export const indexingStatusMiddleware = createMiddleware(async (c) => {
           };
         }
 
-        const historicalTotalBlocks = metrics.getMetricValue("ponder_historical_total_blocks", {
-          chain: chainName,
-        });
-        const historicalCachedBlocks = metrics.getMetricValue("ponder_historical_cached_blocks", {
-          chain: chainName,
-        });
-        if (historicalTotalBlocks === undefined || historicalCachedBlocks === undefined) {
-          throw new Error(
-            `No ponder_historical_total_blocks or ponder_historical_cached_blocks metric found for chain ${chainName}`,
-          );
-        }
-
-        const historicalCompletedBlocks =
-          metrics.getMetricValue("ponder_historical_completed_blocks", {
-            chain: chainName,
-          }) ?? 0;
-
-        const hasSyncBackfill = historicalTotalBlocks > 0;
-
-        // If the chain has a backfill but hasn't completed any blocks,
-        // the chain has not started yet.
-        if (hasSyncBackfill && historicalCompletedBlocks === 0) {
-          return {
-            chainId,
-            result: {
-              status: "not_started" as const,
-              config: chainConfig,
-            } satisfies ChainIndexingStatus,
-          };
-        }
-
         const backfillEndBlock = chainBackfillEndBlocks?.[chainName];
         if (backfillEndBlock === undefined) {
           throw new Error(`No backfill end block found for chain ${chainName}`);

--- a/apps/ensindexer/src/api/lib/indexing-status.ts
+++ b/apps/ensindexer/src/api/lib/indexing-status.ts
@@ -49,6 +49,7 @@ type ChainIndexingStatus =
       startBlock: BlockRef;
       latestIndexedBlock: BlockRef;
       latestKnownBlock: BlockRef;
+      approximateRealtimeDistance: number;
     }
   /**
    * Completed
@@ -305,6 +306,9 @@ export const indexingStatusMiddleware = createMiddleware(async (c) => {
             timestamp: syncBlockTimestamp,
           } satisfies BlockRef;
 
+          const approximateRealtimeDistance =
+            Date.now() - statusBlock.timestamp;
+
           return {
             chainId,
             result: {
@@ -312,6 +316,7 @@ export const indexingStatusMiddleware = createMiddleware(async (c) => {
               startBlock,
               latestIndexedBlock: statusBlock,
               latestKnownBlock: syncBlock,
+              approximateRealtimeDistance,
             } satisfies ChainIndexingStatus,
           };
         }

--- a/apps/ensindexer/src/config/config.schema.ts
+++ b/apps/ensindexer/src/config/config.schema.ts
@@ -78,6 +78,7 @@ const BlockrangeSchema = z
   );
 
 const EnsNodePublicUrlSchema = makeUrlSchema("ENSNODE_PUBLIC_URL");
+const EnsIndexerPrivateUrlSchema = makeUrlSchema("ENSINDEXER_PRIVATE_URL");
 const EnsAdminUrlSchema = makeUrlSchema("ENSADMIN_URL").default(DEFAULT_ENSADMIN_URL);
 
 const PonderDatabaseSchemaSchema = z
@@ -164,6 +165,7 @@ const ENSIndexerConfigSchema = z
   .object({
     namespace: ENSNamespaceSchema,
     globalBlockrange: BlockrangeSchema,
+    ensIndexerPrivateUrl: EnsIndexerPrivateUrlSchema,
     ensNodePublicUrl: EnsNodePublicUrlSchema,
     ensAdminUrl: EnsAdminUrlSchema,
     ponderDatabaseSchema: PonderDatabaseSchemaSchema,

--- a/apps/ensindexer/src/config/index.ts
+++ b/apps/ensindexer/src/config/index.ts
@@ -11,6 +11,7 @@ const environment = {
   plugins: process.env.PLUGINS,
   ensRainbowEndpointUrl: process.env.ENSRAINBOW_URL,
   ensNodePublicUrl: process.env.ENSNODE_PUBLIC_URL,
+  ensIndexerPrivateUrl: process.env.ENSINDEXER_PRIVATE_URL,
   ensAdminUrl: process.env.ENSADMIN_URL,
   healReverseAddresses: process.env.HEAL_REVERSE_ADDRESSES,
   indexAdditionalResolverRecords: process.env.INDEX_ADDITIONAL_RESOLVER_RECORDS,

--- a/apps/ensindexer/src/config/types.ts
+++ b/apps/ensindexer/src/config/types.ts
@@ -59,6 +59,18 @@ export interface ENSIndexerConfig {
   ensNodePublicUrl: string;
 
   /**
+   * The privately accessible endpoint of the ENSIndexer instance (ex: http://localhost:42069).
+   *
+   * This URL is to fetch the status and metrics from the ENSIndexer. For ENSIndexer instances,
+   * this will typically be set to http://localhost:{port}. For ENSApi instances, this should
+   * be set to the private network URL of the corresponding ENSIndexer instance.
+   *
+   * Invariants:
+   * - The URL must be a valid URL (localhost urls are allowed)
+   */
+  ensIndexerPrivateUrl: string;
+
+  /**
    * An ENSRainbow API Endpoint (ex: http://localhost:3223). ENSIndexer uses ENSRainbow to 'heal'
    * unknown labelhashes.
    * @see https://ensnode.io/ensrainbow/overview/what-is-ensrainbow
@@ -221,6 +233,7 @@ export interface ENSIndexerEnvironment {
   plugins: string | undefined;
   ensRainbowEndpointUrl: string | undefined;
   ensNodePublicUrl: string | undefined;
+  ensIndexerPrivateUrl: string | undefined;
   ensAdminUrl: string | undefined;
   healReverseAddresses: string | undefined;
   indexAdditionalResolverRecords: string | undefined;

--- a/apps/ensindexer/test/config.test.ts
+++ b/apps/ensindexer/test/config.test.ts
@@ -157,6 +157,34 @@ describe("config", () => {
     });
   });
 
+  describe(".ensIndexerPrivateUrl", () => {
+    it("throws an error if ENSINDEXER_PRIVATE_URL is not a valid URL", async () => {
+      vi.stubEnv("ENSINDEXER_PRIVATE_URL", "invalid url");
+      await expect(getConfig()).rejects.toThrow(/ENSINDEXER_PRIVATE_URL must be a valid URL string/i);
+    });
+
+    it("throws an error if ENSINDEXER_PRIVATE_URL is empty", async () => {
+      vi.stubEnv("ENSINDEXER_PRIVATE_URL", "");
+      await expect(getConfig()).rejects.toThrow(/ENSINDEXER_PRIVATE_URL must be a valid URL string/i);
+    });
+
+    it("throws an error if ENSINDEXER_PRIVATE_URL is undefined (explicitly testing the refine)", async () => {
+      vi.stubEnv("ENSINDEXER_PRIVATE_URL", undefined);
+      await expect(getConfig()).rejects.toThrow(/ENSINDEXER_PRIVATE_URL must be a valid URL string/i);
+    });
+
+    it("returns the ENSINDEXER_PRIVATE_URL if it is a valid URL", async () => {
+      const config = await getConfig();
+      expect(config.ensIndexerPrivateUrl).toBe("http://localhost:42069");
+    });
+
+    it("returns a different valid ENSINDEXER_PRIVATE_URL if set", async () => {
+      vi.stubEnv("ENSINDEXER_PRIVATE_URL", "https://someotherurl.com");
+      const config = await getConfig();
+      expect(config.ensIndexerPrivateUrl).toBe("https://someotherurl.com");
+    });
+  });
+
   describe(".ensAdminUrl", () => {
     it("throws an error if ENSADMIN_URL is not a valid URL", async () => {
       vi.stubEnv("ENSADMIN_URL", "invalid url");

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       # Override ENSNODE_PUBLIC_URL to point to docker compose ensindexer
       # Note: it must be a "public" URL accessible from a web browser (i.e. it cannot be a hostname exclusive to the internal docker network)
       ENSNODE_PUBLIC_URL: http://localhost:42069
+      # Override ENSINDEXER_PRIVATE_URL to point to docker compose ensindexer
+      ENSINDEXER_PRIVATE_URL: http://localhost:42069
     env_file:
       # NOTE: must define apps/ensindexer/.env.local (see apps/ensindexer/.env.local.example)
       - path: ./apps/ensindexer/.env.local
@@ -41,6 +43,8 @@ services:
       # Override ENSNODE_PUBLIC_URL to point to the docker compose ensindexer-api
       # Note: it must be a "public" URL accessible from a web browser (i.e. it cannot be a hostname exclusive to the internal docker network)
       ENSNODE_PUBLIC_URL: http://localhost:42069
+      # Override ENSINDEXER_PRIVATE_URL to point to the docker compose ensindexer-api
+      ENSINDEXER_PRIVATE_URL: http://localhost:42069
     env_file:
       # NOTE: must define apps/ensindexer/.env.local (see apps/ensindexer/.env.local.example). Requires same env configuration as ensindexer
       - path: ./apps/ensindexer/.env.local

--- a/examples/example-docker-compose/docker-compose.yml
+++ b/examples/example-docker-compose/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       # Override ENSNODE_PUBLIC_URL to point to docker compose ensindexer
       # Note: it must be a "public" URL accessible from a web browser (i.e. it cannot be a hostname exclusive to the internal docker network)
       ENSNODE_PUBLIC_URL: http://localhost:42069
+      # Override ENSINDEXER_PRIVATE_URL to point to docker compose ensindexer
+      ENSINDEXER_PRIVATE_URL: http://localhost:42069
     env_file:
       # NOTE: must define apps/ensindexer/.env.local (see apps/ensindexer/.env.local.example)
       - path: ./apps/ensindexer/.env.local
@@ -41,6 +43,8 @@ services:
       # Override ENSNODE_PUBLIC_URL to point to the docker compose ensindexer-api
       # Note: it must be a "public" URL accessible from a web browser (i.e. it cannot be a hostname exclusive to the internal docker network)
       ENSNODE_PUBLIC_URL: http://localhost:42069
+      # Override ENSINDEXER_PRIVATE_URL to point to the docker compose ensindexer-api
+      ENSINDEXER_PRIVATE_URL: http://localhost:42069
     env_file:
       # NOTE: must define apps/ensindexer/.env.local (see apps/ensindexer/.env.local.example). Requires same env configuration as ensindexer
       - path: ./apps/ensindexer/.env.local


### PR DESCRIPTION
Introduces a new `/indexing-status` endpoint which serves useful progress metrics for each chain.

The custom API endpoint uses data from the Ponder config file, metrics, Status API, and the RPC.

Here's the sample output for a mainnet only instance on my local machine. I also tested it quite a bit on other ponder projects running multiple chains with both multichain and omnichain ordering.

```json
{
  "chains": {
    "1": {
      "status": "backfill",
      "config": {
        "startBlock": {
          "number": 3327417,
          "timestamp": 1489165544
        },
        "endBlock": null
      },
      "latestSyncedBlock": {
        "number": 3884351,
        "timestamp": 1497652888
      },
      "latestIndexedBlock": {
        "number": 3828421,
        "timestamp": 1496734883
      },
      "latestBlock": {
        "number": 22932770,
        "timestamp": 1752681191
      }
    }
  }
}
```