### PR TITLE
fix(cicd): render service port

### DIFF
--- a/terraform/modules/ensindexer/main.tf
+++ b/terraform/modules/ensindexer/main.tf
@@ -67,7 +67,7 @@ resource "render_web_service" "ensindexer" {
         value = "https://${local.full_ensindexer_hostname}"
       },
       ENSINDEXER_URL = {
-        value = "http://localhost:1000"
+        value = "http://localhost:10000"
       }
     }
   )
@@ -98,7 +98,7 @@ resource "render_web_service" "ensindexer_api" {
         value = "https://${local.full_ensindexer_api_hostname}"
       },
       ENSINDEXER_URL = {
-        value = "http://ensindexer-${var.instance_name}:1000"
+        value = "http://ensindexer-${var.instance_name}:10000"
       },
       PONDER_COMMAND = {
         value = "serve"


### PR DESCRIPTION
ENSIndexer service is hosted on port `10000` when it comes to render.com platform.