### PR TITLE
refactor(indexing-status): include `omnichainIndexingCursor`

### DIFF
--- a/.changeset/icy-pants-drum.md
+++ b/.changeset/icy-pants-drum.md
@@ -1,0 +1,6 @@
+---
+"@ensnode/ensnode-sdk": minor
+"ensindexer": minor
+---
+
+Extends the `ENSIndexerOverallIndexingCompletedStatus` data model with the `omnichainIndexingCursor` field.

--- a/.changeset/smart-schools-add.md
+++ b/.changeset/smart-schools-add.md
@@ -1,0 +1,5 @@
+---
+"ensadmin": minor
+---
+
+Aligns date & datetime display format.

--- a/apps/ensadmin/src/components/datetime-utils/index.tsx
+++ b/apps/ensadmin/src/components/datetime-utils/index.tsx
@@ -1,24 +1,51 @@
-import { formatDistance, formatDistanceStrict, intlFormat } from "date-fns";
+import {
+  IntlFormatFormatOptions,
+  formatDistance,
+  formatDistanceStrict,
+  intlFormat,
+} from "date-fns";
 import { millisecondsInSecond } from "date-fns/constants";
 import { useEffect, useState } from "react";
 
 /**
- * Client-only date formatter component
+ * Format date as a datetime string.
  */
-export function FormattedDate({
-  date,
-  options,
-}: {
-  date: Date;
-  options: Intl.DateTimeFormatOptions;
-}) {
-  const [formattedDate, setFormattedDate] = useState<string>("");
+export function datetimeFormat(date: Date, args: Partial<IntlFormatFormatOptions> = {}): string {
+  const {
+    year = "numeric",
+    month = "short",
+    day = "numeric",
+    hour = "numeric",
+    minute = "numeric",
+    second = "numeric",
+    hour12 = true,
+  } = args;
 
-  useEffect(() => {
-    setFormattedDate(intlFormat(date, options));
-  }, [date, options]);
+  return intlFormat(date, {
+    year,
+    month,
+    day,
+    hour,
+    minute,
+    second,
+    hour12,
+  });
+}
 
-  return <>{formattedDate}</>;
+/**
+ * Format date as a date string.
+ */
+export function dateFormat(
+  date: Date,
+  args: Partial<Pick<IntlFormatFormatOptions, "dateStyle" | "year" | "month" | "day">> = {},
+): string {
+  const { year = "numeric", month = "short", day = "numeric" } = args;
+
+  return intlFormat(date, {
+    year,
+    month,
+    day,
+  });
 }
 
 /**

--- a/apps/ensadmin/src/components/indexing-status/backfill-status.tsx
+++ b/apps/ensadmin/src/components/indexing-status/backfill-status.tsx
@@ -8,12 +8,11 @@ import {
   ENSIndexerOverallIndexingBackfillStatus,
   getTimestampForHighestOmnichainKnownBlock,
   getTimestampForLowestOmnichainStartBlock,
-  sortAscChainStatusesByStartBlock,
+  sortEarliestOmnichainStartBlock,
 } from "@ensnode/ensnode-sdk";
-import { fromUnixTime } from "date-fns";
+import { fromUnixTime, intlFormat } from "date-fns";
 import { Clock } from "lucide-react";
 
-import { FormattedDate } from "@/components/datetime-utils";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { getChainName } from "@/lib/namespace-utils";
@@ -39,7 +38,7 @@ interface BackfillStatusProps {
  * Presents indexing status when overall status is "backfill".
  */
 export function BackfillStatus({ indexingStatus }: BackfillStatusProps) {
-  const chainEntries = sortAscChainStatusesByStartBlock([...indexingStatus.chains.entries()]);
+  const chainEntries = sortEarliestOmnichainStartBlock([...indexingStatus.chains.entries()]);
   const chains = chainEntries.map(([, chain]) => chain);
 
   const timelineStartUnixTimestamp = getTimestampForLowestOmnichainStartBlock(chains);
@@ -72,18 +71,11 @@ export function BackfillStatus({ indexingStatus }: BackfillStatusProps) {
               <Clock size={16} className="text-blue-600" />
               <span className="text-sm font-medium">
                 Indexed through{" "}
-                <FormattedDate
-                  date={omnichainIndexingCursorDate}
-                  options={{
-                    year: "numeric",
-                    month: "short",
-                    day: "numeric",
-                    hour: "numeric",
-                    minute: "numeric",
-                    second: "numeric",
-                    hour12: true,
-                  }}
-                />
+                {intlFormat(omnichainIndexingCursorDate, {
+                  dateStyle: "medium",
+                  timeStyle: "medium",
+                  hour12: true,
+                })}
               </span>
             </div>
           </CardTitle>

--- a/apps/ensadmin/src/components/indexing-status/indexing-stats.tsx
+++ b/apps/ensadmin/src/components/indexing-status/indexing-stats.tsx
@@ -17,7 +17,7 @@ import {
   ENSIndexerOverallIndexingUnstartedStatus,
   OverallIndexingStatusId,
   OverallIndexingStatusIds,
-  sortAscChainStatusesByStartBlock,
+  sortEarliestOmnichainStartBlock,
 } from "@ensnode/ensnode-sdk";
 import { PropsWithChildren } from "react";
 
@@ -47,7 +47,7 @@ export function IndexingStatsForIndexerErrorStatus() {
 export function IndexingStatsForUnstartedStatus({
   indexingStatus,
 }: IndexingStatusProps<ENSIndexerOverallIndexingUnstartedStatus>) {
-  const chainEntries = sortAscChainStatusesByStartBlock([...indexingStatus.chains.entries()]);
+  const chainEntries = sortEarliestOmnichainStartBlock([...indexingStatus.chains.entries()]);
 
   return chainEntries.map(([chainId, chain]) => {
     const endBlock = chain.config.endBlock ? blockViewModel(chain.config.endBlock) : null;
@@ -94,7 +94,7 @@ export function IndexingStatsForUnstartedStatus({
 export function IndexingStatsForBackfillStatus({
   indexingStatus,
 }: IndexingStatusProps<ENSIndexerOverallIndexingBackfillStatus>) {
-  const chainEntries = sortAscChainStatusesByStartBlock([...indexingStatus.chains.entries()]);
+  const chainEntries = sortEarliestOmnichainStartBlock([...indexingStatus.chains.entries()]);
 
   return chainEntries.map(([chainId, chain]) => {
     const endBlock = chain.config.endBlock ? blockViewModel(chain.config.endBlock) : null;
@@ -163,7 +163,7 @@ export function IndexingStatsForBackfillStatus({
 export function IndexingStatsForCompletedStatus({
   indexingStatus,
 }: IndexingStatusProps<ENSIndexerOverallIndexingCompletedStatus>) {
-  const chainEntries = sortAscChainStatusesByStartBlock([...indexingStatus.chains.entries()]);
+  const chainEntries = sortEarliestOmnichainStartBlock([...indexingStatus.chains.entries()]);
 
   return chainEntries.map(([chainId, chain]) => {
     const endBlock = chain.config.endBlock ? blockViewModel(chain.config.endBlock) : null;
@@ -216,7 +216,7 @@ export function IndexingStatsForCompletedStatus({
 export function IndexingStatsForFollowingStatus({
   indexingStatus,
 }: IndexingStatusProps<ENSIndexerOverallIndexingFollowingStatus>) {
-  const chainEntries = sortAscChainStatusesByStartBlock([...indexingStatus.chains.entries()]);
+  const chainEntries = sortEarliestOmnichainStartBlock([...indexingStatus.chains.entries()]);
 
   return chainEntries.map(([chainId, chain]) => {
     const endBlock = chain.config.endBlock ? blockViewModel(chain.config.endBlock) : null;

--- a/apps/ensadmin/src/components/indexing-status/indexing-timeline.tsx
+++ b/apps/ensadmin/src/components/indexing-status/indexing-timeline.tsx
@@ -5,8 +5,8 @@
 import { ChainName } from "@/components/chains/ChainName";
 import { cn } from "@/lib/utils";
 import { ChainId, ChainIndexingStatusIds } from "@ensnode/ensnode-sdk";
-import { intlFormat } from "date-fns";
 
+import { dateFormat } from "@/components/datetime-utils";
 import { BlockRefViewModel } from "@/components/indexing-status/block-refs";
 import { getTimelinePosition } from "./indexing-timeline-utils";
 
@@ -141,7 +141,7 @@ export function ChainIndexingTimeline(props: ChainIndexingTimelineProps) {
         >
           <div className="absolute top-4 -translate-x-1/2 whitespace-nowrap">
             <span className="text-xs text-gray-600">
-              {intlFormat(chainStatus.firstBlockToIndex.date)}
+              {dateFormat(chainStatus.firstBlockToIndex.date)}
             </span>
           </div>
         </div>

--- a/apps/ensadmin/src/components/recent-registrations/components.tsx
+++ b/apps/ensadmin/src/components/recent-registrations/components.tsx
@@ -5,12 +5,11 @@ import {
   type ENSIndexerOverallIndexingCompletedStatus,
   type ENSIndexerOverallIndexingFollowingStatus,
   type ENSIndexerPublicConfig,
-  OverallIndexingStatusIds,
 } from "@ensnode/ensnode-sdk";
-import { fromUnixTime } from "date-fns";
+import { fromUnixTime, intlFormat } from "date-fns";
 import { useEffect, useState } from "react";
 
-import { Duration, RelativeTime } from "@/components/datetime-utils";
+import { Duration, RelativeTime, datetimeFormat } from "@/components/datetime-utils";
 import { NameDisplay } from "@/components/identity/utils";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -21,6 +20,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { Clock } from "lucide-react";
 import { Identity } from "../identity";
 import { useRecentRegistrations } from "./hooks";
 import type { Registration } from "./types";
@@ -57,22 +57,23 @@ export function RecentRegistrations({
 
   const { ensNodePublicUrl: ensNodeUrl, namespace: namespaceId } = ensIndexerConfig;
 
-  // Get the current indexing date from the indexing status
-  const currentIndexingDate =
-    indexingStatus.overallStatus === OverallIndexingStatusIds.Following
-      ? fromUnixTime(indexingStatus.omnichainIndexingCursor)
-      : null;
+  const omnichainIndexingCursor = fromUnixTime(indexingStatus.omnichainIndexingCursor);
 
   return (
     <Card className="w-full">
       <CardHeader>
         <CardTitle className="flex justify-between items-center">
           <span>Latest indexed registrations</span>
+
+          <div className="flex items-center gap-1.5">
+            <Clock size={16} className="text-blue-600" />
+            <span className="text-sm font-medium">{datetimeFormat(omnichainIndexingCursor)}</span>
+          </div>
         </CardTitle>
       </CardHeader>
       <CardContent>
         {isClient && (
-          <RegistrationsList
+          <RecentRegistrationsList
             ensNodeUrl={ensNodeUrl}
             namespaceId={namespaceId}
             maxRecords={MAX_NUMBER_OF_LATEST_REGISTRATIONS}
@@ -83,7 +84,7 @@ export function RecentRegistrations({
   );
 }
 
-interface RegistrationsListProps {
+interface RecentRegistrationsListProps {
   ensNodeUrl: URL;
   namespaceId: ENSNamespaceId;
   maxRecords: number;
@@ -95,7 +96,11 @@ interface RegistrationsListProps {
  * @param ensNodeMetadata data about connected ENSNode instance necessary for fetching registrations
  * @param ensNodeUrl URL of currently selected ENSNode instance
  */
-function RegistrationsList({ ensNodeUrl, namespaceId, maxRecords }: RegistrationsListProps) {
+function RecentRegistrationsList({
+  ensNodeUrl,
+  namespaceId,
+  maxRecords,
+}: RecentRegistrationsListProps) {
   const recentRegistrationsQuery = useRecentRegistrations({
     ensNodeUrl,
     namespaceId,
@@ -169,10 +174,10 @@ function RegistrationRow({ registration, namespaceId }: RegistrationRowProps) {
   );
 }
 
-interface RegistrationLoadingProps {
+interface RegistrationsListLoadingProps {
   rowCount: number;
 }
-function RegistrationsListLoading({ rowCount }: RegistrationLoadingProps) {
+function RegistrationsListLoading({ rowCount }: RegistrationsListLoadingProps) {
   return (
     <div className="animate-pulse space-y-4">
       {[...Array(rowCount)].map((_, idx) => (

--- a/apps/ensindexer/src/api/lib/indexing-status/ponder-metadata/zod-schemas.ts
+++ b/apps/ensindexer/src/api/lib/indexing-status/ponder-metadata/zod-schemas.ts
@@ -28,6 +28,7 @@ import {
   checkChainIndexingStatusesForUnstartedOverallStatus,
   getActiveChains,
   getOmnichainIndexingCursor,
+  getOmnichainIndexingCursorForCompletedOverallStatus,
   getOverallApproxRealtimeDistance,
   getOverallIndexingStatus,
 } from "@ensnode/ensnode-sdk";
@@ -131,12 +132,19 @@ export const makePonderChainMetadataSchema = (
         }
 
         case OverallIndexingStatusIds.Completed: {
+          // invariant: all chains are in the completed status
+          if (!checkChainIndexingStatusesForCompletedOverallStatus(chainStatuses)) {
+            throw new Error("All chains must be in the 'completed' status.");
+          }
+
           return {
             overallStatus: OverallIndexingStatusIds.Completed,
             chains: serializedChainIndexingStatuses as Record<
               ChainIdString,
               ChainIndexingCompletedStatus
             >, // forcing the type here, will be validated in the following 'check' step
+            omnichainIndexingCursor:
+              getOmnichainIndexingCursorForCompletedOverallStatus(chainStatuses),
           } satisfies SerializedENSIndexerOverallIndexingCompletedStatus;
         }
 

--- a/packages/ensnode-sdk/src/ensindexer/indexing-status/helpers.ts
+++ b/packages/ensnode-sdk/src/ensindexer/indexing-status/helpers.ts
@@ -261,9 +261,9 @@ export function checkChainIndexingStatusesForFollowingOverallStatus(
  * Sort a list of [{@link ChainId}, {@link ChainIndexingStatus}] tuples
  * by the omnichain start block timestamp in ascending order.
  */
-export function sortAscChainStatusesByStartBlock<ChainStatusType extends ChainIndexingStatus>(
-  chains: [ChainId, ChainStatusType][],
-): [ChainId, ChainStatusType][] {
+export function sortEarliestOmnichainStartBlock<
+  ChainIndexingStatusType extends ChainIndexingStatus,
+>(chains: [ChainId, ChainIndexingStatusType][]): [ChainId, ChainIndexingStatusType][] {
   // Sort the chain statuses by the omnichain first block to index timestamp
   chains.sort(
     ([, chainA], [, chainB]) =>

--- a/packages/ensnode-sdk/src/ensindexer/indexing-status/helpers.ts
+++ b/packages/ensnode-sdk/src/ensindexer/indexing-status/helpers.ts
@@ -125,6 +125,18 @@ export function getOmnichainIndexingCursor(chains: ChainIndexingActiveStatus[]):
 }
 
 /**
+ * Get Omnichain Indexing Cursor across all chains which status is
+ * {@link ChainIndexingCompletedStatus}.
+ *
+ * Note how this function as a different goal to {@link getOmnichainIndexingCursor} one.
+ */
+export function getOmnichainIndexingCursorForCompletedOverallStatus(
+  chains: ChainIndexingCompletedStatus[],
+): UnixTimestamp {
+  return Math.max(...chains.map((chain) => chain.latestIndexedBlock.timestamp));
+}
+
+/**
  * Get all chains which status is {@link ChainIndexingActiveStatus}.
  */
 export function getActiveChains(chains: ChainIndexingStatus[]): ChainIndexingActiveStatus[] {

--- a/packages/ensnode-sdk/src/ensindexer/indexing-status/serialize.ts
+++ b/packages/ensnode-sdk/src/ensindexer/indexing-status/serialize.ts
@@ -57,6 +57,7 @@ export function serializeENSIndexerIndexingStatus(
       return {
         overallStatus: OverallIndexingStatusIds.Completed,
         chains: serializeChainIndexingStatuses(indexingStatus.chains),
+        omnichainIndexingCursor: indexingStatus.omnichainIndexingCursor,
       } satisfies SerializedENSIndexerOverallIndexingCompletedStatus;
     }
 

--- a/packages/ensnode-sdk/src/ensindexer/indexing-status/types.ts
+++ b/packages/ensnode-sdk/src/ensindexer/indexing-status/types.ts
@@ -324,6 +324,19 @@ export interface ENSIndexerOverallIndexingCompletedStatus {
   overallStatus: typeof OverallIndexingStatusIds.Completed;
 
   /**
+   * Omnichain Indexing Cursor
+   *
+   * Identifies the timestamp of the progress of omnichain indexing across
+   * all chains in {@link ChainIndexingCompletedStatus} status.
+   *
+   * Invariants:
+   * - the cursor value is guaranteed to be equal to
+   *   the timestamp of the highest `latestIndexedBlock` across all chains
+   *   in {@link ChainIndexingCompletedStatus} status.
+   */
+  omnichainIndexingCursor: UnixTimestamp;
+
+  /**
    * Indexing Status for each chain.
    *
    * Each chain is guaranteed to have the "completed" status.


### PR DESCRIPTION
This PR extends the `ENSIndexerOverallIndexingCompletedStatus` data model with the `omnichainIndexingCursor` field.
It also aligns date & datetime display format.

Resolves #946, #989.

### Preview

| Backfill timeline | Recent Registrations List |
|--------|--------|
| <img width="1212" height="1009" alt="image" src="https://github.com/user-attachments/assets/b264aa29-3a5b-46e5-b980-f33cc5d52cd8" /> | <img width="1215" height="999" alt="image" src="https://github.com/user-attachments/assets/37c91ec1-db6a-4ac1-9b6b-00b50dccf284" /> |




