### PR TITLE
fix: Bump Hono version to 4.9.7

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ catalogs:
       specifier: '=0.41.0'
       version: 0.41.0
     hono:
-      specifier: ^4.7.6
-      version: 4.7.8
+      specifier: ^4.9.7
+      version: 4.9.7
     ponder:
       specifier: 0.11.43
       version: 0.11.43
@@ -288,10 +288,10 @@ importers:
         version: link:../../packages/ponder-subgraph
       '@hono/otel':
         specifier: ^0.2.2
-        version: 0.2.2(hono@4.7.8)
+        version: 0.2.2(hono@4.9.7)
       '@hono/zod-validator':
         specifier: ^0.7.2
-        version: 0.7.2(hono@4.7.8)(zod@3.25.7)
+        version: 0.7.2(hono@4.9.7)(zod@3.25.7)
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a)
@@ -339,16 +339,16 @@ importers:
         version: 5.6.1
       hono:
         specifier: 'catalog:'
-        version: 4.7.8
+        version: 4.9.7
       pg-connection-string:
         specifier: ^2.9.0
         version: 2.9.0
       ponder:
         specifier: 'catalog:'
-        version: 0.11.43(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))(@types/node@22.15.3)(hono@4.7.8)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(typescript@5.7.3)(viem@2.23.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7))(yaml@2.7.0)(zod@3.25.7)
+        version: 0.11.43(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))(@types/node@22.15.3)(hono@4.9.7)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(typescript@5.7.3)(viem@2.23.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7))(yaml@2.7.0)(zod@3.25.7)
       ponder-enrich-gql-docs-middleware:
         specifier: ^0.1.3
-        version: 0.1.3(graphql@16.10.0)(hono@4.7.8)
+        version: 0.1.3(graphql@16.10.0)(hono@4.9.7)
       viem:
         specifier: 'catalog:'
         version: 2.23.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
@@ -382,13 +382,13 @@ importers:
         version: link:../../packages/ensrainbow-sdk
       '@hono/node-server':
         specifier: ^1.4.1
-        version: 1.13.3(hono@4.7.8)
+        version: 1.13.3(hono@4.9.7)
       classic-level:
         specifier: ^1.4.1
         version: 1.4.1
       hono:
         specifier: 'catalog:'
-        version: 4.7.8
+        version: 4.9.7
       pino:
         specifier: ^8.19.0
         version: 8.21.0
@@ -646,7 +646,7 @@ importers:
     dependencies:
       ponder:
         specifier: 'catalog:'
-        version: 0.11.43(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))(@types/node@22.15.3)(hono@4.7.8)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(typescript@5.7.3)(viem@2.23.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7))(yaml@2.7.0)(zod@3.25.7)
+        version: 0.11.43(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))(@types/node@22.15.3)(hono@4.9.7)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(typescript@5.7.3)(viem@2.23.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7))(yaml@2.7.0)(zod@3.25.7)
       viem:
         specifier: 'catalog:'
         version: 2.23.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
@@ -749,10 +749,10 @@ importers:
         version: 22.15.3
       hono:
         specifier: 'catalog:'
-        version: 4.7.8
+        version: 4.9.7
       ponder:
         specifier: 'catalog:'
-        version: 0.11.43(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))(@types/node@22.15.3)(hono@4.7.8)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(typescript@5.7.3)(viem@2.23.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7))(yaml@2.7.0)(zod@3.25.7)
+        version: 0.11.43(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))(@types/node@22.15.3)(hono@4.9.7)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(typescript@5.7.3)(viem@2.23.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7))(yaml@2.7.0)(zod@3.25.7)
       tsup:
         specifier: 'catalog:'
         version: 8.3.6(jiti@2.4.2)(postcss@8.5.6)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0)
@@ -801,7 +801,7 @@ importers:
         version: 22.15.3
       hono:
         specifier: 'catalog:'
-        version: 4.7.8
+        version: 4.9.7
       tsup:
         specifier: 'catalog:'
         version: 8.3.6(jiti@2.4.2)(postcss@8.5.6)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0)
@@ -5763,8 +5763,8 @@ packages:
   hey-listen@1.0.8:
     resolution: {integrity: sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==}
 
-  hono@4.7.8:
-    resolution: {integrity: sha512-PCibtFdxa7/Ldud9yddl1G81GjYaeMYYTq4ywSaNsYbB1Lug4mwtOMJf2WXykL0pntYwmpRJeOI3NmoDgD+Jxw==}
+  hono@4.9.7:
+    resolution: {integrity: sha512-t4Te6ERzIaC48W3x4hJmBwgNlLhmiEdEE5ViYb02ffw4ignHNHa5IBtPjmbKstmtKa8X6C35iWwK4HaqvrzG9w==}
     engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@4.0.0:
@@ -9941,19 +9941,19 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  '@hono/node-server@1.13.3(hono@4.7.8)':
+  '@hono/node-server@1.13.3(hono@4.9.7)':
     dependencies:
-      hono: 4.7.8
+      hono: 4.9.7
 
-  '@hono/otel@0.2.2(hono@4.7.8)':
+  '@hono/otel@0.2.2(hono@4.9.7)':
     dependencies:
       '@opentelemetry/api': 1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a)
       '@opentelemetry/semantic-conventions': 1.36.0
-      hono: 4.7.8
+      hono: 4.9.7
 
-  '@hono/zod-validator@0.7.2(hono@4.7.8)(zod@3.25.7)':
+  '@hono/zod-validator@0.7.2(hono@4.9.7)(zod@3.25.7)':
     dependencies:
-      hono: 4.7.8
+      hono: 4.9.7
       zod: 3.25.7
 
   '@humanfs/core@0.19.1': {}
@@ -14493,7 +14493,7 @@ snapshots:
 
   hey-listen@1.0.8: {}
 
-  hono@4.7.8: {}
+  hono@4.9.7: {}
 
   html-encoding-sniffer@4.0.0:
     dependencies:
@@ -16050,12 +16050,12 @@ snapshots:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
 
-  ponder-enrich-gql-docs-middleware@0.1.3(graphql@16.10.0)(hono@4.7.8):
+  ponder-enrich-gql-docs-middleware@0.1.3(graphql@16.10.0)(hono@4.9.7):
     dependencies:
       graphql: 16.10.0
-      hono: 4.7.8
+      hono: 4.9.7
 
-  ponder@0.11.43(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))(@types/node@22.15.3)(hono@4.7.8)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(typescript@5.7.3)(viem@2.23.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7))(yaml@2.7.0)(zod@3.25.7):
+  ponder@0.11.43(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))(@types/node@22.15.3)(hono@4.9.7)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(typescript@5.7.3)(viem@2.23.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7))(yaml@2.7.0)(zod@3.25.7):
     dependencies:
       '@babel/code-frame': 7.26.2
       '@commander-js/extra-typings': 12.1.0(commander@12.1.0)
@@ -16063,7 +16063,7 @@ snapshots:
       '@escape.tech/graphql-armor-max-aliases': 2.6.2
       '@escape.tech/graphql-armor-max-depth': 2.4.2
       '@escape.tech/graphql-armor-max-tokens': 2.5.1
-      '@hono/node-server': 1.13.3(hono@4.7.8)
+      '@hono/node-server': 1.13.3(hono@4.9.7)
       '@ponder/utils': 0.2.10(typescript@5.7.3)(viem@2.23.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7))
       abitype: 0.10.3(typescript@5.7.3)(zod@3.25.7)
       ansi-escapes: 7.0.0
@@ -16076,7 +16076,7 @@ snapshots:
       glob: 10.4.5
       graphql: 16.10.0
       graphql-yoga: 5.10.10(graphql@16.10.0)
-      hono: 4.7.8
+      hono: 4.9.7
       http-terminator: 3.2.0
       kysely: 0.26.3
       pg: 8.11.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,7 @@ catalog:
   astro: ^5.13.4
   date-fns: ^4.1.0
   drizzle-orm: =0.41.0
-  hono: ^4.7.6
+  hono: ^4.9.7
   typescript: ^5.7.3
   viem: ^2.22.13
   vitest: ^3.2.4


### PR DESCRIPTION
Change aiming to fix [the dependabot warning](https://github.com/namehash/ensnode/security/dependabot/40) about this [Hono vulnerability issue](https://github.com/advisories/GHSA-92vj-g62v-jqhh)

Per [Hono's release notes since our last version (4.7.6)](https://github.com/honojs/hono/releases), there shouldn't be any breaking changes, but since it affects a large number of our apps, and the version bump is quite significant, I'd appreciate it if any of you could confirm that all works well with that fix.

UPDATE: here is the [diff between our previously used version and the newest bump](https://github.com/honojs/hono/compare/v4.7.6...v4.9.7). I didn't check it fully. Only had a look at the release notes.