### PR TITLE
feat(ci): unset ignored changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -24,5 +24,5 @@
     "version": true,
     "tag": true
   },
-  "ignore": ["@docs/ensnode", "@docs/ensrainbow"]
+  "ignore": []
 }


### PR DESCRIPTION
This PR unsets the `ignore` property in Changesets config file. So far, this property only listed names of packages that were already marked as `private: true` in there respective `package.json` files.

The PR aims to fix an issue listed as the caveats 1. below.

### Context

Source:
https://github.com/changesets/changesets/blob/main/docs/config-file-options.md#ignore-array-of-packages

> There are two caveats to this.
> 1. If the package is mentioned in a changeset that also includes a package that is not ignored, publishing will fail.
> 2. If the package requires one of its dependencies to be updated as part of a publish.

including:

> THIS FEATURE IS DESIGNED FOR TEMPORARY USE TO ALLOW CHANGES TO BE MERGED WITHOUT PUBLISHING THEM - If you want to stop a package from being published at all, set `private: true` in its `package.json`.