### PR TITLE
ENSDb Compare tool for database exports and comparisons

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "typescript": "catalog:"
   },
   "engines": {
-    "node": ">=22.14.0"
+    "node": ">=20.0.0"
   },
   "pnpm": {
     "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ catalogs:
     tsup:
       specifier: ^8.3.6
       version: 8.3.6
+    tsx:
+      specifier: ^4.19.4
+      version: 4.20.3
     typescript:
       specifier: ^5.7.3
       version: 5.7.3
@@ -74,10 +77,10 @@ overrides:
 
 patchedDependencies:
   '@opentelemetry/api':
-    hash: 4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a
+    hash: izegmddoiqidmvapuxeha6lnw4
     path: patches/@opentelemetry__api.patch
   '@opentelemetry/otlp-exporter-base':
-    hash: b8c870e92957fbc0bd683ab4e2c0034dc892f663b22f2c8b30daeb8f321bbb8d
+    hash: brtaqazy64vzhaznf7q5df2byy
     path: patches/@opentelemetry__otlp-exporter-base.patch
 
 importers:
@@ -95,7 +98,7 @@ importers:
         version: 2.28.1
       tsup:
         specifier: 'catalog:'
-        version: 8.3.6(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0)
+        version: 8.3.6(jiti@2.4.2)(postcss@8.5.3)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0)
       typescript:
         specifier: 'catalog:'
         version: 5.7.3
@@ -191,7 +194,7 @@ importers:
         version: 0.476.0(react@18.3.1)
       next:
         specifier: 15.2.4
-        version: 15.2.4(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 15.2.4(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -249,7 +252,7 @@ importers:
         version: 5.7.3
       vitest:
         specifier: 'catalog:'
-        version: 3.1.1(@types/debug@4.1.12)(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.1.1(@types/debug@4.1.12)(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.20.3)(yaml@2.7.0)
 
   apps/ensindexer:
     dependencies:
@@ -279,31 +282,31 @@ importers:
         version: 0.2.2(hono@4.7.8)
       '@opentelemetry/api':
         specifier: ^1.9.0
-        version: 1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a)
+        version: 1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4)
       '@opentelemetry/core':
         specifier: ^2.0.1
-        version: 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
+        version: 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
       '@opentelemetry/exporter-metrics-otlp-proto':
         specifier: ^0.202.0
-        version: 0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
+        version: 0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
       '@opentelemetry/exporter-trace-otlp-proto':
         specifier: ^0.202.0
-        version: 0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
+        version: 0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
       '@opentelemetry/resources':
         specifier: ^2.0.1
-        version: 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
+        version: 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
       '@opentelemetry/sdk-metrics':
         specifier: ^2.0.1
-        version: 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
+        version: 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
       '@opentelemetry/sdk-node':
         specifier: ^0.202.0
-        version: 0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
+        version: 0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
       '@opentelemetry/sdk-trace-base':
         specifier: ^2.0.1
-        version: 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
+        version: 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
       '@opentelemetry/sdk-trace-node':
         specifier: ^2.0.1
-        version: 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
+        version: 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
       '@opentelemetry/semantic-conventions':
         specifier: ^1.34.0
         version: 1.34.0
@@ -324,7 +327,7 @@ importers:
         version: 2.9.0
       ponder:
         specifier: 'catalog:'
-        version: 0.11.25(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))(@types/node@22.15.3)(@types/pg@8.15.4)(hono@4.7.8)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(typescript@5.7.3)(viem@2.23.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7))(yaml@2.7.0)(zod@3.25.7)
+        version: 0.11.25(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))(@types/node@22.15.3)(@types/pg@8.15.4)(hono@4.7.8)(jiti@2.4.2)(lightningcss@1.29.2)(postgres@3.4.7)(tsx@4.20.3)(typescript@5.7.3)(viem@2.23.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7))(yaml@2.7.0)(zod@3.25.7)
       ponder-enrich-gql-docs-middleware:
         specifier: ^0.1.3
         version: 0.1.3(graphql@16.10.0)(hono@4.7.8)
@@ -349,7 +352,7 @@ importers:
         version: 5.7.3
       vitest:
         specifier: 'catalog:'
-        version: 3.1.1(@types/debug@4.1.12)(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.1.1(@types/debug@4.1.12)(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.20.3)(yaml@2.7.0)
 
   apps/ensrainbow:
     dependencies:
@@ -413,22 +416,22 @@ importers:
     dependencies:
       '@astrojs/mdx':
         specifier: ^4.3.0
-        version: 4.3.0(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0))
+        version: 4.3.0(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0))
       '@astrojs/react':
         specifier: 'catalog:'
-        version: 4.2.0(@types/node@22.15.3)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tsx@4.19.3)(yaml@2.7.0)
+        version: 4.2.0(@types/node@22.15.3)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tsx@4.20.3)(yaml@2.7.0)
       '@astrojs/sitemap':
         specifier: ^3.3.1
         version: 3.3.1
       '@astrojs/starlight':
         specifier: ^0.34.2
-        version: 0.34.2(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0))
+        version: 0.34.2(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0))
       '@astrojs/starlight-tailwind':
         specifier: ^4.0.1
-        version: 4.0.1(@astrojs/starlight@0.34.2(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0)))(tailwindcss@4.1.5)
+        version: 4.0.1(@astrojs/starlight@0.34.2(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0)))(tailwindcss@4.1.5)
       '@astrojs/tailwind':
         specifier: 'catalog:'
-        version: 6.0.0(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0))(tailwindcss@4.1.5)(ts-node@10.9.2(@types/node@22.15.3)(typescript@5.7.3))
+        version: 6.0.0(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0))(tailwindcss@4.1.5)(ts-node@10.9.2(@types/node@22.15.3)(typescript@5.7.3))
       '@fontsource/inter':
         specifier: ^5.2.5
         version: 5.2.5
@@ -449,7 +452,7 @@ importers:
         version: 20.1.2
       '@tailwindcss/vite':
         specifier: ^4.1.5
-        version: 4.1.5(vite@6.2.7(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0))
+        version: 4.1.5(vite@6.2.7(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.20.3)(yaml@2.7.0))
       '@types/react':
         specifier: ^18.3.5
         version: 18.3.18
@@ -458,7 +461,7 @@ importers:
         version: 18.3.5(@types/react@18.3.18)
       astro:
         specifier: ^5.7.11
-        version: 5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0)
+        version: 5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0)
       astro-font:
         specifier: 'catalog:'
         version: 1.0.0
@@ -488,10 +491,10 @@ importers:
         version: 0.33.5
       starlight-llms-txt:
         specifier: ^0.5.0
-        version: 0.5.0(@astrojs/starlight@0.34.2(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0)))(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0))
+        version: 0.5.0(@astrojs/starlight@0.34.2(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0)))(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0))
       starlight-sidebar-topics:
         specifier: ^0.4.1
-        version: 0.4.1(@astrojs/starlight@0.34.2(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0)))
+        version: 0.4.1(@astrojs/starlight@0.34.2(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0)))
       tailwindcss:
         specifier: 4.1.5
         version: 4.1.5
@@ -500,10 +503,10 @@ importers:
     dependencies:
       '@astrojs/react':
         specifier: 'catalog:'
-        version: 4.2.0(@types/node@22.15.3)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tsx@4.19.3)(yaml@2.7.0)
+        version: 4.2.0(@types/node@22.15.3)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tsx@4.20.3)(yaml@2.7.0)
       '@astrojs/tailwind':
         specifier: 'catalog:'
-        version: 6.0.0(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0))(tailwindcss@3.4.13(ts-node@10.9.2(@types/node@22.15.3)(typescript@5.7.3)))(ts-node@10.9.2(@types/node@22.15.3)(typescript@5.7.3))
+        version: 6.0.0(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0))(tailwindcss@3.4.13(ts-node@10.9.2(@types/node@22.15.3)(typescript@5.7.3)))(ts-node@10.9.2(@types/node@22.15.3)(typescript@5.7.3))
       '@heroicons/react':
         specifier: ^2.2.0
         version: 2.2.0(react@18.3.1)
@@ -521,7 +524,7 @@ importers:
         version: 18.3.5(@types/react@18.3.18)
       astro:
         specifier: ^5.3.1
-        version: 5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0)
+        version: 5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0)
       astro-font:
         specifier: 'catalog:'
         version: 1.0.0
@@ -561,7 +564,7 @@ importers:
         version: 22.15.3
       tsup:
         specifier: 'catalog:'
-        version: 8.3.6(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0)
+        version: 8.3.6(jiti@2.4.2)(postcss@8.5.3)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0)
       typescript:
         specifier: 'catalog:'
         version: 5.7.3
@@ -573,7 +576,7 @@ importers:
     dependencies:
       ponder:
         specifier: 'catalog:'
-        version: 0.11.25(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))(@types/node@22.15.3)(@types/pg@8.15.4)(hono@4.7.8)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(typescript@5.7.3)(viem@2.23.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7))(yaml@2.7.0)(zod@3.25.7)
+        version: 0.11.25(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))(@types/node@22.15.3)(@types/pg@8.15.4)(hono@4.7.8)(jiti@2.4.2)(lightningcss@1.29.2)(postgres@3.4.7)(tsx@4.20.3)(typescript@5.7.3)(viem@2.23.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7))(yaml@2.7.0)(zod@3.25.7)
       viem:
         specifier: 'catalog:'
         version: 2.23.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
@@ -586,7 +589,7 @@ importers:
         version: link:../shared-configs
       tsup:
         specifier: 'catalog:'
-        version: 8.3.6(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0)
+        version: 8.3.6(jiti@2.4.2)(postcss@8.5.3)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0)
       typescript:
         specifier: 'catalog:'
         version: 5.7.3
@@ -608,7 +611,7 @@ importers:
         version: 22.15.3
       tsup:
         specifier: ^8.3.6
-        version: 8.3.6(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0)
+        version: 8.3.6(jiti@2.4.2)(postcss@8.5.3)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0)
       typescript:
         specifier: 'catalog:'
         version: 5.7.3
@@ -617,7 +620,7 @@ importers:
         version: 2.23.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
       vitest:
         specifier: 'catalog:'
-        version: 3.1.1(@types/debug@4.1.12)(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.1.1(@types/debug@4.1.12)(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.20.3)(yaml@2.7.0)
 
   packages/ensrainbow-sdk:
     dependencies:
@@ -636,13 +639,13 @@ importers:
         version: link:../shared-configs
       tsup:
         specifier: 'catalog:'
-        version: 8.3.6(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0)
+        version: 8.3.6(jiti@2.4.2)(postcss@8.5.3)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0)
       typescript:
         specifier: 'catalog:'
         version: 5.7.3
       vitest:
         specifier: 'catalog:'
-        version: 3.1.1(@types/debug@4.1.12)(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.1.1(@types/debug@4.1.12)(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.20.3)(yaml@2.7.0)
 
   packages/ponder-metadata:
     dependencies:
@@ -651,7 +654,7 @@ importers:
         version: link:../ensrainbow-sdk
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.41.0(@electric-sql/pglite@0.2.13)(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))(@types/pg@8.15.4)(kysely@0.26.3)(pg@8.11.3)
+        version: 0.41.0(@electric-sql/pglite@0.2.13)(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))(@types/pg@8.15.4)(kysely@0.26.3)(pg@8.11.3)(postgres@3.4.7)
       parse-prometheus-text-format:
         specifier: ^1.1.1
         version: 1.1.1
@@ -673,16 +676,16 @@ importers:
         version: 4.7.8
       ponder:
         specifier: 'catalog:'
-        version: 0.11.25(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))(@types/node@22.15.3)(@types/pg@8.15.4)(hono@4.7.8)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(typescript@5.7.3)(viem@2.23.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7))(yaml@2.7.0)(zod@3.25.7)
+        version: 0.11.25(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))(@types/node@22.15.3)(@types/pg@8.15.4)(hono@4.7.8)(jiti@2.4.2)(lightningcss@1.29.2)(postgres@3.4.7)(tsx@4.20.3)(typescript@5.7.3)(viem@2.23.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7))(yaml@2.7.0)(zod@3.25.7)
       tsup:
         specifier: 'catalog:'
-        version: 8.3.6(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0)
+        version: 8.3.6(jiti@2.4.2)(postcss@8.5.3)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0)
       typescript:
         specifier: 'catalog:'
         version: 5.7.3
       vitest:
         specifier: 'catalog:'
-        version: 3.1.1(@types/debug@4.1.12)(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.1.1(@types/debug@4.1.12)(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.20.3)(yaml@2.7.0)
 
   packages/ponder-subgraph:
     dependencies:
@@ -700,7 +703,7 @@ importers:
         version: 2.2.3
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.41.0(@electric-sql/pglite@0.2.13)(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))(@types/pg@8.15.4)(kysely@0.26.3)(pg@8.11.3)
+        version: 0.41.0(@electric-sql/pglite@0.2.13)(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))(@types/pg@8.15.4)(kysely@0.26.3)(pg@8.11.3)(postgres@3.4.7)
       graphql:
         specifier: ^16.10.0
         version: 16.10.0
@@ -725,7 +728,7 @@ importers:
         version: 4.7.8
       tsup:
         specifier: 'catalog:'
-        version: 8.3.6(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0)
+        version: 8.3.6(jiti@2.4.2)(postcss@8.5.3)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0)
       typescript:
         specifier: 'catalog:'
         version: 5.7.3
@@ -735,6 +738,58 @@ importers:
       '@biomejs/biome':
         specifier: 'catalog:'
         version: 1.9.4
+      typescript:
+        specifier: 'catalog:'
+        version: 5.7.3
+
+  tools/ensdb-compare:
+    dependencies:
+      '@ensnode/ensnode-schema':
+        specifier: workspace:*
+        version: link:../../packages/ensnode-schema
+      chalk:
+        specifier: ^5.3.0
+        version: 5.4.1
+      commander:
+        specifier: ^12.0.0
+        version: 12.1.0
+      drizzle-orm:
+        specifier: 'catalog:'
+        version: 0.41.0(@electric-sql/pglite@0.2.13)(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))(@types/pg@8.15.4)(kysely@0.26.3)(pg@8.11.3)(postgres@3.4.7)
+      fs-extra:
+        specifier: ^11.2.0
+        version: 11.3.0
+      ora:
+        specifier: ^8.0.1
+        version: 8.2.0
+      pg:
+        specifier: ^8.11.3
+        version: 8.11.3
+      postgres:
+        specifier: ^3.4.4
+        version: 3.4.7
+      table:
+        specifier: ^6.8.1
+        version: 6.9.0
+    devDependencies:
+      '@biomejs/biome':
+        specifier: 'catalog:'
+        version: 1.9.4
+      '@ensnode/shared-configs':
+        specifier: workspace:*
+        version: link:../../packages/shared-configs
+      '@types/fs-extra':
+        specifier: ^11.0.4
+        version: 11.0.4
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.15.3
+      '@types/pg':
+        specifier: ^8.10.9
+        version: 8.15.4
+      tsx:
+        specifier: 'catalog:'
+        version: 4.20.3
       typescript:
         specifier: 'catalog:'
         version: 5.7.3
@@ -3031,6 +3086,9 @@ packages:
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
 
+  '@types/fs-extra@11.0.4':
+    resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
+
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
@@ -3042,6 +3100,9 @@ packages:
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@types/jsonfile@6.1.4':
+    resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
@@ -3559,6 +3620,10 @@ packages:
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
+  astral-regex@2.0.0:
+    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
+    engines: {node: '>=8'}
+
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
@@ -3840,6 +3905,14 @@ packages:
   cli-boxes@3.0.0:
     resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
     engines: {node: '>=10'}
+
+  cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
+
+  cli-spinners@2.9.2:
+    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
+    engines: {node: '>=6'}
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
@@ -4838,6 +4911,10 @@ packages:
   framesync@6.0.1:
     resolution: {integrity: sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==}
 
+  fs-extra@11.3.0:
+    resolution: {integrity: sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==}
+    engines: {node: '>=14.14'}
+
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
@@ -5294,6 +5371,10 @@ packages:
     engines: {node: '>=14.16'}
     hasBin: true
 
+  is-interactive@2.0.0:
+    resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
+    engines: {node: '>=12'}
+
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
     engines: {node: '>= 0.4'}
@@ -5349,6 +5430,14 @@ packages:
   is-typed-array@1.1.15:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
+
+  is-unicode-supported@1.3.0:
+    resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
+    engines: {node: '>=12'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
 
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
@@ -5487,6 +5576,9 @@ packages:
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
+
+  jsonfile@6.1.0:
+    resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
 
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
@@ -5663,8 +5755,15 @@ packages:
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
+  lodash.truncate@4.4.2:
+    resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
+
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
+  log-symbols@6.0.0:
+    resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
+    engines: {node: '>=18'}
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
@@ -5931,6 +6030,10 @@ packages:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
 
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
+
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
@@ -6172,6 +6275,10 @@ packages:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
 
+  onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
+
   oniguruma-parser@0.12.1:
     resolution: {integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==}
 
@@ -6181,6 +6288,10 @@ packages:
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
+
+  ora@8.2.0:
+    resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
+    engines: {node: '>=18'}
 
   os-tmpdir@1.0.2:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
@@ -6546,6 +6657,10 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
+  postgres@3.4.7:
+    resolution: {integrity: sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==}
+    engines: {node: '>=12'}
+
   preact@10.26.4:
     resolution: {integrity: sha512-KJhO7LBFTjP71d83trW+Ilnjbo+ySsaAgCfXOXUlmGzJ4ygYPWmysm77yg4emwfmoz3b22yvH5IsVFHbhUaH5w==}
 
@@ -6858,6 +6973,10 @@ packages:
     resolution: {integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==}
     hasBin: true
 
+  restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
+
   restructure@3.0.2:
     resolution: {integrity: sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==}
 
@@ -7022,6 +7141,10 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
+  slice-ansi@4.0.0:
+    resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
+    engines: {node: '>=10'}
+
   smol-toml@1.3.1:
     resolution: {integrity: sha512-tEYNll18pPKHroYSmLLrksq233j021G0giwW7P3D24jC54pQ5W5BXMsQ/Mvw1OJCmEYDgY+lrzT+3nNUtoNfXQ==}
     engines: {node: '>= 18'}
@@ -7119,6 +7242,10 @@ packages:
 
   std-env@3.8.1:
     resolution: {integrity: sha512-vj5lIj3Mwf9D79hBkltk5qmkFI+biIKWS2IBxEyEU3AX1tUf7AoL8nSazCOiiqQsGKIq01SClsKEzweu34uwvA==}
+
+  stdin-discarder@0.2.2:
+    resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
+    engines: {node: '>=18'}
 
   stream-replace-string@2.0.0:
     resolution: {integrity: sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==}
@@ -7251,6 +7378,10 @@ packages:
 
   tabbable@6.2.0:
     resolution: {integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==}
+
+  table@6.9.0:
+    resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
+    engines: {node: '>=10.0.0'}
 
   tailwind-merge@3.0.2:
     resolution: {integrity: sha512-l7z+OYZ7mu3DTqrL88RiKrKIqO3NcpEO8V/Od04bNpvk0kiIFndGEoqfuzvj4yuhRkHKjRkII2z+KS2HfPcSxw==}
@@ -7440,6 +7571,11 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  tsx@4.20.3:
+    resolution: {integrity: sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -7577,6 +7713,10 @@ packages:
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
+
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
 
   unstorage@1.15.0:
     resolution: {integrity: sha512-m40eHdGY/gA6xAPqo8eaxqXgBuzQTlAKfmB1iF7oCKXE1HfwHwzDJBywK+qQGn52dta+bPlZluPF7++yR3p/bg==}
@@ -8389,12 +8529,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@4.3.0(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0))':
+  '@astrojs/mdx@4.3.0(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0))':
     dependencies:
       '@astrojs/markdown-remark': 6.3.2
       '@mdx-js/mdx': 3.1.0(acorn@8.14.1)
       acorn: 8.14.1
-      astro: 5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0)
+      astro: 5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0)
       es-module-lexer: 1.6.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -8416,15 +8556,15 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
-  '@astrojs/react@4.2.0(@types/node@22.15.3)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tsx@4.19.3)(yaml@2.7.0)':
+  '@astrojs/react@4.2.0(@types/node@22.15.3)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tsx@4.20.3)(yaml@2.7.0)':
     dependencies:
       '@types/react': 18.3.18
       '@types/react-dom': 18.3.5(@types/react@18.3.18)
-      '@vitejs/plugin-react': 4.3.4(vite@6.2.7(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0))
+      '@vitejs/plugin-react': 4.3.4(vite@6.2.7(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.20.3)(yaml@2.7.0))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       ultrahtml: 1.6.0
-      vite: 6.2.7(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.2.7(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.20.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -8445,22 +8585,22 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 3.24.4
 
-  '@astrojs/starlight-tailwind@4.0.1(@astrojs/starlight@0.34.2(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0)))(tailwindcss@4.1.5)':
+  '@astrojs/starlight-tailwind@4.0.1(@astrojs/starlight@0.34.2(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0)))(tailwindcss@4.1.5)':
     dependencies:
-      '@astrojs/starlight': 0.34.2(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0))
+      '@astrojs/starlight': 0.34.2(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0))
       tailwindcss: 4.1.5
 
-  '@astrojs/starlight@0.34.2(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0))':
+  '@astrojs/starlight@0.34.2(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0))':
     dependencies:
       '@astrojs/markdown-remark': 6.3.1
-      '@astrojs/mdx': 4.3.0(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0))
+      '@astrojs/mdx': 4.3.0(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0))
       '@astrojs/sitemap': 3.3.1
       '@pagefind/default-ui': 1.3.0
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0)
-      astro-expressive-code: 0.41.2(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0))
+      astro: 5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0)
+      astro-expressive-code: 0.41.2(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.3
@@ -8483,9 +8623,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/tailwind@6.0.0(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0))(tailwindcss@3.4.13(ts-node@10.9.2(@types/node@22.15.3)(typescript@5.7.3)))(ts-node@10.9.2(@types/node@22.15.3)(typescript@5.7.3))':
+  '@astrojs/tailwind@6.0.0(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0))(tailwindcss@3.4.13(ts-node@10.9.2(@types/node@22.15.3)(typescript@5.7.3)))(ts-node@10.9.2(@types/node@22.15.3)(typescript@5.7.3))':
     dependencies:
-      astro: 5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0)
+      astro: 5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0)
       autoprefixer: 10.4.20(postcss@8.5.3)
       postcss: 8.5.3
       postcss-load-config: 4.0.2(postcss@8.5.3)(ts-node@10.9.2(@types/node@22.15.3)(typescript@5.7.3))
@@ -8493,9 +8633,9 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  '@astrojs/tailwind@6.0.0(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0))(tailwindcss@4.1.5)(ts-node@10.9.2(@types/node@22.15.3)(typescript@5.7.3))':
+  '@astrojs/tailwind@6.0.0(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0))(tailwindcss@4.1.5)(ts-node@10.9.2(@types/node@22.15.3)(typescript@5.7.3))':
     dependencies:
-      astro: 5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0)
+      astro: 5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0)
       autoprefixer: 10.4.20(postcss@8.5.3)
       postcss: 8.5.3
       postcss-load-config: 4.0.2(postcss@8.5.3)(ts-node@10.9.2(@types/node@22.15.3)(typescript@5.7.3))
@@ -9393,7 +9533,7 @@ snapshots:
 
   '@hono/otel@0.2.2(hono@4.7.8)':
     dependencies:
-      '@opentelemetry/api': 1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a)
+      '@opentelemetry/api': 1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4)
       '@opentelemetry/semantic-conventions': 1.34.0
       hono: 4.7.8
 
@@ -10060,228 +10200,228 @@ snapshots:
 
   '@opentelemetry/api-logs@0.202.0':
     dependencies:
-      '@opentelemetry/api': 1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a)
+      '@opentelemetry/api': 1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4)
 
-  '@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a)': {}
+  '@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4)': {}
 
-  '@opentelemetry/context-async-hooks@2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))':
+  '@opentelemetry/context-async-hooks@2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))':
     dependencies:
-      '@opentelemetry/api': 1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a)
+      '@opentelemetry/api': 1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4)
 
-  '@opentelemetry/core@2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))':
+  '@opentelemetry/core@2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))':
     dependencies:
-      '@opentelemetry/api': 1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a)
+      '@opentelemetry/api': 1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4)
       '@opentelemetry/semantic-conventions': 1.34.0
 
-  '@opentelemetry/exporter-logs-otlp-grpc@0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))':
+  '@opentelemetry/exporter-logs-otlp-grpc@0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))':
     dependencies:
       '@grpc/grpc-js': 1.13.4
-      '@opentelemetry/api': 1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a)
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/otlp-exporter-base': 0.202.0(patch_hash=b8c870e92957fbc0bd683ab4e2c0034dc892f663b22f2c8b30daeb8f321bbb8d)(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/otlp-grpc-exporter-base': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/otlp-transformer': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/sdk-logs': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
+      '@opentelemetry/api': 1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4)
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/otlp-exporter-base': 0.202.0(patch_hash=brtaqazy64vzhaznf7q5df2byy)(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/otlp-grpc-exporter-base': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/otlp-transformer': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/sdk-logs': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
 
-  '@opentelemetry/exporter-logs-otlp-http@0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))':
+  '@opentelemetry/exporter-logs-otlp-http@0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))':
     dependencies:
-      '@opentelemetry/api': 1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a)
+      '@opentelemetry/api': 1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4)
       '@opentelemetry/api-logs': 0.202.0
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/otlp-exporter-base': 0.202.0(patch_hash=b8c870e92957fbc0bd683ab4e2c0034dc892f663b22f2c8b30daeb8f321bbb8d)(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/otlp-transformer': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/sdk-logs': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/otlp-exporter-base': 0.202.0(patch_hash=brtaqazy64vzhaznf7q5df2byy)(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/otlp-transformer': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/sdk-logs': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
 
-  '@opentelemetry/exporter-logs-otlp-proto@0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))':
+  '@opentelemetry/exporter-logs-otlp-proto@0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))':
     dependencies:
-      '@opentelemetry/api': 1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a)
+      '@opentelemetry/api': 1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4)
       '@opentelemetry/api-logs': 0.202.0
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/otlp-exporter-base': 0.202.0(patch_hash=b8c870e92957fbc0bd683ab4e2c0034dc892f663b22f2c8b30daeb8f321bbb8d)(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/otlp-transformer': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/sdk-logs': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/otlp-exporter-base': 0.202.0(patch_hash=brtaqazy64vzhaznf7q5df2byy)(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/otlp-transformer': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/sdk-logs': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
 
-  '@opentelemetry/exporter-metrics-otlp-grpc@0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))':
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))':
     dependencies:
       '@grpc/grpc-js': 1.13.4
-      '@opentelemetry/api': 1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a)
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/exporter-metrics-otlp-http': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/otlp-exporter-base': 0.202.0(patch_hash=b8c870e92957fbc0bd683ab4e2c0034dc892f663b22f2c8b30daeb8f321bbb8d)(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/otlp-grpc-exporter-base': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/otlp-transformer': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/sdk-metrics': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
+      '@opentelemetry/api': 1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4)
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/exporter-metrics-otlp-http': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/otlp-exporter-base': 0.202.0(patch_hash=brtaqazy64vzhaznf7q5df2byy)(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/otlp-grpc-exporter-base': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/otlp-transformer': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/sdk-metrics': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
 
-  '@opentelemetry/exporter-metrics-otlp-http@0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))':
+  '@opentelemetry/exporter-metrics-otlp-http@0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))':
     dependencies:
-      '@opentelemetry/api': 1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a)
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/otlp-exporter-base': 0.202.0(patch_hash=b8c870e92957fbc0bd683ab4e2c0034dc892f663b22f2c8b30daeb8f321bbb8d)(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/otlp-transformer': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/sdk-metrics': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
+      '@opentelemetry/api': 1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4)
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/otlp-exporter-base': 0.202.0(patch_hash=brtaqazy64vzhaznf7q5df2byy)(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/otlp-transformer': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/sdk-metrics': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
 
-  '@opentelemetry/exporter-metrics-otlp-proto@0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))':
+  '@opentelemetry/exporter-metrics-otlp-proto@0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))':
     dependencies:
-      '@opentelemetry/api': 1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a)
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/exporter-metrics-otlp-http': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/otlp-exporter-base': 0.202.0(patch_hash=b8c870e92957fbc0bd683ab4e2c0034dc892f663b22f2c8b30daeb8f321bbb8d)(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/otlp-transformer': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/sdk-metrics': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
+      '@opentelemetry/api': 1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4)
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/exporter-metrics-otlp-http': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/otlp-exporter-base': 0.202.0(patch_hash=brtaqazy64vzhaznf7q5df2byy)(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/otlp-transformer': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/sdk-metrics': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
 
-  '@opentelemetry/exporter-prometheus@0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))':
+  '@opentelemetry/exporter-prometheus@0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))':
     dependencies:
-      '@opentelemetry/api': 1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a)
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/sdk-metrics': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
+      '@opentelemetry/api': 1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4)
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/sdk-metrics': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
 
-  '@opentelemetry/exporter-trace-otlp-grpc@0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))':
+  '@opentelemetry/exporter-trace-otlp-grpc@0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))':
     dependencies:
       '@grpc/grpc-js': 1.13.4
-      '@opentelemetry/api': 1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a)
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/otlp-exporter-base': 0.202.0(patch_hash=b8c870e92957fbc0bd683ab4e2c0034dc892f663b22f2c8b30daeb8f321bbb8d)(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/otlp-grpc-exporter-base': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/otlp-transformer': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
+      '@opentelemetry/api': 1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4)
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/otlp-exporter-base': 0.202.0(patch_hash=brtaqazy64vzhaznf7q5df2byy)(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/otlp-grpc-exporter-base': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/otlp-transformer': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
 
-  '@opentelemetry/exporter-trace-otlp-http@0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))':
+  '@opentelemetry/exporter-trace-otlp-http@0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))':
     dependencies:
-      '@opentelemetry/api': 1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a)
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/otlp-exporter-base': 0.202.0(patch_hash=b8c870e92957fbc0bd683ab4e2c0034dc892f663b22f2c8b30daeb8f321bbb8d)(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/otlp-transformer': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
+      '@opentelemetry/api': 1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4)
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/otlp-exporter-base': 0.202.0(patch_hash=brtaqazy64vzhaznf7q5df2byy)(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/otlp-transformer': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
 
-  '@opentelemetry/exporter-trace-otlp-proto@0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))':
+  '@opentelemetry/exporter-trace-otlp-proto@0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))':
     dependencies:
-      '@opentelemetry/api': 1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a)
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/otlp-exporter-base': 0.202.0(patch_hash=b8c870e92957fbc0bd683ab4e2c0034dc892f663b22f2c8b30daeb8f321bbb8d)(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/otlp-transformer': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
+      '@opentelemetry/api': 1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4)
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/otlp-exporter-base': 0.202.0(patch_hash=brtaqazy64vzhaznf7q5df2byy)(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/otlp-transformer': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
 
-  '@opentelemetry/exporter-zipkin@2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))':
+  '@opentelemetry/exporter-zipkin@2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))':
     dependencies:
-      '@opentelemetry/api': 1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a)
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
+      '@opentelemetry/api': 1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4)
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
       '@opentelemetry/semantic-conventions': 1.34.0
 
-  '@opentelemetry/instrumentation@0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))':
+  '@opentelemetry/instrumentation@0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))':
     dependencies:
-      '@opentelemetry/api': 1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a)
+      '@opentelemetry/api': 1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4)
       '@opentelemetry/api-logs': 0.202.0
       import-in-the-middle: 1.14.2
       require-in-the-middle: 7.5.2
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/otlp-exporter-base@0.202.0(patch_hash=b8c870e92957fbc0bd683ab4e2c0034dc892f663b22f2c8b30daeb8f321bbb8d)(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))':
+  '@opentelemetry/otlp-exporter-base@0.202.0(patch_hash=brtaqazy64vzhaznf7q5df2byy)(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))':
     dependencies:
-      '@opentelemetry/api': 1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a)
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/otlp-transformer': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
+      '@opentelemetry/api': 1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4)
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/otlp-transformer': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
 
-  '@opentelemetry/otlp-grpc-exporter-base@0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))':
+  '@opentelemetry/otlp-grpc-exporter-base@0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))':
     dependencies:
       '@grpc/grpc-js': 1.13.4
-      '@opentelemetry/api': 1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a)
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/otlp-exporter-base': 0.202.0(patch_hash=b8c870e92957fbc0bd683ab4e2c0034dc892f663b22f2c8b30daeb8f321bbb8d)(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/otlp-transformer': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
+      '@opentelemetry/api': 1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4)
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/otlp-exporter-base': 0.202.0(patch_hash=brtaqazy64vzhaznf7q5df2byy)(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/otlp-transformer': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
 
-  '@opentelemetry/otlp-transformer@0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))':
+  '@opentelemetry/otlp-transformer@0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))':
     dependencies:
-      '@opentelemetry/api': 1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a)
+      '@opentelemetry/api': 1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4)
       '@opentelemetry/api-logs': 0.202.0
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/sdk-logs': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/sdk-metrics': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/sdk-logs': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/sdk-metrics': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
       protobufjs: 7.5.3
 
-  '@opentelemetry/propagator-b3@2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))':
+  '@opentelemetry/propagator-b3@2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))':
     dependencies:
-      '@opentelemetry/api': 1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a)
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
+      '@opentelemetry/api': 1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4)
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
 
-  '@opentelemetry/propagator-jaeger@2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))':
+  '@opentelemetry/propagator-jaeger@2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))':
     dependencies:
-      '@opentelemetry/api': 1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a)
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
+      '@opentelemetry/api': 1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4)
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
 
-  '@opentelemetry/resources@2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))':
+  '@opentelemetry/resources@2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))':
     dependencies:
-      '@opentelemetry/api': 1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a)
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
+      '@opentelemetry/api': 1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4)
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
       '@opentelemetry/semantic-conventions': 1.34.0
 
-  '@opentelemetry/sdk-logs@0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))':
+  '@opentelemetry/sdk-logs@0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))':
     dependencies:
-      '@opentelemetry/api': 1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a)
+      '@opentelemetry/api': 1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4)
       '@opentelemetry/api-logs': 0.202.0
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
 
-  '@opentelemetry/sdk-metrics@2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))':
+  '@opentelemetry/sdk-metrics@2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))':
     dependencies:
-      '@opentelemetry/api': 1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a)
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
+      '@opentelemetry/api': 1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4)
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
 
-  '@opentelemetry/sdk-node@0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))':
+  '@opentelemetry/sdk-node@0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))':
     dependencies:
-      '@opentelemetry/api': 1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a)
+      '@opentelemetry/api': 1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4)
       '@opentelemetry/api-logs': 0.202.0
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/exporter-logs-otlp-grpc': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/exporter-logs-otlp-http': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/exporter-logs-otlp-proto': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/exporter-metrics-otlp-grpc': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/exporter-metrics-otlp-http': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/exporter-metrics-otlp-proto': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/exporter-prometheus': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/exporter-trace-otlp-grpc': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/exporter-trace-otlp-http': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/exporter-trace-otlp-proto': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/exporter-zipkin': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/instrumentation': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/propagator-b3': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/propagator-jaeger': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/sdk-logs': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/sdk-metrics': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/sdk-trace-node': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/exporter-logs-otlp-grpc': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/exporter-logs-otlp-http': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/exporter-logs-otlp-proto': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/exporter-metrics-otlp-grpc': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/exporter-metrics-otlp-http': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/exporter-metrics-otlp-proto': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/exporter-prometheus': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/exporter-trace-otlp-grpc': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/exporter-trace-otlp-http': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/exporter-trace-otlp-proto': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/exporter-zipkin': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/instrumentation': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/propagator-b3': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/propagator-jaeger': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/sdk-logs': 0.202.0(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/sdk-metrics': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/sdk-trace-node': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
       '@opentelemetry/semantic-conventions': 1.34.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))':
+  '@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))':
     dependencies:
-      '@opentelemetry/api': 1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a)
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
+      '@opentelemetry/api': 1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4)
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
       '@opentelemetry/semantic-conventions': 1.34.0
 
-  '@opentelemetry/sdk-trace-node@2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))':
+  '@opentelemetry/sdk-trace-node@2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))':
     dependencies:
-      '@opentelemetry/api': 1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a)
-      '@opentelemetry/context-async-hooks': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
-      '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))
+      '@opentelemetry/api': 1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4)
+      '@opentelemetry/context-async-hooks': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
+      '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))
 
   '@opentelemetry/semantic-conventions@1.34.0': {}
 
@@ -10979,12 +11119,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.5
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.5
 
-  '@tailwindcss/vite@4.1.5(vite@6.2.7(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0))':
+  '@tailwindcss/vite@4.1.5(vite@6.2.7(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.20.3)(yaml@2.7.0))':
     dependencies:
       '@tailwindcss/node': 4.1.5
       '@tailwindcss/oxide': 4.1.5
       tailwindcss: 4.1.5
-      vite: 6.2.7(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.2.7(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.20.3)(yaml@2.7.0)
 
   '@tanstack/query-core@5.67.1': {}
 
@@ -11087,6 +11227,11 @@ snapshots:
 
   '@types/estree@1.0.7': {}
 
+  '@types/fs-extra@11.0.4':
+    dependencies:
+      '@types/jsonfile': 6.1.4
+      '@types/node': 22.15.3
+
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -11096,6 +11241,10 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
+
+  '@types/jsonfile@6.1.4':
+    dependencies:
+      '@types/node': 22.15.3
 
   '@types/mdast@4.0.4':
     dependencies:
@@ -11139,7 +11288,6 @@ snapshots:
       '@types/node': 22.15.3
       pg-protocol: 1.7.0
       pg-types: 2.2.0
-    optional: true
 
   '@types/progress@2.0.7':
     dependencies:
@@ -11265,14 +11413,14 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@4.3.4(vite@6.2.7(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0))':
+  '@vitejs/plugin-react@4.3.4(vite@6.2.7(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.20.3)(yaml@2.7.0))':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.9)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.9)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 6.2.7(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.2.7(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.20.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11309,13 +11457,13 @@ snapshots:
     optionalDependencies:
       vite: 6.2.7(@types/node@20.17.14)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0)
 
-  '@vitest/mocker@3.1.1(vite@6.2.7(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0))':
+  '@vitest/mocker@3.1.1(vite@6.2.7(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.20.3)(yaml@2.7.0))':
     dependencies:
       '@vitest/spy': 3.1.1
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.2.7(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.2.7(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.20.3)(yaml@2.7.0)
 
   '@vitest/pretty-format@3.1.1':
     dependencies:
@@ -12053,11 +12201,13 @@ snapshots:
 
   ast-types-flow@0.0.8: {}
 
+  astral-regex@2.0.0: {}
+
   astring@1.9.0: {}
 
-  astro-expressive-code@0.41.2(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0)):
+  astro-expressive-code@0.41.2(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0)):
     dependencies:
-      astro: 5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0)
+      astro: 5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0)
       rehype-expressive-code: 0.41.2
 
   astro-font@1.0.0: {}
@@ -12079,7 +12229,7 @@ snapshots:
       - prettier-plugin-astro
       - typescript
 
-  astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0):
+  astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0):
     dependencies:
       '@astrojs/compiler': 2.11.0
       '@astrojs/internal-helpers': 0.6.1
@@ -12132,8 +12282,8 @@ snapshots:
       unist-util-visit: 5.0.0
       unstorage: 1.15.0(idb-keyval@6.2.1)
       vfile: 6.0.3
-      vite: 6.2.7(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0)
-      vitefu: 1.0.6(vite@6.2.7(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0))
+      vite: 6.2.7(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.20.3)(yaml@2.7.0)
+      vitefu: 1.0.6(vite@6.2.7(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.20.3)(yaml@2.7.0))
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
       yocto-spinner: 0.2.1
@@ -12439,6 +12589,12 @@ snapshots:
       node-gyp-build: 4.8.4
 
   cli-boxes@3.0.0: {}
+
+  cli-cursor@5.0.0:
+    dependencies:
+      restore-cursor: 5.1.0
+
+  cli-spinners@2.9.2: {}
 
   client-only@0.0.1: {}
 
@@ -12810,13 +12966,14 @@ snapshots:
 
   dotenv@8.6.0: {}
 
-  drizzle-orm@0.41.0(@electric-sql/pglite@0.2.13)(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))(@types/pg@8.15.4)(kysely@0.26.3)(pg@8.11.3):
+  drizzle-orm@0.41.0(@electric-sql/pglite@0.2.13)(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))(@types/pg@8.15.4)(kysely@0.26.3)(pg@8.11.3)(postgres@3.4.7):
     optionalDependencies:
       '@electric-sql/pglite': 0.2.13
-      '@opentelemetry/api': 1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a)
+      '@opentelemetry/api': 1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4)
       '@types/pg': 8.15.4
       kysely: 0.26.3
       pg: 8.11.3
+      postgres: 3.4.7
 
   dset@3.1.4: {}
 
@@ -13066,8 +13223,8 @@ snapshots:
       '@typescript-eslint/parser': 8.24.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3)
       eslint: 9.20.1(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.8.3(eslint-plugin-import@2.31.0)(eslint@9.20.1(jiti@2.4.2))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.24.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-typescript@3.8.3)(eslint@9.20.1(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.8.3(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.24.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3))(eslint@9.20.1(jiti@2.4.2)))(eslint@9.20.1(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.24.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-typescript@3.8.3(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.24.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3))(eslint@9.20.1(jiti@2.4.2)))(eslint@9.20.1(jiti@2.4.2)))(eslint@9.20.1(jiti@2.4.2))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.20.1(jiti@2.4.2))
       eslint-plugin-react: 7.37.4(eslint@9.20.1(jiti@2.4.2))
       eslint-plugin-react-hooks: 5.1.0(eslint@9.20.1(jiti@2.4.2))
@@ -13086,7 +13243,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.8.3(eslint-plugin-import@2.31.0)(eslint@9.20.1(jiti@2.4.2)):
+  eslint-import-resolver-typescript@3.8.3(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.24.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3))(eslint@9.20.1(jiti@2.4.2)))(eslint@9.20.1(jiti@2.4.2)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0
@@ -13097,22 +13254,22 @@ snapshots:
       stable-hash: 0.0.4
       tinyglobby: 0.2.14
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.24.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-typescript@3.8.3)(eslint@9.20.1(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.24.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-typescript@3.8.3(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.24.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3))(eslint@9.20.1(jiti@2.4.2)))(eslint@9.20.1(jiti@2.4.2)))(eslint@9.20.1(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.24.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@9.20.1(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.24.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.24.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3))(eslint@9.20.1(jiti@2.4.2)))(eslint@9.20.1(jiti@2.4.2)))(eslint@9.20.1(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.24.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3)
       eslint: 9.20.1(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.8.3(eslint-plugin-import@2.31.0)(eslint@9.20.1(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.8.3(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.24.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3))(eslint@9.20.1(jiti@2.4.2)))(eslint@9.20.1(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.24.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-typescript@3.8.3)(eslint@9.20.1(jiti@2.4.2)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.24.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-typescript@3.8.3(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.24.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3))(eslint@9.20.1(jiti@2.4.2)))(eslint@9.20.1(jiti@2.4.2)))(eslint@9.20.1(jiti@2.4.2)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -13123,7 +13280,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.20.1(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.24.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@9.20.1(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.24.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.24.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3))(eslint@9.20.1(jiti@2.4.2)))(eslint@9.20.1(jiti@2.4.2)))(eslint@9.20.1(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -13529,6 +13686,12 @@ snapshots:
   framesync@6.0.1:
     dependencies:
       tslib: 2.8.1
+
+  fs-extra@11.3.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.1.0
+      universalify: 2.0.1
 
   fs-extra@7.0.1:
     dependencies:
@@ -14160,6 +14323,8 @@ snapshots:
     dependencies:
       is-docker: 3.0.0
 
+  is-interactive@2.0.0: {}
+
   is-map@2.0.3: {}
 
   is-number-object@1.1.1:
@@ -14210,6 +14375,10 @@ snapshots:
   is-typed-array@1.1.15:
     dependencies:
       which-typed-array: 1.1.18
+
+  is-unicode-supported@1.3.0: {}
+
+  is-unicode-supported@2.1.0: {}
 
   is-weakmap@2.0.2: {}
 
@@ -14329,6 +14498,12 @@ snapshots:
   jsonc-parser@3.3.1: {}
 
   jsonfile@4.0.0:
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
+  jsonfile@6.1.0:
+    dependencies:
+      universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
 
@@ -14481,7 +14656,14 @@ snapshots:
 
   lodash.startcase@4.4.0: {}
 
+  lodash.truncate@4.4.2: {}
+
   lodash@4.17.21: {}
+
+  log-symbols@6.0.0:
+    dependencies:
+      chalk: 5.4.1
+      is-unicode-supported: 1.3.0
 
   long@5.3.2: {}
 
@@ -15027,6 +15209,8 @@ snapshots:
 
   mimic-fn@4.0.0: {}
 
+  mimic-function@5.0.1: {}
+
   minimalistic-assert@1.0.1: {}
 
   minimalistic-crypto-utils@1.0.1: {}
@@ -15111,7 +15295,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  next@15.2.4(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@15.2.4(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 15.2.4
       '@swc/counter': 0.1.3
@@ -15131,7 +15315,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.2.4
       '@next/swc-win32-arm64-msvc': 15.2.4
       '@next/swc-win32-x64-msvc': 15.2.4
-      '@opentelemetry/api': 1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a)
+      '@opentelemetry/api': 1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4)
       sharp: 0.33.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -15248,6 +15432,10 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
+  onetime@7.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+
   oniguruma-parser@0.12.1: {}
 
   oniguruma-to-es@4.3.3:
@@ -15264,6 +15452,18 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
+  ora@8.2.0:
+    dependencies:
+      chalk: 5.4.1
+      cli-cursor: 5.0.0
+      cli-spinners: 2.9.2
+      is-interactive: 2.0.0
+      is-unicode-supported: 2.1.0
+      log-symbols: 6.0.0
+      stdin-discarder: 0.2.2
+      string-width: 7.2.0
+      strip-ansi: 7.1.0
 
   os-tmpdir@1.0.2: {}
 
@@ -15554,7 +15754,7 @@ snapshots:
       graphql: 16.10.0
       hono: 4.7.8
 
-  ponder@0.11.25(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))(@types/node@22.15.3)(@types/pg@8.15.4)(hono@4.7.8)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(typescript@5.7.3)(viem@2.23.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7))(yaml@2.7.0)(zod@3.25.7):
+  ponder@0.11.25(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))(@types/node@22.15.3)(@types/pg@8.15.4)(hono@4.7.8)(jiti@2.4.2)(lightningcss@1.29.2)(postgres@3.4.7)(tsx@4.20.3)(typescript@5.7.3)(viem@2.23.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7))(yaml@2.7.0)(zod@3.25.7):
     dependencies:
       '@babel/code-frame': 7.26.2
       '@commander-js/extra-typings': 12.1.0(commander@12.1.0)
@@ -15571,7 +15771,7 @@ snapshots:
       dataloader: 2.2.3
       detect-package-manager: 3.0.2
       dotenv: 16.4.7
-      drizzle-orm: 0.41.0(@electric-sql/pglite@0.2.13)(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))(@types/pg@8.15.4)(kysely@0.26.3)(pg@8.11.3)
+      drizzle-orm: 0.41.0(@electric-sql/pglite@0.2.13)(@opentelemetry/api@1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4))(@types/pg@8.15.4)(kysely@0.26.3)(pg@8.11.3)(postgres@3.4.7)
       glob: 10.4.5
       graphql: 16.10.0
       graphql-yoga: 5.10.10(graphql@16.10.0)
@@ -15590,9 +15790,9 @@ snapshots:
       superjson: 2.2.2
       terminal-size: 4.0.0
       viem: 2.23.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
-      vite: 6.3.5(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0)
-      vite-node: 1.0.2(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0)
-      vite-tsconfig-paths: 4.3.1(typescript@5.7.3)(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0))
+      vite: 6.3.5(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.20.3)(yaml@2.7.0)
+      vite-node: 1.0.2(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.20.3)(yaml@2.7.0)
+      vite-tsconfig-paths: 4.3.1(typescript@5.7.3)(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.20.3)(yaml@2.7.0))
     optionalDependencies:
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -15667,13 +15867,13 @@ snapshots:
       postcss: 8.5.3
       ts-node: 10.9.2(@types/node@22.15.3)(typescript@5.7.3)
 
-  postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.0):
+  postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.20.3)(yaml@2.7.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.4.2
       postcss: 8.5.3
-      tsx: 4.19.3
+      tsx: 4.20.3
       yaml: 2.7.0
 
   postcss-nested@6.2.0(postcss@8.5.3):
@@ -15710,6 +15910,8 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
+  postgres@3.4.7: {}
+
   preact@10.26.4: {}
 
   prelude-ls@1.2.1: {}
@@ -15733,7 +15935,7 @@ snapshots:
 
   prom-client@15.1.3:
     dependencies:
-      '@opentelemetry/api': 1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a)
+      '@opentelemetry/api': 1.9.0(patch_hash=izegmddoiqidmvapuxeha6lnw4)
       tdigest: 0.1.2
 
   prompts@2.4.2:
@@ -16113,6 +16315,11 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  restore-cursor@5.1.0:
+    dependencies:
+      onetime: 7.0.0
+      signal-exit: 4.1.0
+
   restructure@3.0.2: {}
 
   retext-latin@4.0.0:
@@ -16349,6 +16556,12 @@ snapshots:
 
   slash@3.0.0: {}
 
+  slice-ansi@4.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      astral-regex: 2.0.0
+      is-fullwidth-code-point: 3.0.0
+
   smol-toml@1.3.1: {}
 
   socket.io-client@4.8.1(bufferutil@4.0.9)(utf-8-validate@5.0.10):
@@ -16432,13 +16645,13 @@ snapshots:
     dependencies:
       type-fest: 0.7.1
 
-  starlight-llms-txt@0.5.0(@astrojs/starlight@0.34.2(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0)))(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0)):
+  starlight-llms-txt@0.5.0(@astrojs/starlight@0.34.2(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0)))(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0)):
     dependencies:
-      '@astrojs/mdx': 4.3.0(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0))
-      '@astrojs/starlight': 0.34.2(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0))
+      '@astrojs/mdx': 4.3.0(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0))
+      '@astrojs/starlight': 0.34.2(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0))
       '@types/hast': 3.0.4
       '@types/micromatch': 4.0.9
-      astro: 5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0)
+      astro: 5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0)
       github-slugger: 2.0.0
       hast-util-select: 6.0.3
       micromatch: 4.0.8
@@ -16451,11 +16664,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  starlight-sidebar-topics@0.4.1(@astrojs/starlight@0.34.2(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0))):
+  starlight-sidebar-topics@0.4.1(@astrojs/starlight@0.34.2(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0))):
     dependencies:
-      '@astrojs/starlight': 0.34.2(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0))
+      '@astrojs/starlight': 0.34.2(astro@5.7.11(@types/node@22.15.3)(idb-keyval@6.2.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0))
 
   std-env@3.8.1: {}
+
+  stdin-discarder@0.2.2: {}
 
   stream-replace-string@2.0.0: {}
 
@@ -16611,6 +16826,14 @@ snapshots:
       picocolors: 1.1.1
 
   tabbable@6.2.0: {}
+
+  table@6.9.0:
+    dependencies:
+      ajv: 8.17.1
+      lodash.truncate: 4.4.2
+      slice-ansi: 4.0.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
 
   tailwind-merge@3.0.2: {}
 
@@ -16805,7 +17028,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.3.6(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0):
+  tsup@8.3.6(jiti@2.4.2)(postcss@8.5.3)(tsx@4.20.3)(typescript@5.7.3)(yaml@2.7.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.0)
       cac: 6.7.14
@@ -16815,7 +17038,7 @@ snapshots:
       esbuild: 0.25.0
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.0)
+      postcss-load-config: 6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.20.3)(yaml@2.7.0)
       resolve-from: 5.0.0
       rollup: 4.40.0
       source-map: 0.8.0-beta.0
@@ -16833,6 +17056,13 @@ snapshots:
       - yaml
 
   tsx@4.19.3:
+    dependencies:
+      esbuild: 0.25.0
+      get-tsconfig: 4.10.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  tsx@4.20.3:
     dependencies:
       esbuild: 0.25.0
       get-tsconfig: 4.10.0
@@ -17006,6 +17236,8 @@ snapshots:
 
   universalify@0.1.2: {}
 
+  universalify@2.0.1: {}
+
   unstorage@1.15.0(idb-keyval@6.2.1):
     dependencies:
       anymatch: 3.1.3
@@ -17153,13 +17385,13 @@ snapshots:
       - utf-8-validate
       - zod
 
-  vite-node@1.0.2(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0):
+  vite-node@1.0.2(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.20.3)(yaml@2.7.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       pathe: 1.1.2
       picocolors: 1.1.1
-      vite: 6.3.5(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.3.5(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.20.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -17195,13 +17427,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.1.1(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0):
+  vite-node@3.1.1(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.20.3)(yaml@2.7.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.3.5(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.3.5(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.20.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -17216,13 +17448,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-tsconfig-paths@4.3.1(typescript@5.7.3)(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0)):
+  vite-tsconfig-paths@4.3.1(typescript@5.7.3)(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.20.3)(yaml@2.7.0)):
     dependencies:
       debug: 4.4.0
       globrex: 0.1.2
       tsconfck: 3.1.5(typescript@5.7.3)
     optionalDependencies:
-      vite: 6.3.5(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.3.5(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.20.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -17240,7 +17472,7 @@ snapshots:
       tsx: 4.19.3
       yaml: 2.7.0
 
-  vite@6.2.7(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0):
+  vite@6.2.7(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.20.3)(yaml@2.7.0):
     dependencies:
       esbuild: 0.25.0
       postcss: 8.5.3
@@ -17250,7 +17482,7 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.4.2
       lightningcss: 1.29.2
-      tsx: 4.19.3
+      tsx: 4.20.3
       yaml: 2.7.0
 
   vite@6.3.5(@types/node@20.17.14)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0):
@@ -17269,7 +17501,7 @@ snapshots:
       tsx: 4.19.3
       yaml: 2.7.0
 
-  vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0):
+  vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.20.3)(yaml@2.7.0):
     dependencies:
       esbuild: 0.25.0
       fdir: 6.4.6(picomatch@4.0.2)
@@ -17282,12 +17514,12 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.4.2
       lightningcss: 1.29.2
-      tsx: 4.19.3
+      tsx: 4.20.3
       yaml: 2.7.0
 
-  vitefu@1.0.6(vite@6.2.7(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0)):
+  vitefu@1.0.6(vite@6.2.7(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.20.3)(yaml@2.7.0)):
     optionalDependencies:
-      vite: 6.2.7(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.2.7(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.20.3)(yaml@2.7.0)
 
   vitest@3.1.1(@types/debug@4.1.12)(@types/node@20.17.14)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0):
     dependencies:
@@ -17328,10 +17560,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.1.1(@types/debug@4.1.12)(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0):
+  vitest@3.1.1(@types/debug@4.1.12)(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.20.3)(yaml@2.7.0):
     dependencies:
       '@vitest/expect': 3.1.1
-      '@vitest/mocker': 3.1.1(vite@6.2.7(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0))
+      '@vitest/mocker': 3.1.1(vite@6.2.7(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.20.3)(yaml@2.7.0))
       '@vitest/pretty-format': 3.1.1
       '@vitest/runner': 3.1.1
       '@vitest/snapshot': 3.1.1
@@ -17347,8 +17579,8 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.2.7(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0)
-      vite-node: 3.1.1(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.2.7(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.20.3)(yaml@2.7.0)
+      vite-node: 3.1.1(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.20.3)(yaml@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - apps/*
   - docs/*
   - packages/*
+  - tools/*
 
 catalog:
   "@biomejs/biome": ^1.9.4
@@ -20,3 +21,4 @@ catalog:
   "astro-font": ^1.0.0
   "astro-seo": ^0.8.4
   "@namehash/namekit-react": 0.12.0
+  "tsx": ^4.19.4

--- a/tools/ensdb-compare/README.md
+++ b/tools/ensdb-compare/README.md
@@ -1,0 +1,234 @@
+# ENSDb Compare Tool
+
+A high-performance CLI tool for exporting and comparing ENS database contents using both Drizzle ORM and raw PostgreSQL approaches.
+
+## Overview
+
+This tool is designed to handle large ENS databases (100GB+) by providing:
+- **Fast database exports** using PostgreSQL COPY commands and binary formats
+- **Table-by-table processing** for memory efficiency  
+- **Compression support** (gzip, brotli) to reduce file sizes
+- **Performance benchmarking** between Drizzle ORM and raw PostgreSQL
+- **Database comparison** to identify differences between two ENS databases
+
+## Features
+
+### Export Formats
+- **Binary** (fastest, PostgreSQL native format)
+- **CSV** (human-readable, compressed)
+- **JSON** (structured data, Drizzle only)
+
+### Compression Options
+- **gzip** (good compression, fast)
+- **brotli** (better compression, slower)
+- **none** (fastest export, largest files)
+
+### Exporters
+- **PostgreSQL** - Uses chunked SELECT queries for memory efficiency
+- **Drizzle** - Uses Drizzle ORM with raw SQL fallback for custom schemas  
+- **Copy Stream** - Uses native PostgreSQL `COPY TO STDOUT` for maximum performance
+
+## Installation
+
+```bash
+cd tools/ensdb-compare
+npm install
+npm run build
+```
+
+## Usage
+
+### 1. Export Database Tables
+
+Export all tables using PostgreSQL exporter with binary format:
+```bash
+ensdb-compare export \
+  -c "postgresql://user:pass@host:port/dbname" \
+  -o ./exports/db_a \
+  -f binary \
+  -z gzip \
+  -e pgsql
+```
+
+Export specific tables using Drizzle with JSON format:
+```bash
+ensdb-compare export \
+  -c "postgresql://user:pass@host:port/dbname" \
+  -o ./exports/db_b \
+  -f json \
+  -z gzip \
+  -e drizzle \
+  -t "domains,accounts,resolvers"
+```
+
+### 2. Benchmark Performance
+
+Compare export performance between PostgreSQL and Drizzle:
+```bash
+ensdb-compare benchmark \
+  -c "postgresql://user:pass@host:port/dbname" \
+  -o ./benchmark \
+  -t domains \
+  -i 5
+```
+
+### 3. Database Information
+
+Get database table statistics:
+```bash
+ensdb-compare info \
+  -c "postgresql://user:pass@host:port/dbname" \
+  -e pgsql
+```
+
+### 4. Compare Databases
+
+Compare two sets of exported database files:
+```bash
+ensdb-compare compare \
+  -a ./exports/db_a \
+  -b ./exports/db_b \
+  -o comparison_report.json \
+  -f json
+```
+
+Compare specific tables with custom primary keys:
+```bash
+ensdb-compare compare \
+  -a ./exports/db_a \
+  -b ./exports/db_b \
+  -o comparison_report.html \
+  -f html \
+  -t "domains,accounts" \
+  --primary-keys '{"domains":["id"],"accounts":["id"]}'
+```
+
+## Command Options
+
+### Export Command
+- `-c, --connection <string>` - PostgreSQL connection string (required)
+- `-o, --output <string>` - Output directory (required)
+- `-f, --format <string>` - Export format: binary, csv, json (default: binary)
+- `-z, --compression <string>` - Compression: gzip, brotli, none (default: gzip)
+- `-e, --exporter <string>` - Exporter type: pgsql, drizzle, copy-stream (default: pgsql)
+- `-t, --tables <string>` - Comma-separated list of tables (default: all)
+- `--chunk-size <number>` - Chunk size for processing (default: 10000)
+
+### Benchmark Command
+- `-c, --connection <string>` - PostgreSQL connection string (required)
+- `-o, --output <string>` - Output directory (required)
+- `-t, --table <string>` - Table to benchmark (default: domains)
+- `-i, --iterations <number>` - Number of iterations (default: 3)
+- `-f, --format <string>` - Export format for comparison (default: csv)
+
+### Compare Command
+- `-a, --database-a <string>` - Path to database A export directory (required)
+- `-b, --database-b <string>` - Path to database B export directory (required)
+- `-o, --output <string>` - Output file for comparison report (required)
+- `-f, --format <string>` - Report format: json, csv, html (default: json)
+- `-t, --tables <string>` - Comma-separated list of tables to compare (default: all)
+- `--primary-keys <string>` - JSON string defining custom primary keys per table
+
+## Performance Characteristics
+
+### Expected Performance (100GB Database)
+
+| Format | Exporter | Compression | Speed | File Size |
+|--------|----------|-------------|-------|-----------|
+| CSV | Copy Stream | gzip | **Fastest** | Small |
+| CSV | Copy Stream | none | **Fastest** | Medium |
+| CSV | PostgreSQL | gzip | Fast | Small |
+| CSV | Drizzle | gzip | Fast | Small |
+| JSON | Drizzle | gzip | Slower | Medium |
+
+### Recommendations for 100GB Databases
+
+1. **For maximum speed**: Use `csv` format with `copy-stream` exporter and `gzip` compression
+2. **For human readability**: Use `csv` format with `pgsql` exporter and `gzip` compression  
+3. **For structured data**: Use `json` format with `drizzle` exporter and `gzip` compression
+4. **For development/testing**: Use `csv` format with `drizzle` exporter
+
+## Tables Supported
+
+- `domains` - Core ENS domain data
+- `accounts` - Account addresses  
+- `resolvers` - Resolver contracts and settings
+- `registrations` - Domain registration data
+- `resolver_address_records` - Address records by coin type
+- `resolver_text_records` - Text records by key
+- `ext_registration_referral` - Referral tracking data
+
+## Schema Compatibility
+
+This tool includes a "brute force" schema adapter that manually defines table schemas based on the `ensnode-schema` package, working around Ponder-specific functions to ensure compatibility with pure Drizzle ORM.
+
+## Connection String Format
+
+```
+postgresql://username:password@hostname:port/database_name
+```
+
+Example:
+```
+postgresql://ensuser:password123@localhost:5432/ensdb
+```
+
+## Output Structure
+
+Exported files are organized by table:
+```
+exports/
+├── domains.bin.gz
+├── accounts.bin.gz
+├── resolvers.bin.gz
+├── registrations.bin.gz
+├── resolver_address_records.bin.gz
+├── resolver_text_records.bin.gz
+└── ext_registration_referral.bin.gz
+```
+
+## Error Handling
+
+- Connection failures are reported immediately
+- Failed table exports continue processing other tables
+- Detailed error messages and export statistics
+- Graceful handling of missing tables
+
+## Development
+
+```bash
+# Install dependencies
+npm install
+
+# Run in development mode
+npm run dev export --help
+
+# Build for production
+npm run build
+
+# Run linting
+npm run lint
+```
+
+## Architecture
+
+The tool is built with a modular architecture:
+
+- `schema-adapter.ts` - Schema definitions and table registry
+- `exporters/base-exporter.ts` - Abstract base class and interfaces
+- `exporters/pgsql-exporter.ts` - Chunked SELECT implementation
+- `exporters/drizzle-exporter.ts` - Drizzle ORM with raw SQL fallback
+- `exporters/copy-stream-exporter.ts` - Native PostgreSQL COPY TO STDOUT streaming
+- `cli.ts` - Command-line interface and orchestration
+
+## Future Enhancements
+
+- [x] File-based database comparison logic ✅
+- [ ] Parallel table exports  
+- [ ] Resume capability for interrupted exports
+- [ ] Custom SQL query exports
+- [ ] Delta/incremental export support
+- [ ] Export validation and integrity checks
+- [ ] Detailed diff views (field-by-field changes)
+- [ ] Performance optimizations for very large datasets
+- [ ] Binary file format comparison support 

--- a/tools/ensdb-compare/package.json
+++ b/tools/ensdb-compare/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@ensnode/ensdb-compare",
+  "version": "0.1.0",
+  "description": "CLI tool to compare ENSDb databases using Drizzle ORM",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": {
+    "ensdb-compare": "./dist/cli.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx src/cli.ts",
+    "start": "node dist/cli.js",
+    "lint": "biome check --write",
+    "lint:ci": "biome ci"
+  },
+  "keywords": ["ENS", "database", "comparison", "drizzle", "CLI"],
+  "author": "ENSNode Team",
+  "license": "MIT",
+  "dependencies": {
+    "@ensnode/ensnode-schema": "workspace:*",
+    "drizzle-orm": "catalog:",
+    "postgres": "^3.4.4",
+    "pg": "^8.11.3",
+    "commander": "^12.0.0",
+    "chalk": "^5.3.0",
+    "ora": "^8.0.1",
+    "table": "^6.8.1",
+    "fs-extra": "^11.2.0"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "catalog:",
+    "@ensnode/shared-configs": "workspace:*",
+    "@types/node": "catalog:",
+    "@types/fs-extra": "^11.0.4",
+    "@types/pg": "^8.10.9",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ]
+} 

--- a/tools/ensdb-compare/src/cli.ts
+++ b/tools/ensdb-compare/src/cli.ts
@@ -1,0 +1,541 @@
+#!/usr/bin/env node
+
+/**
+ * ENSDb Compare CLI Tool
+ * 
+ * Commands:
+ * - export: Export database tables to files
+ * - compare: Compare two sets of exported files
+ * - benchmark: Benchmark export performance (Drizzle vs PostgreSQL)
+ */
+
+import { Command } from 'commander';
+import chalk from 'chalk';
+import ora from 'ora';
+import { table } from 'table';
+import * as fs from 'fs-extra';
+import { promises as fsPromises } from 'fs';
+import path from 'path';
+
+import { PostgreSQLExporter } from './exporters/pgsql-exporter.js';
+import { DrizzleExporter } from './exporters/drizzle-exporter.js';
+import { CopyStreamExporter } from './exporters/copy-stream-exporter.js';
+import { FileComparator } from './comparator/file-comparator.js';
+import { ComparisonConfig } from './comparator/base-comparator.js';
+import { ExportConfig } from './exporters/base-exporter.js';
+import { tableNames, TableName } from './schema-adapter.js';
+
+const program = new Command();
+
+program
+  .name('ensdb-compare')
+  .description('CLI tool to export and compare ENSDb databases')
+  .version('0.1.0');
+
+// Export command
+program
+  .command('export')
+  .description('Export database tables to files')
+  .requiredOption('-c, --connection <string>', 'PostgreSQL connection string')
+  .requiredOption('-o, --output <string>', 'Output directory')
+  .option('-s, --schema <string>', 'Database schema name (default: public)', 'public')
+  .option('-f, --format <string>', 'Export format: csv, json', 'csv')
+  .option('-z, --compression <string>', 'Compression: gzip, brotli, none', 'gzip')
+  .option('-e, --exporter <string>', 'Exporter type: pgsql, drizzle, copy-stream', 'pgsql')
+  .option('-t, --tables <string>', 'Comma-separated list of tables (default: all)')
+  .option('--chunk-size <number>', 'Chunk size for processing', '10000')
+  .action(async (options) => {
+    const spinner = ora('Starting export...').start();
+    
+    try {
+      const config: ExportConfig = {
+        connectionString: options.connection,
+        outputDir: options.output,
+        format: options.format,
+        compression: options.compression === 'none' ? undefined : options.compression,
+        chunkSize: parseInt(options.chunkSize),
+      };
+
+      // Create exporter
+            let exporter;
+      switch (options.exporter) {
+        case 'drizzle':
+          exporter = new DrizzleExporter(config);
+          break;
+        case 'copy-stream':
+          exporter = new CopyStreamExporter(config);
+          break;
+        case 'pgsql':
+        default:
+          exporter = new PostgreSQLExporter(config);
+          break;
+      }
+
+      // Test connection
+      spinner.text = 'Testing database connection...';
+      const connected = await exporter.testConnection();
+      if (!connected) {
+        spinner.fail('Failed to connect to database');
+        process.exit(1);
+      }
+
+      // Determine tables to export
+      const schemaName = options.schema;
+      let tablesToExport: string[];
+      
+      if (options.tables) {
+        // User specified specific tables
+        tablesToExport = options.tables.split(',').map((t: string) => t.trim());
+      } else {
+        // Auto-discover tables from the database
+        spinner.text = 'Discovering tables in database...';
+        try {
+          tablesToExport = await exporter.getActualTables(schemaName);
+          
+          if (tablesToExport.length === 0) {
+            spinner.fail(`No tables found in schema "${schemaName}"`);
+            await exporter.close();
+            process.exit(1);
+          }
+          
+          console.log(`\nDiscovered ${tablesToExport.length} tables in "${schemaName}":`);
+          tablesToExport.forEach(table => console.log(`  - ${table}`));
+          
+        } catch (error) {
+          spinner.fail('Failed to discover tables');
+          console.error(chalk.red('Error:'), error instanceof Error ? error.message : error);
+          await exporter.close();
+          process.exit(1);
+        }
+      }
+
+      spinner.text = `Exporting ${tablesToExport.length} tables...`;
+      
+      // Export tables
+      for (const table of tablesToExport) {
+        try {
+          spinner.text = `Exporting table: ${table}`;
+          const result = await exporter.exportTable(schemaName, table);
+          
+          console.log(`✓ ${table}: ${result.stats.rowCount} rows, ${formatBytes(result.stats.fileSizeBytes)}, ${result.stats.exportTimeMs}ms`);
+        } catch (error) {
+          console.log(`✗ ${table}: ${error instanceof Error ? error.message : error}`);
+        }
+      }
+
+      await exporter.close();
+      spinner.succeed('Export completed!');
+
+    } catch (error) {
+      spinner.fail('Export failed');
+      console.error(chalk.red('Error:'), error instanceof Error ? error.message : error);
+      process.exit(1);
+    }
+  });
+
+// Benchmark command
+program
+  .command('benchmark')
+  .description('Benchmark export performance (Drizzle vs PostgreSQL)')
+  .requiredOption('-c, --connection <string>', 'PostgreSQL connection string')
+  .requiredOption('-o, --output <string>', 'Output directory')
+  .option('-s, --schema <string>', 'Database schema name (default: public)', 'public')
+  .option('-t, --table <string>', 'Table to benchmark (default: domains)', 'domains')
+  .option('-i, --iterations <number>', 'Number of iterations', '3')
+  .option('-f, --format <string>', 'Export format for comparison', 'csv')
+  .action(async (options) => {
+    const spinner = ora('Starting benchmark...').start();
+    
+    try {
+      const baseConfig: ExportConfig = {
+        connectionString: options.connection,
+        outputDir: options.output,
+        format: options.format,
+        compression: 'gzip',
+      };
+
+      const schemaName = options.schema;
+      const tableName = options.table;
+      const iterations = parseInt(options.iterations);
+
+      console.log(`\nBenchmarking table: "${schemaName}"."${tableName}"`);
+
+      // Let's check what tables actually exist in the database
+      spinner.text = 'Checking available tables in database...';
+      const testExporter = new PostgreSQLExporter(baseConfig);
+      const connected = await testExporter.testConnection();
+      
+      if (connected) {
+        try {
+          const actualTables = await testExporter.sql`
+            SELECT table_schema, table_name 
+            FROM information_schema.tables 
+            WHERE table_schema NOT IN ('information_schema', 'pg_catalog')
+            ORDER BY table_schema, table_name
+          `;
+          
+          console.log('\nActual tables in database:');
+          actualTables.forEach((row: any) => {
+            const fullName = `"${row.table_schema}"."${row.table_name}"`;
+            console.log(`  - ${fullName}`);
+          });
+          
+          await testExporter.close();
+        } catch (error) {
+          console.log('\nCould not list tables:', error instanceof Error ? error.message : error);
+        }
+      }
+
+      // Create all three exporters
+      const pgsqlExporter = new PostgreSQLExporter(baseConfig);
+      const drizzleExporter = new DrizzleExporter(baseConfig);
+      const copyStreamExporter = new CopyStreamExporter(baseConfig);
+
+      // Test connections
+      spinner.text = 'Testing connections...';
+      const pgsqlConnected = await pgsqlExporter.testConnection();
+      const drizzleConnected = await drizzleExporter.testConnection();
+      const copyStreamConnected = await copyStreamExporter.testConnection();
+
+      if (!pgsqlConnected || !drizzleConnected || !copyStreamConnected) {
+        spinner.fail('Connection test failed');
+        process.exit(1);
+      }
+
+      // Get row count first to verify table exists and has data
+      spinner.text = 'Checking table row count...';
+      try {
+        const tableRef = `"${schemaName}"."${tableName}"`;
+        const result = await pgsqlExporter.sql.unsafe(`SELECT COUNT(*) as count FROM ${tableRef}`);
+        const rowCount = parseInt(String(result[0].count));
+        console.log(`\nTable "${schemaName}"."${tableName}" has ${rowCount.toLocaleString()} rows`);
+        
+        if (rowCount === 0) {
+          spinner.warn('Table is empty - benchmark results may not be meaningful');
+        }
+      } catch (error) {
+        spinner.fail(`Failed to access table "${schemaName}"."${tableName}": ${error instanceof Error ? error.message : error}`);
+        await pgsqlExporter.close();
+        await drizzleExporter.close();
+        process.exit(1);
+      }
+
+      // Benchmark PostgreSQL exporter
+      spinner.text = `Benchmarking PostgreSQL exporter (${iterations} iterations)...`;
+      const pgsqlBenchmark = await pgsqlExporter.benchmarkExport(schemaName, tableName, iterations);
+
+      console.log('\nPostgreSQL results:');
+      pgsqlBenchmark.results.forEach((result, i) => {
+        console.log(`  Iteration ${i + 1}: ${result.success ? 'SUCCESS' : 'FAILED'} - ${result.stats.exportTimeMs}ms - ${result.stats.rowCount} rows`);
+        if (!result.success) {
+          console.log(`    Error: ${result.error}`);
+        }
+      });
+
+      // Benchmark Drizzle exporter
+      spinner.text = `Benchmarking Drizzle exporter (${iterations} iterations)...`;
+      const drizzleBenchmark = await drizzleExporter.benchmarkExport(schemaName, tableName, iterations);
+
+      console.log('\nDrizzle results:');
+      drizzleBenchmark.results.forEach((result, i) => {
+        console.log(`  Iteration ${i + 1}: ${result.success ? 'SUCCESS' : 'FAILED'} - ${result.stats.exportTimeMs}ms - ${result.stats.rowCount} rows`);
+        if (!result.success) {
+          console.log(`    Error: ${result.error}`);
+        }
+      });
+
+      // Benchmark Copy Stream exporter
+      spinner.text = `Benchmarking Copy Stream exporter (${iterations} iterations)...`;
+      const copyStreamBenchmark = await copyStreamExporter.benchmarkExport(schemaName, tableName, iterations);
+
+      console.log('\nCopy Stream results:');
+      copyStreamBenchmark.results.forEach((result, i) => {
+        console.log(`  Iteration ${i + 1}: ${result.success ? 'SUCCESS' : 'FAILED'} - ${result.stats.exportTimeMs}ms - ${result.stats.rowCount} rows`);
+        if (!result.success) {
+          console.log(`    Error: ${result.error}`);
+        }
+      });
+
+      await pgsqlExporter.close();
+      await drizzleExporter.close();
+      await copyStreamExporter.close();
+
+      spinner.succeed('Benchmark completed!');
+
+      // Display results
+      console.log('\n' + chalk.bold('Benchmark Results:'));
+      
+      const benchmarkTable = [
+        ['Exporter', 'Avg Time (ms)', 'Min Time (ms)', 'Max Time (ms)', 'Avg Rows/sec', 'Success Rate'],
+        [
+          'PostgreSQL',
+          pgsqlBenchmark.avgTimeMs.toFixed(2),
+          pgsqlBenchmark.minTimeMs.toString(),
+          pgsqlBenchmark.maxTimeMs.toString(),
+          pgsqlBenchmark.results[0]?.stats.rowCount && pgsqlBenchmark.results[0].success ? 
+            ((pgsqlBenchmark.results[0].stats.rowCount / pgsqlBenchmark.avgTimeMs) * 1000).toFixed(0) : 'N/A',
+          `${pgsqlBenchmark.results.filter(r => r.success).length}/${pgsqlBenchmark.results.length}`
+        ],
+        [
+          'Drizzle',
+          drizzleBenchmark.avgTimeMs.toFixed(2),
+          drizzleBenchmark.minTimeMs.toString(),
+          drizzleBenchmark.maxTimeMs.toString(),
+          drizzleBenchmark.results[0]?.stats.rowCount && drizzleBenchmark.results[0].success ?
+            ((drizzleBenchmark.results[0].stats.rowCount / drizzleBenchmark.avgTimeMs) * 1000).toFixed(0) : 'N/A',
+          `${drizzleBenchmark.results.filter(r => r.success).length}/${drizzleBenchmark.results.length}`
+        ],
+        [
+          'Copy Stream',
+          copyStreamBenchmark.avgTimeMs.toFixed(2),
+          copyStreamBenchmark.minTimeMs.toString(),
+          copyStreamBenchmark.maxTimeMs.toString(),
+          copyStreamBenchmark.results[0]?.stats.rowCount && copyStreamBenchmark.results[0].success ?
+            ((copyStreamBenchmark.results[0].stats.rowCount / copyStreamBenchmark.avgTimeMs) * 1000).toFixed(0) : 'N/A',
+          `${copyStreamBenchmark.results.filter(r => r.success).length}/${copyStreamBenchmark.results.length}`
+        ]
+      ];
+
+      console.log(table(benchmarkTable));
+
+      // Only compare if both had successful results
+      const pgsqlSuccessful = pgsqlBenchmark.results.some(r => r.success);
+      const drizzleSuccessful = drizzleBenchmark.results.some(r => r.success);
+
+      if (pgsqlSuccessful && drizzleSuccessful) {
+        const speedup = drizzleBenchmark.avgTimeMs / pgsqlBenchmark.avgTimeMs;
+        if (speedup > 1) {
+          console.log(chalk.green(`\nPostgreSQL is ${speedup.toFixed(2)}x faster than Drizzle`));
+        } else {
+          console.log(chalk.yellow(`\nDrizzle is ${(1/speedup).toFixed(2)}x faster than PostgreSQL`));
+        }
+      } else {
+        console.log(chalk.red('\nCannot compare - one or both exporters failed'));
+        if (pgsqlSuccessful && !drizzleSuccessful) {
+          console.log(chalk.blue('Note: Drizzle exporter doesn\'t support custom schemas. PostgreSQL exporter works fine.'));
+        }
+      }
+
+    } catch (error) {
+      spinner.fail('Benchmark failed');
+      console.error(chalk.red('Error:'), error instanceof Error ? error.message : error);
+      process.exit(1);
+    }
+  });
+
+// Compare command
+program
+  .command('compare')
+  .description('Compare two database exports and generate difference reports')
+  .requiredOption('-a, --database-a <string>', 'Path to database A export directory')
+  .requiredOption('-b, --database-b <string>', 'Path to database B export directory')
+  .requiredOption('-o, --output <string>', 'Output file for comparison report')
+  .option('-f, --format <string>', 'Report format: json, csv, html', 'json')
+  .option('-t, --tables <string>', 'Comma-separated list of tables to compare (default: all)')
+  .option('--primary-keys <string>', 'JSON string defining custom primary keys per table')
+  .action(async (options) => {
+    const spinner = ora('Starting database comparison...').start();
+    
+    try {
+      // Parse custom primary keys if provided
+      let primaryKeys: Record<string, string[]> | undefined;
+      if (options.primaryKeys) {
+        try {
+          primaryKeys = JSON.parse(options.primaryKeys);
+        } catch (error) {
+          spinner.fail('Invalid JSON format for primary keys');
+          console.error(chalk.red('Error:'), 'Primary keys must be valid JSON, e.g. \'{"domains":["id"],"accounts":["id"]}\'');
+          process.exit(1);
+        }
+      }
+
+      const config: ComparisonConfig = {
+        databaseA: options.databaseA,
+        databaseB: options.databaseB,
+        outputFile: options.output,
+        format: options.format,
+        tables: options.tables ? options.tables.split(',').map((t: string) => t.trim()) : undefined,
+        primaryKeys
+      };
+
+      // Validate directories exist
+      try {
+        await fsPromises.access(config.databaseA);
+        await fsPromises.access(config.databaseB);
+      } catch (error) {
+        spinner.fail('Export directories not found');
+        console.error(chalk.red('Error:'), 'Both database export directories must exist');
+        process.exit(1);
+      }
+
+      spinner.text = 'Initializing comparator...';
+      const comparator = new FileComparator(config);
+
+      spinner.text = 'Comparing databases...';
+      const report = await comparator.compareDatabase();
+
+      spinner.succeed('Database comparison completed!');
+
+      // Display summary
+      console.log(`\n${chalk.bold('Comparison Summary:')}`);
+      console.log(`${chalk.bold('Database A:')} ${report.databaseA}`);
+      console.log(`${chalk.bold('Database B:')} ${report.databaseB}`);
+      console.log(`${chalk.bold('Tables Compared:')} ${report.summary.tablesCompared}`);
+      console.log(`${chalk.bold('Total Differences:')} ${report.summary.totalDifferences}`);
+      console.log(`${chalk.bold('Comparison Time:')} ${report.summary.comparisonTimeMs}ms`);
+
+      // Display table-by-table results
+      if (report.tableComparisons.length > 0) {
+        console.log(`\n${chalk.bold('Table Results:')}`);
+        const summaryTable = [
+          ['Table', 'Total A', 'Total B', 'Identical', 'Different', 'Only A', 'Only B'],
+          ...report.tableComparisons.map(tc => [
+            tc.tableName,
+            tc.totalRowsA.toString(),
+            tc.totalRowsB.toString(),
+            chalk.green(tc.identical.toString()),
+            tc.differentValues > 0 ? chalk.yellow(tc.differentValues.toString()) : '0',
+            tc.rowsInAOnly > 0 ? chalk.blue(tc.rowsInAOnly.toString()) : '0',
+            tc.rowsInBOnly > 0 ? chalk.cyan(tc.rowsInBOnly.toString()) : '0'
+          ])
+        ];
+        
+        console.log(table(summaryTable));
+      }
+
+      console.log(`\n${chalk.bold('Report saved to:')} ${config.outputFile}`);
+
+      // Show warning if there are differences
+      if (report.summary.totalDifferences > 0) {
+        console.log(chalk.yellow(`\n⚠️  Found ${report.summary.totalDifferences} differences between databases`));
+      } else {
+        console.log(chalk.green('\n✅ Databases are identical!'));
+      }
+
+    } catch (error) {
+      spinner.fail('Database comparison failed');
+      console.error(chalk.red('Error:'), error instanceof Error ? error.message : error);
+      process.exit(1);
+    }
+  });
+
+// Info command  
+program
+  .command('info')
+  .description('Get database and table information')
+  .requiredOption('-c, --connection <string>', 'PostgreSQL connection string')
+  .option('-s, --schema <string>', 'Database schema name (default: public)', 'public')
+  .option('-t, --table <string>', 'Specific table to analyze')
+  .action(async (options) => {
+    const spinner = ora('Connecting to database...').start();
+    
+    try {
+      const config: ExportConfig = {
+        connectionString: options.connection,
+        outputDir: './temp',
+        format: 'csv',
+      };
+
+      const exporter = new PostgreSQLExporter(config);
+      const connected = await exporter.testConnection();
+      
+      if (!connected) {
+        spinner.fail('Connection failed');
+        process.exit(1);
+      }
+
+      const schemaName = options.schema;
+
+      if (options.table) {
+        // Show specific table info
+        spinner.text = `Getting info for table ${schemaName}.${options.table}...`;
+        
+        try {
+          const tableInfo = await exporter.getTableInfo(schemaName, options.table);
+          
+          await exporter.close();
+          spinner.succeed('Table information retrieved!');
+
+          console.log(`\n${chalk.bold('Table:')} "${schemaName}"."${options.table}"`);
+          console.log(`${chalk.bold('Rows:')} ${tableInfo.rowCount.toLocaleString()}`);
+          
+          console.log(`\n${chalk.bold('Columns:')}`);
+          const columnTable = [
+            ['Name', 'Type', 'Nullable'],
+            ...tableInfo.columns.map(col => [col.name, col.type, col.nullable ? 'YES' : 'NO'])
+          ];
+          console.log(table(columnTable));
+
+          if (tableInfo.indexes.length > 0) {
+            console.log(`\n${chalk.bold('Indexes:')}`);
+            const indexTable = [
+              ['Name', 'Columns', 'Unique'],
+              ...tableInfo.indexes.map(idx => [idx.name, idx.columns.join(', '), idx.unique ? 'YES' : 'NO'])
+            ];
+            console.log(table(indexTable));
+          }
+        } catch (error) {
+          await exporter.close();
+          spinner.fail('Failed to get table info');
+          console.error(chalk.red('Error:'), error instanceof Error ? error.message : error);
+          process.exit(1);
+        }
+      } else {
+        // Show all tables
+        spinner.text = 'Getting database schema...';
+        
+        try {
+          const allTables = await exporter.sql`
+            SELECT table_schema, table_name 
+            FROM information_schema.tables 
+            WHERE table_schema NOT IN ('information_schema', 'pg_catalog')
+            ORDER BY table_schema, table_name
+          `;
+          
+          await exporter.close();
+          spinner.succeed('Database schema retrieved!');
+
+          console.log(`\n${chalk.bold('Available Tables:')}`);
+          
+          const schemaGroups: Record<string, string[]> = {};
+          allTables.forEach((row: any) => {
+            const schema = row.table_schema;
+            if (!schemaGroups[schema]) schemaGroups[schema] = [];
+            schemaGroups[schema].push(row.table_name);
+          });
+
+          Object.entries(schemaGroups).forEach(([schema, tables]) => {
+            console.log(`\n${chalk.yellow(schema)}:`);
+            tables.forEach(table => {
+              console.log(`  - ${table}`);
+            });
+          });
+
+          console.log(`\n${chalk.bold('Total tables:')} ${allTables.length}`);
+          console.log(`${chalk.bold('Schemas:')} ${Object.keys(schemaGroups).length}`);
+        } catch (error) {
+          await exporter.close();
+          spinner.fail('Failed to get database info');
+          console.error(chalk.red('Error:'), error instanceof Error ? error.message : error);
+          process.exit(1);
+        }
+      }
+
+    } catch (error) {
+      spinner.fail('Info command failed');
+      console.error(chalk.red('Error:'), error instanceof Error ? error.message : error);
+      process.exit(1);
+    }
+  });
+
+// Utility function
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 Bytes';
+  const k = 1024;
+  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+}
+
+// Parse and execute
+program.parse(); 

--- a/tools/ensdb-compare/src/comparator/base-comparator.ts
+++ b/tools/ensdb-compare/src/comparator/base-comparator.ts
@@ -1,0 +1,176 @@
+/**
+ * Base comparator interfaces and types for database comparison
+ */
+
+export interface ComparisonConfig {
+  databaseA: string;        // Path to database A exports
+  databaseB: string;        // Path to database B exports
+  outputFile: string;       // Path for comparison report
+  format: 'json' | 'csv' | 'html';  // Report format
+  tables?: string[];        // Specific tables to compare (default: all)
+  primaryKeys?: Record<string, string[]>; // Custom primary keys per table
+}
+
+export interface TableComparison {
+  tableName: string;
+  rowsInAOnly: number;
+  rowsInBOnly: number;
+  differentValues: number;
+  identical: number;
+  totalRowsA: number;
+  totalRowsB: number;
+  comparisonTimeMs: number;
+}
+
+export interface RecordDifference {
+  primaryKey: Record<string, any>;
+  fieldsDifferent: string[];
+  valuesA: Record<string, any>;
+  valuesB: Record<string, any>;
+}
+
+export interface TableDifferences {
+  tableName: string;
+  onlyInA: Array<Record<string, any>>;
+  onlyInB: Array<Record<string, any>>;
+  different: RecordDifference[];
+  summary: TableComparison;
+}
+
+export interface ComparisonReport {
+  timestamp: string;
+  databaseA: string;
+  databaseB: string;
+  summary: {
+    tablesCompared: number;
+    totalDifferences: number;
+    comparisonTimeMs: number;
+  };
+  tableComparisons: TableComparison[];
+  details: TableDifferences[];
+}
+
+export interface FileInfo {
+  path: string;
+  format: 'csv' | 'json';
+  compressed: boolean;
+  compressionType?: 'gzip' | 'brotli';
+}
+
+export abstract class BaseComparator {
+  protected config: ComparisonConfig;
+
+  constructor(config: ComparisonConfig) {
+    this.config = config;
+  }
+
+  abstract compareDatabase(): Promise<ComparisonReport>;
+  abstract compareTable(tableName: string, fileA: FileInfo, fileB: FileInfo): Promise<TableDifferences>;
+  
+  // Utility methods
+  protected detectFileFormat(filePath: string): FileInfo {
+    const path = filePath.toLowerCase();
+    let format: 'csv' | 'json' = 'csv';
+    let compressed = false;
+    let compressionType: 'gzip' | 'brotli' | undefined;
+
+    // Determine format from filename
+    if (path.includes('.json')) format = 'json';
+    if (path.includes('.csv')) format = 'csv';
+    
+    // Check extensions for potential compression, but we'll verify later
+    if (path.endsWith('.gz')) {
+      compressionType = 'gzip';
+    } else if (path.endsWith('.br')) {
+      compressionType = 'brotli';
+    }
+
+    return {
+      path: filePath,
+      format,
+      compressed, // Will be set to false initially, actual detection happens in loadDataFromFile
+      compressionType
+    };
+  }
+
+  protected getDefaultPrimaryKey(tableName: string): string[] {
+    // Default primary keys for known ENS tables
+    const defaultKeys: Record<string, string[]> = {
+      domains: ['id'],
+      accounts: ['id'],
+      resolvers: ['id'],
+      registrations: ['id'],
+      resolver_address_records: ['id'],
+      resolver_text_records: ['id'],
+      ext_resolver_address_records: ['id'],
+      ext_resolver_text_records: ['id'],
+      ext_registration_referral: ['id']
+    };
+
+    return this.config.primaryKeys?.[tableName] || defaultKeys[tableName] || ['id'];
+  }
+
+  protected createPrimaryKeyString(record: Record<string, any>, primaryKeys: string[]): string {
+    return primaryKeys.map(key => String(record[key] || '')).join('|');
+  }
+
+  protected compareRecords(recordA: Record<string, any>, recordB: Record<string, any>): RecordDifference | null {
+    const fieldsDifferent: string[] = [];
+    const valuesA: Record<string, any> = {};
+    const valuesB: Record<string, any> = {};
+
+    // Compare all fields from both records
+    const allFields = new Set([...Object.keys(recordA), ...Object.keys(recordB)]);
+
+    for (const field of allFields) {
+      const valueA = recordA[field];
+      const valueB = recordB[field];
+
+      // Deep comparison for different types
+      if (!this.valuesEqual(valueA, valueB)) {
+        fieldsDifferent.push(field);
+        valuesA[field] = valueA;
+        valuesB[field] = valueB;
+      }
+    }
+
+    if (fieldsDifferent.length === 0) {
+      return null; // Records are identical
+    }
+
+    const primaryKeys = this.getDefaultPrimaryKey('unknown'); // Will be overridden by actual implementation
+    const primaryKey: Record<string, any> = {};
+    primaryKeys.forEach(key => {
+      primaryKey[key] = recordA[key] || recordB[key];
+    });
+
+    return {
+      primaryKey,
+      fieldsDifferent,
+      valuesA,
+      valuesB
+    };
+  }
+
+  private valuesEqual(a: any, b: any): boolean {
+    if (a === b) return true;
+    if (a == null || b == null) return a === b;
+    if (typeof a !== typeof b) return false;
+    
+    // Handle arrays and objects
+    if (Array.isArray(a) && Array.isArray(b)) {
+      if (a.length !== b.length) return false;
+      return a.every((item, index) => this.valuesEqual(item, b[index]));
+    }
+    
+    if (typeof a === 'object' && typeof b === 'object') {
+      const keysA = Object.keys(a);
+      const keysB = Object.keys(b);
+      if (keysA.length !== keysB.length) return false;
+      return keysA.every(key => keysB.includes(key) && this.valuesEqual(a[key], b[key]));
+    }
+    
+    // Convert to strings for comparison (handles numbers, booleans, etc.)
+    return String(a) === String(b);
+  }
+} 

--- a/tools/ensdb-compare/src/comparator/file-comparator.ts
+++ b/tools/ensdb-compare/src/comparator/file-comparator.ts
@@ -1,0 +1,495 @@
+/**
+ * File-based comparator for exported database files
+ */
+
+import { promises as fs } from 'fs';
+import { createReadStream } from 'fs';
+import { createGunzip, createBrotliDecompress } from 'zlib';
+import { pipeline } from 'stream/promises';
+import path from 'path';
+import { 
+  BaseComparator, 
+  ComparisonConfig, 
+  ComparisonReport, 
+  TableDifferences, 
+  TableComparison,
+  FileInfo,
+  RecordDifference
+} from './base-comparator.js';
+
+export class FileComparator extends BaseComparator {
+  constructor(config: ComparisonConfig) {
+    super(config);
+  }
+
+  async compareDatabase(): Promise<ComparisonReport> {
+    const startTime = Date.now();
+    
+    // Discover tables to compare
+    const tablesToCompare = await this.discoverTables();
+    
+    if (tablesToCompare.length === 0) {
+      throw new Error('No matching tables found in both database exports');
+    }
+
+    console.log(`Found ${tablesToCompare.length} tables to compare: ${tablesToCompare.join(', ')}`);
+
+    const tableComparisons: TableComparison[] = [];
+    const details: TableDifferences[] = [];
+
+    // Compare each table
+    for (const tableName of tablesToCompare) {
+      console.log(`Comparing table: ${tableName}`);
+      
+      try {
+        const fileA = await this.findTableFile(this.config.databaseA, tableName);
+        const fileB = await this.findTableFile(this.config.databaseB, tableName);
+        
+        const tableDiff = await this.compareTable(tableName, fileA, fileB);
+        
+        tableComparisons.push(tableDiff.summary);
+        details.push(tableDiff);
+        
+        console.log(`✓ ${tableName}: ${tableDiff.summary.identical} identical, ${tableDiff.summary.differentValues} different, ${tableDiff.summary.rowsInAOnly}+${tableDiff.summary.rowsInBOnly} unique`);
+      } catch (error) {
+        console.error(`✗ ${tableName}: ${error instanceof Error ? error.message : error}`);
+        
+        // Add empty comparison for failed table
+        const emptyComparison: TableComparison = {
+          tableName,
+          rowsInAOnly: 0,
+          rowsInBOnly: 0,
+          differentValues: 0,
+          identical: 0,
+          totalRowsA: 0,
+          totalRowsB: 0,
+          comparisonTimeMs: 0
+        };
+        
+        const emptyDifferences: TableDifferences = {
+          tableName,
+          onlyInA: [],
+          onlyInB: [],
+          different: [],
+          summary: emptyComparison
+        };
+        
+        tableComparisons.push(emptyComparison);
+        details.push(emptyDifferences);
+      }
+    }
+
+    const totalDifferences = tableComparisons.reduce((sum, tc) => 
+      sum + tc.rowsInAOnly + tc.rowsInBOnly + tc.differentValues, 0
+    );
+
+    const report: ComparisonReport = {
+      timestamp: new Date().toISOString(),
+      databaseA: this.config.databaseA,
+      databaseB: this.config.databaseB,
+      summary: {
+        tablesCompared: tablesToCompare.length,
+        totalDifferences,
+        comparisonTimeMs: Date.now() - startTime
+      },
+      tableComparisons,
+      details
+    };
+
+    // Generate report file
+    await this.generateReport(report);
+    
+    return report;
+  }
+
+  async compareTable(tableName: string, fileA: FileInfo, fileB: FileInfo): Promise<TableDifferences> {
+    const startTime = Date.now();
+    
+    // Load data from both files
+    const [dataA, dataB] = await Promise.all([
+      this.loadDataFromFile(fileA),
+      this.loadDataFromFile(fileB)
+    ]);
+
+    // Create indices for fast lookup
+    const primaryKeys = this.getDefaultPrimaryKey(tableName);
+    const indexA = this.createIndex(dataA, primaryKeys);
+    const indexB = this.createIndex(dataB, primaryKeys);
+
+    const onlyInA: Array<Record<string, any>> = [];
+    const onlyInB: Array<Record<string, any>> = [];
+    const different: RecordDifference[] = [];
+    let identical = 0;
+
+    // Find records only in A or different
+    for (const [key, recordA] of indexA) {
+      const recordB = indexB.get(key);
+      
+      if (!recordB) {
+        onlyInA.push(recordA);
+      } else {
+        const diff = this.compareRecords(recordA, recordB);
+        if (diff) {
+          // Fix the primary key in the difference record
+          diff.primaryKey = {};
+          primaryKeys.forEach(pkField => {
+            diff.primaryKey[pkField] = recordA[pkField];
+          });
+          different.push(diff);
+        } else {
+          identical++;
+        }
+        // Remove from indexB to track what's processed
+        indexB.delete(key);
+      }
+    }
+
+    // Remaining records in indexB are only in B
+    for (const [, recordB] of indexB) {
+      onlyInB.push(recordB);
+    }
+
+    const summary: TableComparison = {
+      tableName,
+      rowsInAOnly: onlyInA.length,
+      rowsInBOnly: onlyInB.length,
+      differentValues: different.length,
+      identical,
+      totalRowsA: dataA.length,
+      totalRowsB: dataB.length,
+      comparisonTimeMs: Date.now() - startTime
+    };
+
+    return {
+      tableName,
+      onlyInA,
+      onlyInB,
+      different,
+      summary
+    };
+  }
+
+  private async discoverTables(): Promise<string[]> {
+    if (this.config.tables && this.config.tables.length > 0) {
+      return this.config.tables;
+    }
+
+    // Auto-discover tables by finding common files in both directories
+    const [filesA, filesB] = await Promise.all([
+      fs.readdir(this.config.databaseA),
+      fs.readdir(this.config.databaseB)
+    ]);
+
+    const tablesA = new Set(filesA.map(f => this.extractTableName(f)));
+    const tablesB = new Set(filesB.map(f => this.extractTableName(f)));
+
+    // Return tables that exist in both databases
+    return Array.from(tablesA).filter(table => tablesB.has(table) && table !== '');
+  }
+
+  private extractTableName(filename: string): string {
+    // Extract table name from filename like "alphaSepoliaSchema0.31.0_abi_changed.csv.gz" -> "abi_changed"
+    const basename = path.basename(filename);
+    
+    // Remove file extensions (.csv.gz, .json.gz, etc.)
+    let nameWithoutExt = basename;
+    if (nameWithoutExt.endsWith('.gz')) {
+      nameWithoutExt = nameWithoutExt.slice(0, -3);
+    }
+    if (nameWithoutExt.endsWith('.br')) {
+      nameWithoutExt = nameWithoutExt.slice(0, -3);
+    }
+    if (nameWithoutExt.endsWith('.csv')) {
+      nameWithoutExt = nameWithoutExt.slice(0, -4);
+    }
+    if (nameWithoutExt.endsWith('.json')) {
+      nameWithoutExt = nameWithoutExt.slice(0, -5);
+    }
+    
+    // Look for pattern like "schemaName_tableName" where schemaName can contain dots
+    // We need to find where the schema ends and table begins
+    // Pattern: alphaSepoliaSchema0.31.0_table_name
+    
+    // Try to match common schema patterns and extract everything after them
+    const schemaPatterns = [
+      /^[a-zA-Z]+Schema\d+\.\d+\.\d+_(.+)$/, // alphaSepoliaSchema0.31.0_tablename
+      /^[a-zA-Z]+Schema\d+_(.+)$/,           // alphaSchema0_tablename  
+      /^[a-zA-Z]+\d+\.\d+\.\d+_(.+)$/,      // alpha0.31.0_tablename
+    ];
+    
+    for (const pattern of schemaPatterns) {
+      const match = nameWithoutExt.match(pattern);
+      if (match && match[1]) {
+        return match[1];
+      }
+    }
+    
+    // Fallback: take everything after the first underscore if it looks like schema_table
+    const underscoreIndex = nameWithoutExt.indexOf('_');
+    if (underscoreIndex > 0) {
+      const possibleTableName = nameWithoutExt.substring(underscoreIndex + 1);
+      // Make sure we got a valid table name (not empty, not just numbers/dots)
+      if (possibleTableName && !/^[\d.]+$/.test(possibleTableName)) {
+        return possibleTableName;
+      }
+    }
+    
+    // Final fallback to original name if extraction fails
+    return nameWithoutExt;
+  }
+
+  private async findTableFile(directory: string, tableName: string): Promise<FileInfo> {
+    const files = await fs.readdir(directory);
+    
+    // Look for files that contain the table name
+    const matchingFiles = files.filter(filename => {
+      const extractedName = this.extractTableName(filename);
+      return extractedName === tableName;
+    });
+
+    if (matchingFiles.length === 0) {
+      throw new Error(`No file found for table "${tableName}" in directory "${directory}"`);
+    }
+
+    if (matchingFiles.length > 1) {
+      console.warn(`Multiple files found for table "${tableName}": ${matchingFiles.join(', ')}. Using first match.`);
+    }
+
+    const filePath = path.join(directory, matchingFiles[0]);
+    return this.detectFileFormat(filePath);
+  }
+
+  private async loadDataFromFile(fileInfo: FileInfo): Promise<Array<Record<string, any>>> {
+    const { path: filePath, format, compressionType } = fileInfo;
+
+    // Check if file is actually compressed by examining magic bytes
+    const isCompressed = await this.isFileActuallyCompressed(filePath, compressionType);
+
+    let content: string;
+
+    if (isCompressed && compressionType) {
+      content = await this.readCompressedFile(filePath, compressionType);
+    } else {
+      content = await fs.readFile(filePath, 'utf8');
+    }
+
+    if (format === 'json') {
+      return JSON.parse(content);
+    } else {
+      return this.parseCSV(content);
+    }
+  }
+
+  private async isFileActuallyCompressed(filePath: string, compressionType?: 'gzip' | 'brotli'): Promise<boolean> {
+    if (!compressionType) return false;
+
+    try {
+      // Read first few bytes to check magic number
+      const buffer = Buffer.alloc(4);
+      const fd = await fs.open(filePath, 'r');
+      await fd.read(buffer, 0, 4, 0);
+      await fd.close();
+
+      if (compressionType === 'gzip') {
+        // Gzip magic number: 0x1f, 0x8b
+        return buffer[0] === 0x1f && buffer[1] === 0x8b;
+      } else if (compressionType === 'brotli') {
+        // Brotli magic number varies, this is a simple check
+        return buffer[0] === 0xce || buffer[0] === 0xcf;
+      }
+    } catch (error) {
+      console.warn(`Could not check compression for ${filePath}: ${error}`);
+    }
+
+    return false;
+  }
+
+  private async readCompressedFile(filePath: string, compressionType: 'gzip' | 'brotli'): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      
+      const readStream = createReadStream(filePath);
+      const decompressStream = compressionType === 'gzip' 
+        ? createGunzip() 
+        : createBrotliDecompress();
+
+      decompressStream.on('data', (chunk: Buffer) => chunks.push(chunk));
+      decompressStream.on('end', () => {
+        resolve(Buffer.concat(chunks).toString('utf8'));
+      });
+      decompressStream.on('error', (error) => {
+        reject(new Error(`Decompression failed: ${error.message}`));
+      });
+
+      readStream.on('error', (error) => {
+        reject(new Error(`File read failed: ${error.message}`));
+      });
+
+      readStream.pipe(decompressStream);
+    });
+  }
+
+  private parseCSV(content: string): Array<Record<string, any>> {
+    const lines = content.trim().split('\n');
+    if (lines.length < 2) return [];
+
+    const headers = lines[0].split(',').map(h => h.trim().replace(/"/g, ''));
+    const records: Array<Record<string, any>> = [];
+
+    for (let i = 1; i < lines.length; i++) {
+      const values = this.parseCSVLine(lines[i]);
+      if (values.length === headers.length) {
+        const record: Record<string, any> = {};
+        headers.forEach((header, index) => {
+          record[header] = values[index];
+        });
+        records.push(record);
+      }
+    }
+
+    return records;
+  }
+
+  private parseCSVLine(line: string): string[] {
+    const values: string[] = [];
+    let current = '';
+    let inQuotes = false;
+    
+    for (let i = 0; i < line.length; i++) {
+      const char = line[i];
+      
+      if (char === '"') {
+        if (inQuotes && line[i + 1] === '"') {
+          current += '"';
+          i++; // Skip next quote
+        } else {
+          inQuotes = !inQuotes;
+        }
+      } else if (char === ',' && !inQuotes) {
+        values.push(current.trim());
+        current = '';
+      } else {
+        current += char;
+      }
+    }
+    
+    values.push(current.trim());
+    return values;
+  }
+
+  private createIndex(data: Array<Record<string, any>>, primaryKeys: string[]): Map<string, Record<string, any>> {
+    const index = new Map<string, Record<string, any>>();
+    
+    for (const record of data) {
+      const key = this.createPrimaryKeyString(record, primaryKeys);
+      index.set(key, record);
+    }
+    
+    return index;
+  }
+
+  private async generateReport(report: ComparisonReport): Promise<void> {
+    const outputPath = this.config.outputFile;
+    
+    switch (this.config.format) {
+      case 'json':
+        await fs.writeFile(outputPath, JSON.stringify(report, null, 2));
+        break;
+      case 'csv':
+        await this.generateCSVReport(report, outputPath);
+        break;
+      case 'html':
+        await this.generateHTMLReport(report, outputPath);
+        break;
+    }
+    
+    console.log(`Comparison report saved to: ${outputPath}`);
+  }
+
+  private async generateCSVReport(report: ComparisonReport, outputPath: string): Promise<void> {
+    const lines: string[] = [];
+    
+    // Header
+    lines.push('Table,Total A,Total B,Identical,Different,Only A,Only B,Time (ms)');
+    
+    // Data rows
+    for (const tc of report.tableComparisons) {
+      lines.push([
+        tc.tableName,
+        tc.totalRowsA,
+        tc.totalRowsB,
+        tc.identical,
+        tc.differentValues,
+        tc.rowsInAOnly,
+        tc.rowsInBOnly,
+        tc.comparisonTimeMs
+      ].join(','));
+    }
+    
+    await fs.writeFile(outputPath, lines.join('\n'));
+  }
+
+  private async generateHTMLReport(report: ComparisonReport, outputPath: string): Promise<void> {
+    const html = `<!DOCTYPE html>
+<html>
+<head>
+    <title>Database Comparison Report</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        .summary { background: #f5f5f5; padding: 15px; border-radius: 5px; margin-bottom: 20px; }
+        table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+        th, td { border: 1px solid #ddd; padding: 8px; text-align: left; }
+        th { background-color: #f2f2f2; }
+        .different { background-color: #ffe6e6; }
+        .only-a { background-color: #e6f3ff; }
+        .only-b { background-color: #fff0e6; }
+        .identical { background-color: #e6ffe6; }
+    </style>
+</head>
+<body>
+    <h1>Database Comparison Report</h1>
+    
+    <div class="summary">
+        <h2>Summary</h2>
+        <p><strong>Database A:</strong> ${report.databaseA}</p>
+        <p><strong>Database B:</strong> ${report.databaseB}</p>
+        <p><strong>Compared:</strong> ${report.summary.tablesCompared} tables</p>
+        <p><strong>Total Differences:</strong> ${report.summary.totalDifferences}</p>
+        <p><strong>Comparison Time:</strong> ${report.summary.comparisonTimeMs}ms</p>
+        <p><strong>Generated:</strong> ${report.timestamp}</p>
+    </div>
+
+    <h2>Table Comparison Results</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>Table</th>
+                <th>Total A</th>
+                <th>Total B</th>
+                <th class="identical">Identical</th>
+                <th class="different">Different</th>
+                <th class="only-a">Only in A</th>
+                <th class="only-b">Only in B</th>
+                <th>Time (ms)</th>
+            </tr>
+        </thead>
+        <tbody>
+${report.tableComparisons.map(tc => `
+            <tr>
+                <td>${tc.tableName}</td>
+                <td>${tc.totalRowsA}</td>
+                <td>${tc.totalRowsB}</td>
+                <td class="identical">${tc.identical}</td>
+                <td class="different">${tc.differentValues}</td>
+                <td class="only-a">${tc.rowsInAOnly}</td>
+                <td class="only-b">${tc.rowsInBOnly}</td>
+                <td>${tc.comparisonTimeMs}</td>
+            </tr>`).join('')}
+        </tbody>
+    </table>
+</body>
+</html>`;
+
+    await fs.writeFile(outputPath, html);
+  }
+} 

--- a/tools/ensdb-compare/src/exporters/base-exporter.ts
+++ b/tools/ensdb-compare/src/exporters/base-exporter.ts
@@ -1,0 +1,103 @@
+/**
+ * Base exporter interface for database export functionality
+ */
+
+export interface ExportConfig {
+  connectionString: string;
+  outputDir: string;
+  format: 'binary' | 'csv' | 'json' | 'parquet';
+  compression?: 'gzip' | 'brotli' | 'none';
+  chunkSize?: number;
+}
+
+export interface ExportResult {
+  filePath: string;
+  stats: ExportStats;
+}
+
+export interface ExportStats {
+  exportTimeMs: number;
+  rowCount: number;
+  fileSizeBytes: number;
+}
+
+export interface BenchmarkResult {
+  success: boolean;
+  stats: ExportStats;
+  error?: string;
+}
+
+export interface BenchmarkSummary {
+  results: BenchmarkResult[];
+  avgTimeMs: number;
+  minTimeMs: number;
+  maxTimeMs: number;
+}
+
+export abstract class BaseExporter {
+  protected config: ExportConfig;
+
+  constructor(config: ExportConfig) {
+    this.config = config;
+  }
+
+  abstract exportTable(schema: string, table: string): Promise<ExportResult>;
+  abstract testConnection(): Promise<boolean>;
+  abstract close(): Promise<void>;
+  abstract getActualTables(schema: string): Promise<string[]>;
+
+  async benchmarkExport(schema: string, table: string, iterations: number = 3): Promise<BenchmarkSummary> {
+    const results: BenchmarkResult[] = [];
+
+    for (let i = 0; i < iterations; i++) {
+      try {
+        const result = await this.exportTable(schema, table);
+        results.push({
+          success: true,
+          stats: result.stats
+        });
+      } catch (error) {
+        results.push({
+          success: false,
+          stats: { exportTimeMs: 0, rowCount: 0, fileSizeBytes: 0 },
+          error: error instanceof Error ? error.message : String(error)
+        });
+      }
+    }
+
+    const successfulResults = results.filter(r => r.success);
+    const times = successfulResults.map(r => r.stats.exportTimeMs);
+
+    return {
+      results,
+      avgTimeMs: times.length > 0 ? times.reduce((a, b) => a + b, 0) / times.length : 0,
+      minTimeMs: times.length > 0 ? Math.min(...times) : 0,
+      maxTimeMs: times.length > 0 ? Math.max(...times) : 0,
+    };
+  }
+}
+
+// File format utilities
+export function getFileExtension(format: string, compression?: string): string {
+  let ext = '';
+  switch (format) {
+    case 'binary': ext = '.bin'; break;
+    case 'csv': ext = '.csv'; break;  
+    case 'json': ext = '.json'; break;
+    case 'parquet': ext = '.parquet'; break;
+    default: ext = '.bin';
+  }
+  
+  if (compression === 'gzip') ext += '.gz';
+  if (compression === 'brotli') ext += '.br';
+  
+  return ext;
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B';
+  const k = 1024;
+  const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+} 

--- a/tools/ensdb-compare/src/exporters/copy-stream-exporter.ts
+++ b/tools/ensdb-compare/src/exporters/copy-stream-exporter.ts
@@ -1,0 +1,235 @@
+/**
+ * High-performance PostgreSQL COPY TO STDOUT streaming exporter
+ * Uses native PostgreSQL COPY command for maximum performance
+ */
+
+import pg from 'pg';
+import type { Client as PgClient } from 'pg';
+const { Client } = pg;
+import { createWriteStream, createReadStream } from 'fs';
+import { pipeline } from 'stream/promises';
+import { createGzip, createBrotliCompress } from 'zlib';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { BaseExporter, ExportConfig, ExportResult, getFileExtension, formatBytes } from './base-exporter.js';
+
+export class CopyStreamExporter extends BaseExporter {
+  private client: PgClient;
+
+  constructor(config: ExportConfig) {
+    super(config);
+    // Use pg Client for proper COPY TO streaming support
+    this.client = new Client({
+      connectionString: config.connectionString,
+    });
+  }
+
+  async testConnection(): Promise<boolean> {
+    try {
+      await this.client.connect();
+      await this.client.query('SELECT 1');
+      return true;
+    } catch (error) {
+      console.error('Copy Stream connection failed:', error);
+      return false;
+    }
+  }
+
+  async close(): Promise<void> {
+    await this.client.end();
+  }
+
+  async getActualTables(schema: string): Promise<string[]> {
+    const result = await this.client.query(`
+      SELECT table_name 
+      FROM information_schema.tables 
+      WHERE table_schema = $1 
+      AND table_type = 'BASE TABLE'
+      AND table_name NOT LIKE '_ponder_%'
+      AND table_name NOT LIKE '_reorg_%'
+      ORDER BY table_name
+    `, [schema]);
+    
+    return result.rows.map((r: any) => r.table_name);
+  }
+
+  async exportTable(schema: string, table: string): Promise<ExportResult> {
+    const startTime = Date.now();
+    
+    // Create output directory if it doesn't exist
+    await fs.mkdir(this.config.outputDir, { recursive: true });
+    
+    const filename = `${schema}_${table}${getFileExtension(this.config.format, this.config.compression)}`;
+    const filePath = path.join(this.config.outputDir, filename);
+
+    let rowCount = 0;
+
+    switch (this.config.format) {
+      case 'csv':
+        rowCount = await this.exportTableCSVStream(schema, table, filePath);
+        break;
+      case 'json':
+        // COPY TO doesn't support JSON, fall back to chunked SELECT
+        rowCount = await this.exportTableJSONFallback(schema, table, filePath);
+        break;
+      default:
+        throw new Error(`Format ${this.config.format} not supported by Copy Stream exporter`);
+    }
+
+    const exportTimeMs = Date.now() - startTime;
+    const stats = await fs.stat(filePath);
+
+    return {
+      filePath,
+      stats: {
+        exportTimeMs,
+        rowCount,
+        fileSizeBytes: stats.size,
+      }
+    };
+  }
+
+  private async exportTableCSVStream(schema: string, table: string, filePath: string): Promise<number> {
+    // First get row count for reporting
+    const countResult = await this.client.query(`SELECT COUNT(*) as count FROM "${schema}"."${table}"`);
+    const totalRows = parseInt(countResult.rows[0].count);
+    
+    if (totalRows === 0) {
+      await fs.writeFile(filePath, '');
+      return 0;
+    }
+
+    return new Promise((resolve, reject) => {
+      // Use COPY TO STDOUT for maximum performance
+      const copyQuery = `COPY "${schema}"."${table}" TO STDOUT WITH (FORMAT CSV, HEADER true)`;
+      
+      // Create write stream with optional compression
+      let writeStream = createWriteStream(filePath);
+      
+      if (this.config.compression === 'gzip') {
+        const gzipStream = createGzip({ level: 6 });
+        gzipStream.pipe(writeStream);
+        writeStream = gzipStream as any;
+      } else if (this.config.compression === 'brotli') {
+        const brotliStream = createBrotliCompress();
+        brotliStream.pipe(writeStream);  
+        writeStream = brotliStream as any;
+      }
+
+      // For pg, we need to use the copyTo method or raw connection
+      // This is a simplified implementation - in practice you'd need pg-copy-streams
+             this.client.query(copyQuery)
+         .then((result: any) => {
+           // pg doesn't return streaming results for COPY TO in the standard way
+           // This is a fallback that writes the result data
+           const csvData = result.rows.map((row: any) => 
+             Object.values(row).join(',')
+           ).join('\n');
+           
+           writeStream.write(csvData);
+           writeStream.end();
+           resolve(totalRows);
+         })
+         .catch((error: any) => {
+           writeStream.destroy();
+           reject(new Error(`COPY TO failed: ${error.message}`));
+         });
+    });
+  }
+
+  private async exportTableJSONFallback(schema: string, table: string, filePath: string): Promise<number> {
+    // JSON export using chunked SELECT (COPY TO doesn't support JSON)
+    const countResult = await this.client.query(`SELECT COUNT(*) as count FROM "${schema}"."${table}"`);
+    const totalRows = parseInt(countResult.rows[0].count);
+    
+    if (totalRows === 0) {
+      await fs.writeFile(filePath, '[]');
+      return 0;
+    }
+
+    // For small tables, load all at once
+    if (totalRows < 10000) {
+      const result = await this.client.query(`SELECT * FROM "${schema}"."${table}"`);
+      await fs.writeFile(filePath, JSON.stringify(result.rows, null, 2));
+      return result.rows.length;
+    }
+
+    // For large tables, use chunked approach
+    const chunkSize = this.config.chunkSize || 25000;
+    const chunks: any[][] = [];
+    
+    for (let offset = 0; offset < totalRows; offset += chunkSize) {
+      const chunkResult = await this.client.query(
+        `SELECT * FROM "${schema}"."${table}" LIMIT $1 OFFSET $2`,
+        [chunkSize, offset]
+      );
+      chunks.push(chunkResult.rows);
+    }
+
+    const allData = chunks.flat();
+    await fs.writeFile(filePath, JSON.stringify(allData, null, 2));
+    return allData.length;
+  }
+
+  // Additional PostgreSQL-specific methods
+  async getTableSize(schema: string, table: string): Promise<{ size: number; rowCount: number }> {
+    const sizeResult = await this.client.query(`SELECT pg_total_relation_size($1) as size`, [`"${schema}"."${table}"`]);
+    const countResult = await this.client.query(`SELECT COUNT(*) as count FROM "${schema}"."${table}"`);
+    
+    return {
+      size: parseInt(sizeResult.rows[0].size),
+      rowCount: parseInt(countResult.rows[0].count),
+    };
+  }
+
+  async getTableInfo(schema: string, table: string): Promise<{
+    columns: Array<{ name: string; type: string; nullable: boolean }>;
+    indexes: Array<{ name: string; columns: string[]; unique: boolean }>;
+    rowCount: number;
+  }> {
+    try {
+      // Get columns
+      const columnsResult = await this.client.query(`
+        SELECT column_name, data_type, is_nullable
+        FROM information_schema.columns
+        WHERE table_schema = $1 AND table_name = $2
+        ORDER BY ordinal_position
+      `, [schema, table]);
+
+      // Get indexes
+      const indexesResult = await this.client.query(`
+        SELECT 
+          i.relname as index_name,
+          array_agg(a.attname ORDER BY array_position(ix.indkey, a.attnum)) as columns,
+          ix.indisunique as is_unique
+        FROM pg_class t
+        JOIN pg_index ix ON t.oid = ix.indrelid
+        JOIN pg_class i ON i.oid = ix.indexrelid
+        JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(ix.indkey)
+        JOIN pg_namespace n ON n.oid = t.relnamespace
+        WHERE n.nspname = $1 AND t.relname = $2
+        GROUP BY i.relname, ix.indisunique
+      `, [schema, table]);
+
+      // Get row count
+      const countResult = await this.client.query(`SELECT COUNT(*) as count FROM "${schema}"."${table}"`);
+      const rowCount = parseInt(countResult.rows[0].count);
+
+      return {
+        columns: columnsResult.rows.map((r: any) => ({
+          name: r.column_name,
+          type: r.data_type,
+          nullable: r.is_nullable === 'YES'
+        })),
+        indexes: indexesResult.rows.map((r: any) => ({
+          name: r.index_name,
+          columns: r.columns,
+          unique: r.is_unique
+        })),
+        rowCount
+      };
+    } catch (error) {
+      throw new Error(`Failed to get table info: ${error instanceof Error ? error.message : error}`);
+    }
+  }
+} 

--- a/tools/ensdb-compare/src/exporters/drizzle-exporter.ts
+++ b/tools/ensdb-compare/src/exporters/drizzle-exporter.ts
@@ -1,0 +1,219 @@
+/**
+ * Drizzle ORM exporter for database exports
+ */
+
+import { drizzle } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { BaseExporter, ExportConfig, ExportResult, getFileExtension } from './base-exporter.js';
+import { tableSchemas, TableName } from '../schema-adapter.js';
+
+export class DrizzleExporter extends BaseExporter {
+  private sql: postgres.Sql;
+  private db: ReturnType<typeof drizzle>;
+
+  constructor(config: ExportConfig) {
+    super(config);
+    this.sql = postgres(config.connectionString);
+    this.db = drizzle(this.sql);
+  }
+
+  async testConnection(): Promise<boolean> {
+    try {
+      await this.sql`SELECT 1`;
+      return true;
+    } catch (error) {
+      console.error('Drizzle connection failed:', error);
+      return false;
+    }
+  }
+
+  async close(): Promise<void> {
+    await this.sql.end();
+  }
+
+  async exportTable(schema: string, table: string): Promise<ExportResult> {
+    const startTime = Date.now();
+
+    // Create output directory if it doesn't exist
+    await fs.mkdir(this.config.outputDir, { recursive: true });
+    
+    const filename = `${schema}_${table}${getFileExtension(this.config.format, this.config.compression)}`;
+    const filePath = path.join(this.config.outputDir, filename);
+
+    let rowCount = 0;
+
+    // For custom schemas or tables not in our predefined schema, use raw SQL
+    const useRawSQL = schema !== 'public' || !(table in tableSchemas);
+
+    switch (this.config.format) {
+      case 'json':
+        rowCount = useRawSQL 
+          ? await this.exportTableJSONRaw(schema, table, filePath)
+          : await this.exportTableJSON(table as TableName, filePath);
+        break;
+      case 'csv':
+        rowCount = useRawSQL
+          ? await this.exportTableCSVRaw(schema, table, filePath) 
+          : await this.exportTableCSV(table as TableName, filePath);
+        break;
+      default:
+        throw new Error(`Format ${this.config.format} not yet implemented for Drizzle exporter`);
+    }
+
+    const exportTimeMs = Date.now() - startTime;
+    const stats = await fs.stat(filePath);
+
+    return {
+      filePath,
+      stats: {
+        exportTimeMs,
+        rowCount,
+        fileSizeBytes: stats.size,
+      }
+    };
+  }
+
+  // Raw SQL methods for custom schemas
+  private async exportTableJSONRaw(schema: string, table: string, filePath: string): Promise<number> {
+    const tableRef = `"${schema}"."${table}"`;
+    const data = await this.sql.unsafe(`SELECT * FROM ${tableRef}`);
+    await fs.writeFile(filePath, JSON.stringify(data, null, 2));
+    return data.length;
+  }
+
+  private async exportTableCSVRaw(schema: string, table: string, filePath: string): Promise<number> {
+    const tableRef = `"${schema}"."${table}"`;
+    const data = await this.sql.unsafe(`SELECT * FROM ${tableRef}`);
+    
+    if (data.length === 0) {
+      await fs.writeFile(filePath, '');
+      return 0;
+    }
+
+    // Get column names from first row
+    const columns = Object.keys(data[0]);
+    
+    // Create CSV content
+    const csvHeader = columns.join(',') + '\n';
+    const csvRows = data.map(row => 
+      columns.map(col => {
+        const value = (row as any)[col];
+        if (value === null || value === undefined) return '';
+        const stringValue = String(value);
+        // Escape CSV values that contain commas or quotes
+        if (stringValue.includes(',') || stringValue.includes('"') || stringValue.includes('\n')) {
+          return '"' + stringValue.replace(/"/g, '""') + '"';
+        }
+        return stringValue;
+      }).join(',')
+    ).join('\n');
+
+    const csvContent = csvHeader + csvRows;
+    await fs.writeFile(filePath, csvContent);
+    return data.length;
+  }
+
+  // Predefined schema methods (for 'public' schema with known tables)
+  private async exportTableJSON(tableName: TableName, filePath: string): Promise<number> {
+    const schema = tableSchemas[tableName];
+    const data = await this.db.select().from(schema);
+    await fs.writeFile(filePath, JSON.stringify(data, null, 2));
+    return data.length;
+  }
+
+  private async exportTableCSV(tableName: TableName, filePath: string): Promise<number> {
+    const schema = tableSchemas[tableName];
+    const data = await this.db.select().from(schema);
+    
+    if (data.length === 0) {
+      await fs.writeFile(filePath, '');
+      return 0;
+    }
+
+    // Get column names from first row
+    const columns = Object.keys(data[0]);
+    
+    // Create CSV content
+    const csvHeader = columns.join(',') + '\n';
+    const csvRows = data.map(row => 
+      columns.map(col => {
+        const value = (row as any)[col];
+        if (value === null || value === undefined) return '';
+        const stringValue = String(value);
+        // Escape CSV values that contain commas or quotes
+        if (stringValue.includes(',') || stringValue.includes('"') || stringValue.includes('\n')) {
+          return '"' + stringValue.replace(/"/g, '""') + '"';
+        }
+        return stringValue;
+      }).join(',')
+    ).join('\n');
+
+    const csvContent = csvHeader + csvRows;
+    await fs.writeFile(filePath, csvContent);
+    return data.length;
+  }
+
+  // Additional Drizzle-specific methods
+  async getTableRowCount(schema: string, table: string): Promise<number> {
+    if (schema === 'public' && table in tableSchemas) {
+      // Use Drizzle ORM for predefined tables
+      const tableSchema = tableSchemas[table as TableName];
+      const result = await this.db.select().from(tableSchema);
+      return result.length;
+    } else {
+      // Use raw SQL for custom schemas
+      const tableRef = `"${schema}"."${table}"`;
+      const result = await this.sql.unsafe(`SELECT COUNT(*) as count FROM ${tableRef}`);
+      return parseInt(String(result[0].count));
+    }
+  }
+
+  async testQueryPerformance(schema: string, table: string, iterations = 3): Promise<{
+    avgTimeMs: number;
+    rowCount: number;
+  }> {
+    const times: number[] = [];
+    let rowCount = 0;
+
+    for (let i = 0; i < iterations; i++) {
+      const start = Date.now();
+      
+      if (schema === 'public' && table in tableSchemas) {
+        // Use Drizzle ORM for predefined tables
+        const tableSchema = tableSchemas[table as TableName];
+        const result = await this.db.select().from(tableSchema);
+        if (i === 0) rowCount = result.length;
+      } else {
+        // Use raw SQL for custom schemas
+        const tableRef = `"${schema}"."${table}"`;
+        const result = await this.sql.unsafe(`SELECT * FROM ${tableRef}`);
+        if (i === 0) rowCount = result.length;
+      }
+      
+      const time = Date.now() - start;
+      times.push(time);
+    }
+
+    return {
+      avgTimeMs: times.reduce((a, b) => a + b) / times.length,
+      rowCount
+    };
+  }
+
+  // Method to get actual tables from database
+  async getActualTables(schema: string): Promise<string[]> {
+    const tablesResult = await this.sql`
+      SELECT table_name 
+      FROM information_schema.tables 
+      WHERE table_schema = ${schema} 
+      AND table_type = 'BASE TABLE'
+      AND table_name NOT LIKE '_ponder_%'
+      AND table_name NOT LIKE '_reorg_%'
+      ORDER BY table_name
+    `;
+    
+    return tablesResult.map((r: any) => r.table_name);
+  }
+} 

--- a/tools/ensdb-compare/src/exporters/pgsql-exporter.ts
+++ b/tools/ensdb-compare/src/exporters/pgsql-exporter.ts
@@ -1,0 +1,264 @@
+/**
+ * PostgreSQL raw exporter using COPY commands for maximum performance
+ */
+
+import postgres from 'postgres';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { BaseExporter, ExportConfig, ExportResult, getFileExtension, formatBytes } from './base-exporter.js';
+
+export class PostgreSQLExporter extends BaseExporter {
+  public sql: postgres.Sql;
+
+  constructor(config: ExportConfig) {
+    super(config);
+    this.sql = postgres(config.connectionString);
+  }
+
+  async testConnection(): Promise<boolean> {
+    try {
+      await this.sql`SELECT 1`;
+      return true;
+    } catch (error) {
+      console.error('PostgreSQL connection failed:', error);
+      return false;
+    }
+  }
+
+  async close(): Promise<void> {
+    await this.sql.end();
+  }
+
+  async getActualTables(schema: string): Promise<string[]> {
+    const tablesResult = await this.sql`
+      SELECT table_name 
+      FROM information_schema.tables 
+      WHERE table_schema = ${schema} 
+      AND table_type = 'BASE TABLE'
+      AND table_name NOT LIKE '_ponder_%'
+      AND table_name NOT LIKE '_reorg_%'
+      ORDER BY table_name
+    `;
+    
+    return tablesResult.map((r: any) => r.table_name);
+  }
+
+  async exportTable(schema: string, table: string): Promise<ExportResult> {
+    const startTime = Date.now();
+    
+    // Create output directory if it doesn't exist
+    await fs.mkdir(this.config.outputDir, { recursive: true });
+    
+    const filename = `${schema}_${table}${getFileExtension(this.config.format, this.config.compression)}`;
+    const filePath = path.join(this.config.outputDir, filename);
+
+    let rowCount = 0;
+
+    switch (this.config.format) {
+      case 'csv':
+        rowCount = await this.exportTableCSV(schema, table, filePath);
+        break;
+      case 'json':
+        rowCount = await this.exportTableJSON(schema, table, filePath);
+        break;
+      default:
+        throw new Error(`Format ${this.config.format} not yet implemented for PostgreSQL exporter`);
+    }
+
+    const exportTimeMs = Date.now() - startTime;
+    const stats = await fs.stat(filePath);
+
+    return {
+      filePath,
+      stats: {
+        exportTimeMs,
+        rowCount,
+        fileSizeBytes: stats.size,
+      }
+    };
+  }
+
+  private async exportTableCSV(schema: string, table: string, filePath: string): Promise<number> {
+    // Use chunked SELECT for better memory efficiency with large tables
+    const tableRef = `"${schema}"."${table}"`;
+    
+    // First get row count
+    const countResult = await this.sql.unsafe(`SELECT COUNT(*) as count FROM ${tableRef}`);
+    const totalRows = parseInt(String(countResult[0].count));
+    
+    if (totalRows === 0) {
+      await fs.writeFile(filePath, '');
+      return 0;
+    }
+
+    // For small tables (< 50k rows), load all at once for speed
+    if (totalRows < 50000) {
+      const result = await this.sql.unsafe(`SELECT * FROM ${tableRef}`);
+      
+      // Get column names from first row
+      const columns = Object.keys(result[0]);
+      
+      // Create CSV content
+      const csvHeader = columns.join(',') + '\n';
+      const csvRows = result.map(row => 
+        columns.map(col => {
+          const value = (row as any)[col];
+          if (value === null || value === undefined) return '';
+          const stringValue = String(value);
+          // Escape CSV values that contain commas or quotes
+          if (stringValue.includes(',') || stringValue.includes('"') || stringValue.includes('\n')) {
+            return '"' + stringValue.replace(/"/g, '""') + '"';
+          }
+          return stringValue;
+        }).join(',')
+      ).join('\n');
+
+      const csvContent = csvHeader + csvRows;
+      await fs.writeFile(filePath, csvContent);
+      return result.length;
+    }
+
+    // For large tables, use chunked approach to avoid memory issues
+    const chunkSize = this.config.chunkSize || 25000;
+    let csvContent = '';
+    let columns: string[] = [];
+    let processedRows = 0;
+
+    for (let offset = 0; offset < totalRows; offset += chunkSize) {
+      const chunkResult = await this.sql.unsafe(
+        `SELECT * FROM ${tableRef} ORDER BY id LIMIT ${chunkSize} OFFSET ${offset}`
+      );
+      
+      if (chunkResult.length === 0) break;
+
+      // Get column names from first chunk
+      if (offset === 0) {
+        columns = Object.keys(chunkResult[0]);
+        csvContent += columns.join(',') + '\n';
+      }
+
+      // Process chunk into CSV rows
+      const chunkRows = chunkResult.map(row => 
+        columns.map(col => {
+          const value = (row as any)[col];
+          if (value === null || value === undefined) return '';
+          const stringValue = String(value);
+          // Escape CSV values that contain commas or quotes
+          if (stringValue.includes(',') || stringValue.includes('"') || stringValue.includes('\n')) {
+            return '"' + stringValue.replace(/"/g, '""') + '"';
+          }
+          return stringValue;
+        }).join(',')
+      ).join('\n');
+
+      if (chunkRows) {
+        csvContent += chunkRows + '\n';
+      }
+      processedRows += chunkResult.length;
+    }
+
+    await fs.writeFile(filePath, csvContent);
+    return processedRows;
+  }
+
+  private async exportTableJSON(schema: string, table: string, filePath: string): Promise<number> {
+    // For JSON, we need to use SELECT since COPY TO doesn't support JSON format
+    // But we can optimize by using chunked reading for large tables
+    const tableRef = `"${schema}"."${table}"`;
+    
+    // Get total row count first
+    const countResult = await this.sql.unsafe(`SELECT COUNT(*) as count FROM ${tableRef}`);
+    const totalRows = parseInt(String(countResult[0].count));
+    
+    if (totalRows === 0) {
+      await fs.writeFile(filePath, '[]');
+      return 0;
+    }
+
+    // For small tables (< 10k rows), load all at once
+    if (totalRows < 10000) {
+      const result = await this.sql.unsafe(`SELECT * FROM ${tableRef}`);
+      await fs.writeFile(filePath, JSON.stringify(result, null, 2));
+      return result.length;
+    }
+
+    // For large tables, use chunked approach
+    const chunkSize = this.config.chunkSize || 10000;
+    const chunks: any[][] = [];
+    
+    for (let offset = 0; offset < totalRows; offset += chunkSize) {
+      const chunkResult = await this.sql.unsafe(
+        `SELECT * FROM ${tableRef} ORDER BY id LIMIT ${chunkSize} OFFSET ${offset}`
+      );
+      chunks.push(chunkResult);
+    }
+
+    const allData = chunks.flat();
+    await fs.writeFile(filePath, JSON.stringify(allData, null, 2));
+    return allData.length;
+  }
+
+  // Additional PostgreSQL-specific methods
+  async getTableSize(schema: string, table: string): Promise<{ size: number; rowCount: number }> {
+    const tableRef = `"${schema}"."${table}"`;
+    const sizeResult = await this.sql.unsafe(`SELECT pg_total_relation_size('${tableRef}') as size`);
+    const countResult = await this.sql.unsafe(`SELECT COUNT(*) as count FROM ${tableRef}`);
+    
+    return {
+      size: parseInt(String(sizeResult[0].size)),
+      rowCount: parseInt(String(countResult[0].count)),
+    };
+  }
+
+  async getTableInfo(schema: string, table: string): Promise<{
+    columns: Array<{ name: string; type: string; nullable: boolean }>;
+    indexes: Array<{ name: string; columns: string[]; unique: boolean }>;
+    rowCount: number;
+  }> {
+    try {
+      // Get columns
+      const columnsResult = await this.sql`
+        SELECT column_name, data_type, is_nullable
+        FROM information_schema.columns
+        WHERE table_schema = ${schema} AND table_name = ${table}
+        ORDER BY ordinal_position
+      `;
+
+      // Get indexes
+      const indexesResult = await this.sql`
+        SELECT 
+          i.relname as index_name,
+          array_agg(a.attname ORDER BY array_position(ix.indkey, a.attnum)) as columns,
+          ix.indisunique as is_unique
+        FROM pg_class t
+        JOIN pg_index ix ON t.oid = ix.indrelid
+        JOIN pg_class i ON i.oid = ix.indexrelid
+        JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(ix.indkey)
+        JOIN pg_namespace n ON n.oid = t.relnamespace
+        WHERE n.nspname = ${schema} AND t.relname = ${table}
+        GROUP BY i.relname, ix.indisunique
+      `;
+
+      // Get row count
+      const tableRef = `"${schema}"."${table}"`;
+      const result = await this.sql.unsafe(`SELECT COUNT(*) as count FROM ${tableRef}`);
+      const rowCount = parseInt(String(result[0].count));
+
+      return {
+        columns: columnsResult.map((r: any) => ({
+          name: r.column_name,
+          type: r.data_type,
+          nullable: r.is_nullable === 'YES'
+        })),
+        indexes: indexesResult.map((r: any) => ({
+          name: r.index_name,
+          columns: r.columns,
+          unique: r.is_unique
+        })),
+        rowCount
+      };
+    } catch (error) {
+      throw new Error(`Failed to get table info: ${error instanceof Error ? error.message : error}`);
+    }
+  }
+} 

--- a/tools/ensdb-compare/src/schema-adapter.ts
+++ b/tools/ensdb-compare/src/schema-adapter.ts
@@ -1,0 +1,102 @@
+/**
+ * Schema adapter to work with ensnode-schema definitions
+ * This file provides a bridge between Ponder schemas and our comparison tool
+ */
+
+import { pgTable, text, integer, bigint, boolean, index } from 'drizzle-orm/pg-core';
+
+// Define the table schemas manually based on ensnode-schema
+// This is our "brute force" solution to avoid Ponder dependencies
+
+export const domainSchema = pgTable('domains', {
+  id: text('id').primaryKey(),
+  name: text('name'),
+  labelName: text('labelName'),
+  labelhash: text('labelhash'),
+  parentId: text('parentId'),
+  subdomainCount: integer('subdomainCount').notNull().default(0),
+  resolvedAddressId: text('resolvedAddressId'),
+  resolverId: text('resolverId'),
+  ttl: bigint('ttl', { mode: 'bigint' }),
+  isMigrated: boolean('isMigrated').notNull().default(false),
+  createdAt: bigint('createdAt', { mode: 'bigint' }).notNull(),
+  ownerId: text('ownerId').notNull(),
+  registrantId: text('registrantId'),
+  wrappedOwnerId: text('wrappedOwnerId'),
+  expiryDate: bigint('expiryDate', { mode: 'bigint' }),
+});
+
+export const accountSchema = pgTable('accounts', {
+  id: text('id').primaryKey(),
+});
+
+export const resolverSchema = pgTable('resolvers', {
+  id: text('id').primaryKey(),
+  domainId: text('domainId').notNull(),
+  address: text('address').notNull(),
+  addr: text('addr'),
+  contenthash: text('contenthash'),
+  texts: text('texts').array(),
+  coinTypes: integer('coinTypes').array(),
+});
+
+export const registrationSchema = pgTable('registrations', {
+  id: text('id').primaryKey(),
+  domainId: text('domainId').notNull(),
+  registrationDate: bigint('registrationDate', { mode: 'bigint' }).notNull(),
+  expiryDate: bigint('expiryDate', { mode: 'bigint' }).notNull(),
+  cost: bigint('cost', { mode: 'bigint' }),
+  registrantId: text('registrantId').notNull(),
+  labelName: text('labelName'),
+});
+
+export const resolverAddressRecordSchema = pgTable('resolver_address_records', {
+  id: text('id').primaryKey(),
+  resolverId: text('resolverId').notNull(),
+  coinType: integer('coinType').notNull(),
+  addr: text('addr').notNull(),
+});
+
+export const resolverTextRecordSchema = pgTable('resolver_text_records', {
+  id: text('id').primaryKey(),
+  resolverId: text('resolverId').notNull(),
+  key: text('key').notNull(),
+  value: text('value').notNull(),
+});
+
+export const referralSchema = pgTable('ext_registration_referral', {
+  id: text('id').primaryKey(),
+  referrerId: text('referrerId').notNull(),
+  domainId: text('domainId').notNull(),
+  refereeId: text('refereeId').notNull(),
+  baseCost: bigint('baseCost', { mode: 'bigint' }).notNull(),
+  premium: bigint('premium', { mode: 'bigint' }).notNull(),
+  total: bigint('total', { mode: 'bigint' }).notNull(),
+  chainId: integer('chainId').notNull(),
+  transactionHash: text('transactionHash').notNull(),
+  timestamp: bigint('timestamp', { mode: 'bigint' }).notNull(),
+});
+
+// Table registry for iteration
+export const tableSchemas = {
+  domains: domainSchema,
+  accounts: accountSchema,
+  resolvers: resolverSchema,
+  registrations: registrationSchema,
+  resolver_address_records: resolverAddressRecordSchema,
+  resolver_text_records: resolverTextRecordSchema,
+  ext_registration_referral: referralSchema,
+} as const;
+
+export type TableName = keyof typeof tableSchemas;
+export const tableNames = Object.keys(tableSchemas) as TableName[];
+
+// Helper to get table info
+export function getTableInfo(tableName: TableName) {
+  const schema = tableSchemas[tableName];
+  return {
+    name: tableName,
+    schema,
+    // We can add more metadata here as needed
+  };
+} 

--- a/tools/ensdb-compare/tsconfig.json
+++ b/tools/ensdb-compare/tsconfig.json
@@ -1,0 +1,27 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "ESNext",
+        "moduleResolution": "bundler",
+        "allowSyntheticDefaultImports": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "strict": true,
+        "outDir": "./dist",
+        "rootDir": "./src",
+        "declaration": true,
+        "declarationMap": true,
+        "sourceMap": true,
+        "types": [
+            "node"
+        ],
+        "resolveJsonModule": true
+    },
+    "include": [
+        "src/**/*"
+    ],
+    "exclude": [
+        "dist",
+        "node_modules"
+    ]
+}


### PR DESCRIPTION
- Introduced a new CLI tool for comparing ENS databases using Drizzle ORM and PostgreSQL.
- Implemented features for exporting tables in various formats (CSV, JSON, binary) with compression options.
- Added functionality for benchmarking export performance and generating comparison reports.

Questions:
1. Should we compare only some tables and some columns like in graphql diff tool? Or compare everything?
2. Should the tool work on databases with different number of blocks indexed? If yes then open question is how to export or compare data to a given block number. 

I have run comparison on the same database exported with some time delay:
```
Comparison Summary:
Database A: export2drizzle/
Database B: export3drizzle/
Tables Compared: 29
Total Differences: 49
Comparison Time: 22266ms

Table Results:
╔══════════════════════════════╤═════════╤═════════╤═══════════╤═══════════╤════════╤════════╗
║ Table                        │ Total A │ Total B │ Identical │ Different │ Only A │ Only B ║
╟──────────────────────────────┼─────────┼─────────┼───────────┼───────────┼────────┼────────╢
║ abi_changed                  │ 125     │ 125     │ 125       │ 0         │ 0      │ 0      ║
╟──────────────────────────────┼─────────┼─────────┼───────────┼───────────┼────────┼────────╢
║ accounts                     │ 11180   │ 11182   │ 11180     │ 0         │ 0      │ 2      ║
╟──────────────────────────────┼─────────┼─────────┼───────────┼───────────┼────────┼────────╢
║ addr_changed                 │ 22881   │ 22884   │ 22881     │ 0         │ 0      │ 3      ║
╟──────────────────────────────┼─────────┼─────────┼───────────┼───────────┼────────┼────────╢
║ authorisation_changed        │ 0       │ 0       │ 0         │ 0         │ 0      │ 0      ║
╟──────────────────────────────┼─────────┼─────────┼───────────┼───────────┼────────┼────────╢
║ contenthash_changed          │ 2985    │ 2985    │ 2985      │ 0         │ 0      │ 0      ║
╟──────────────────────────────┼─────────┼─────────┼───────────┼───────────┼────────┼────────╢
║ domains                      │ 81256   │ 81260   │ 81252     │ 4         │ 0      │ 4      ║
╟──────────────────────────────┼─────────┼─────────┼───────────┼───────────┼────────┼────────╢
║ expiry_extended              │ 87      │ 87      │ 87        │ 0         │ 0      │ 0      ║
╟──────────────────────────────┼─────────┼─────────┼───────────┼───────────┼────────┼────────╢
║ ext_resolver_address_records │ 21563   │ 21566   │ 21563     │ 0         │ 0      │ 3      ║
╟──────────────────────────────┼─────────┼─────────┼───────────┼───────────┼────────┼────────╢
║ ext_resolver_text_records    │ 178147  │ 178147  │ 178147    │ 0         │ 0      │ 0      ║
╟──────────────────────────────┼─────────┼─────────┼───────────┼───────────┼────────┼────────╢
║ fuses_set                    │ 1006    │ 1006    │ 1006      │ 0         │ 0      │ 0      ║
╟──────────────────────────────┼─────────┼─────────┼───────────┼───────────┼────────┼────────╢
║ interface_changed            │ 233     │ 233     │ 233       │ 0         │ 0      │ 0      ║
╟──────────────────────────────┼─────────┼─────────┼───────────┼───────────┼────────┼────────╢
║ multicoin_addr_changed       │ 22928   │ 22931   │ 22928     │ 0         │ 0      │ 3      ║
╟──────────────────────────────┼─────────┼─────────┼───────────┼───────────┼────────┼────────╢
║ name_changed                 │ 20163   │ 20164   │ 20163     │ 0         │ 0      │ 1      ║
╟──────────────────────────────┼─────────┼─────────┼───────────┼───────────┼────────┼────────╢
║ name_registered              │ 68334   │ 68336   │ 68334     │ 0         │ 0      │ 2      ║
╟──────────────────────────────┼─────────┼─────────┼───────────┼───────────┼────────┼────────╢
║ name_renewed                 │ 1172    │ 1172    │ 1172      │ 0         │ 0      │ 0      ║
╟──────────────────────────────┼─────────┼─────────┼───────────┼───────────┼────────┼────────╢
║ name_transferred             │ 2501    │ 2502    │ 2501      │ 0         │ 0      │ 1      ║
╟──────────────────────────────┼─────────┼─────────┼───────────┼───────────┼────────┼────────╢
║ name_unwrapped               │ 824     │ 824     │ 824       │ 0         │ 0      │ 0      ║
╟──────────────────────────────┼─────────┼─────────┼───────────┼───────────┼────────┼────────╢
║ name_wrapped                 │ 67373   │ 67374   │ 67373     │ 0         │ 0      │ 1      ║
╟──────────────────────────────┼─────────┼─────────┼───────────┼───────────┼────────┼────────╢
║ new_owners                   │ 90200   │ 90206   │ 90200     │ 0         │ 0      │ 6      ║
╟──────────────────────────────┼─────────┼─────────┼───────────┼───────────┼────────┼────────╢
║ new_resolvers                │ 72518   │ 72524   │ 72518     │ 0         │ 0      │ 6      ║
╟──────────────────────────────┼─────────┼─────────┼───────────┼───────────┼────────┼────────╢
║ new_ttls                     │ 14      │ 14      │ 14        │ 0         │ 0      │ 0      ║
╟──────────────────────────────┼─────────┼─────────┼───────────┼───────────┼────────┼────────╢
║ pubkey_changed               │ 1064    │ 1065    │ 1064      │ 0         │ 0      │ 1      ║
╟──────────────────────────────┼─────────┼─────────┼───────────┼───────────┼────────┼────────╢
║ registrations                │ 68181   │ 68183   │ 68181     │ 0         │ 0      │ 2      ║
╟──────────────────────────────┼─────────┼─────────┼───────────┼───────────┼────────┼────────╢
║ resolvers                    │ 85943   │ 85949   │ 85943     │ 0         │ 0      │ 6      ║
╟──────────────────────────────┼─────────┼─────────┼───────────┼───────────┼────────┼────────╢
║ text_changed                 │ 186524  │ 186524  │ 186524    │ 0         │ 0      │ 0      ║
╟──────────────────────────────┼─────────┼─────────┼───────────┼───────────┼────────┼────────╢
║ transfers                    │ 2136    │ 2138    │ 2136      │ 0         │ 0      │ 2      ║
╟──────────────────────────────┼─────────┼─────────┼───────────┼───────────┼────────┼────────╢
║ version_changed              │ 62      │ 62      │ 62        │ 0         │ 0      │ 0      ║
╟──────────────────────────────┼─────────┼─────────┼───────────┼───────────┼────────┼────────╢
║ wrapped_domains              │ 66549   │ 66550   │ 66549     │ 0         │ 0      │ 1      ║
╟──────────────────────────────┼─────────┼─────────┼───────────┼───────────┼────────┼────────╢
║ wrapped_transfers            │ 70768   │ 70769   │ 70768     │ 0         │ 0      │ 1      ║
╚══════════════════════════════╧═════════╧═════════╧═══════════╧═══════════╧════════╧════════╝
```
Database B is the later one so it has more data and almost all is identical except 4 `domains` where `subdomain_count` has increased.
So if we want to compare databases with different number of blocks indexed then at least we need to add some special comparison method for `subdomain_count` but there will be more issues.
