### PR TITLE
fix(ensadmin): docker file env vars

### DIFF
--- a/apps/ensadmin/Dockerfile
+++ b/apps/ensadmin/Dockerfile
@@ -23,6 +23,9 @@ RUN pnpm --filter ensadmin build
 # runner
 FROM base AS runner
 
+# Set the environment variable for the default ENSNode URLs
+ARG NEXT_PUBLIC_DEFAULT_ENSNODE_URLS
+ENV NEXT_PUBLIC_DEFAULT_ENSNODE_URLS=${NEXT_PUBLIC_DEFAULT_ENSNODE_URLS}
 ENV NODE_ENV=production
 
 RUN addgroup --system --gid 1001 nodejs


### PR DESCRIPTION
This PR allows the env vars set via Docker build args to be propagated to the container runtime. All it takes is to set envs in the very last stage that's going to host the target application.