### PR TITLE
Introduce SUBGRAPH_COMPAT behavior

### DIFF
--- a/.changeset/seven-peas-look.md
+++ b/.changeset/seven-peas-look.md
@@ -1,0 +1,5 @@
+---
+"ensindexer": minor
+---
+
+Introduce new SUBGRAPH_COMPAT flag to configure ENSIndexer's subgraph-compatible indexing behavior.

--- a/apps/ensindexer/src/config/derived-params.ts
+++ b/apps/ensindexer/src/config/derived-params.ts
@@ -1,7 +1,7 @@
 import type { ENSIndexerConfig } from "@/config/types";
 import { getENSNamespaceAsFullyDefinedAtCompileTime } from "@/lib/plugin-helpers";
 import { getPlugin } from "@/plugins";
-import { ChainId, isSubgraphCompatible } from "@ensnode/ensnode-sdk";
+import { ChainId } from "@ensnode/ensnode-sdk";
 
 /**
  * Derive `indexedChainIds` configuration parameter and include it in
@@ -32,19 +32,5 @@ export const derive_indexedChainIds = <
   return {
     ...config,
     indexedChainIds,
-  };
-};
-
-/**
- * Derived `isSubgraphCompatible` config param based on validated ENSIndexerConfig object.
- */
-export const derive_isSubgraphCompatible = <
-  CONFIG extends Pick<ENSIndexerConfig, "plugins" | "labelSet">,
->(
-  config: CONFIG,
-): CONFIG & { isSubgraphCompatible: boolean } => {
-  return {
-    ...config,
-    isSubgraphCompatible: isSubgraphCompatible(config),
   };
 };

--- a/apps/ensindexer/src/config/environment-defaults.ts
+++ b/apps/ensindexer/src/config/environment-defaults.ts
@@ -1,0 +1,48 @@
+import { ENSIndexerEnvironment } from "@/config/types";
+import { DeepPartial, PluginName } from "@ensnode/ensnode-sdk";
+
+/**
+ * These are defaults for the ENSIndexerConfig's schema. By applying them at the environment level
+ * these inputs still go through the ENSIndexerConfig parsing/validation steps.
+ */
+export const EnvironmentDefaults = {
+  subgraphCompatible: {
+    plugins: [PluginName.Subgraph].join(","),
+    labelSet: { labelSetId: "subgraph", labelSetVersion: "0" },
+  },
+  alpha: {
+    plugins: [
+      // TODO: collapse all of these subgraph-specific core plugins into 'subgraph' plugin
+      PluginName.Subgraph,
+      PluginName.Basenames,
+      PluginName.Lineanames,
+      PluginName.ThreeDNS,
+    ].join(","),
+    // TODO: set these to the most up-to-date ENSRainbow Label Set
+    labelSet: { labelSetId: "subgraph", labelSetVersion: "0" },
+  },
+} satisfies Record<string, Partial<ENSIndexerEnvironment>>;
+
+/**
+ * Applies partial defaults to an object iff the property in question is undefined.
+ */
+export const applyDefaults = <T extends Record<string, any>>(
+  data: T,
+  defaults: DeepPartial<T>,
+): T => {
+  const result = { ...data } as any;
+
+  for (const [key, value] of Object.entries(defaults)) {
+    // handle nested objects
+    if (typeof value === "object" && !Array.isArray(value)) {
+      result[key] = applyDefaults(result[key], value);
+      continue;
+    }
+
+    if (result[key] === undefined) {
+      result[key] = value;
+    }
+  }
+
+  return result as T;
+};

--- a/apps/ensindexer/src/config/index.ts
+++ b/apps/ensindexer/src/config/index.ts
@@ -1,9 +1,8 @@
 import { buildConfigFromEnvironment } from "@/config/config.schema";
-import { ENSIndexerEnvironment } from "@/config/types";
 import { getRpcConfigsFromEnv } from "@/lib/lib-config";
 
-// format the relevant environment variables into the shape of an ENSIndexerEnvironment
-const environment = {
+// build, validate, and export the ENSIndexerConfig given the env
+export default buildConfigFromEnvironment({
   port: process.env.PORT,
   databaseSchemaName: process.env.DATABASE_SCHEMA,
   databaseUrl: process.env.DATABASE_URL,
@@ -22,7 +21,5 @@ const environment = {
     endBlock: process.env.END_BLOCK,
   },
   rpcConfigs: getRpcConfigsFromEnv(),
-} satisfies ENSIndexerEnvironment;
-
-// build, validate, and export the ENSIndexerConfig
-export default buildConfigFromEnvironment(environment);
+  isSubgraphCompatible: process.env.SUBGRAPH_COMPAT,
+});

--- a/apps/ensindexer/src/config/types.ts
+++ b/apps/ensindexer/src/config/types.ts
@@ -182,10 +182,7 @@ export interface ENSIndexerConfig {
   globalBlockrange: Blockrange;
 
   /**
-   * A flag derived from the built config indicating whether ENSIndexer is operating in a
-   * subgraph-compatible way. This flag is true if:
-   * a) only the subgraph plugin is activated, and
-   * b) the labelSet is { labelSetId: 'subgraph', labelSetVersion: 0 }.
+   * A feature flag to enable/disable ENSIndexer's Subgraph Compatible Indexing Behavior.
    *
    * If {@link isSubgraphCompatible} is true, indexing behavior will match that of the legacy ENS
    * Subgraph.
@@ -193,6 +190,10 @@ export interface ENSIndexerConfig {
    * ENSIndexer will store and return Literal Labels and Literal Names without further interpretation.
    * @see https://ensnode.io/docs/reference/terminology#literal-label
    * @see https://ensnode.io/docs/reference/terminology#literal-name
+   *
+   * If {@link isSubgraphCompatible} is true, the following invariants are true for the ENSIndexerConfig:
+   * 1. only the 'subgraph' plugin is enabled, and
+   * 2. the labelSet must be { labelSetId: 'subgraph', labelSetVersion: 0 }
    *
    * If {@link isSubgraphCompatible} is false, ENSIndexer will additionally:
    *
@@ -220,9 +221,6 @@ export interface ENSIndexerConfig {
   isSubgraphCompatible: boolean;
 }
 
-/**
- * Represents the raw unvalidated environment variables for an rpc endpoint.
- */
 export interface RpcConfigEnvironment {
   url: string;
   maxRequestsPerSecond: string | undefined;
@@ -255,4 +253,5 @@ export interface ENSIndexerEnvironment {
     endBlock: string | undefined;
   };
   rpcConfigs: Record<ChainIdString, RpcConfigEnvironment>;
+  isSubgraphCompatible: string | undefined;
 }

--- a/apps/ensindexer/src/lib/lib-config.ts
+++ b/apps/ensindexer/src/lib/lib-config.ts
@@ -5,6 +5,7 @@ import type { RpcConfigEnvironment } from "@/config/types";
 export const DEFAULT_RPC_RATE_LIMIT = 500;
 export const DEFAULT_ENSADMIN_URL = new URL("https://admin.ensnode.io");
 export const DEFAULT_PORT = 42069;
+export const DEFAULT_SUBGRAPH_COMPAT = false;
 
 /**
  * Extracts dynamic chain configuration from environment variables.

--- a/apps/ensindexer/test/environment-defaults.test.ts
+++ b/apps/ensindexer/test/environment-defaults.test.ts
@@ -1,0 +1,51 @@
+import { applyDefaults } from "@/config/environment-defaults";
+import { DeepPartial } from "@ensnode/ensnode-sdk";
+import { describe, expect, it } from "vitest";
+
+interface ExampleEnvironment {
+  defined: string | undefined;
+  undefined: string | undefined;
+  undefaulted: string | undefined;
+  nested: {
+    defined: string | undefined;
+    undefined: string | undefined;
+    undefaulted: string | undefined;
+  };
+}
+
+const EXAMPLE: ExampleEnvironment = {
+  defined: "defined",
+  undefined: undefined,
+  undefaulted: undefined,
+  nested: {
+    defined: "defined",
+    undefined: undefined,
+    undefaulted: undefined,
+  },
+};
+
+const DEFAULTS: DeepPartial<ExampleEnvironment> = {
+  defined: "defaulted",
+  undefined: "defaulted",
+  nested: {
+    defined: "defaulted",
+    undefined: "defaulted",
+  },
+};
+
+describe("environment-defaults", () => {
+  describe("applyDefaults", () => {
+    it("applies partial defaults, including nested, ignoring undefaulted", () => {
+      expect(applyDefaults(EXAMPLE, DEFAULTS)).toStrictEqual({
+        defined: "defined",
+        undefined: "defaulted",
+        undefaulted: undefined,
+        nested: {
+          defined: "defined",
+          undefined: "defaulted",
+          undefaulted: undefined,
+        },
+      });
+    });
+  });
+});

--- a/apps/ensindexer/test/utils/mockConfig.ts
+++ b/apps/ensindexer/test/utils/mockConfig.ts
@@ -26,6 +26,7 @@ const _defaultMockConfig = buildConfigFromEnvironment({
     },
   },
   globalBlockrange: { startBlock: undefined, endBlock: undefined },
+  isSubgraphCompatible: undefined,
 });
 
 // the current, mutable ENSIndexerConfig for tests

--- a/packages/ensnode-sdk/src/ensindexer/config/types.ts
+++ b/packages/ensnode-sdk/src/ensindexer/config/types.ts
@@ -99,10 +99,7 @@ export interface ENSIndexerPublicConfig {
   indexedChainIds: Set<ChainId>;
 
   /**
-   * A flag derived from the built config indicating whether ENSIndexer is operating in a
-   * subgraph-compatible way. This flag is true if:
-   * a) only the subgraph plugin is activated, and
-   * b) the labelSet is { labelSetId: 'subgraph', labelSetVersion: 0 }.
+   * A feature flag to enable/disable ENSIndexer's Subgraph Compatible Indexing Behavior.
    *
    * If {@link isSubgraphCompatible} is true, indexing behavior will match that of the legacy ENS
    * Subgraph.
@@ -110,6 +107,10 @@ export interface ENSIndexerPublicConfig {
    * ENSIndexer will store and return Literal Labels and Literal Names without further interpretation.
    * @see https://ensnode.io/docs/reference/terminology#literal-label
    * @see https://ensnode.io/docs/reference/terminology#literal-name
+   *
+   * If {@link isSubgraphCompatible} is true, the following invariants are true for the ENSIndexerConfig:
+   * 1. only the 'subgraph' plugin is enabled, and
+   * 2. the labelSet must be { labelSetId: 'subgraph', labelSetVersion: 0 }
    *
    * If {@link isSubgraphCompatible} is false, ENSIndexer will additionally:
    *

--- a/packages/ensnode-sdk/src/ensindexer/config/zod-schemas.ts
+++ b/packages/ensnode-sdk/src/ensindexer/config/zod-schemas.ts
@@ -136,7 +136,7 @@ export const makeDependencyInfoSchema = (valueLabel: string = "Value") =>
     },
   );
 
-// Invariant: isSubgraphCompatible requires Subgraph plugin only, no extra indexing features, and subgraph label set
+// Invariant: If config.isSubgraphCompatible, the config must pass isSubgraphCompatible(config)
 export function invariant_isSubgraphCompatibleRequirements(
   ctx: ZodCheckFnInput<
     Pick<ENSIndexerPublicConfig, "plugins" | "isSubgraphCompatible" | "labelSet">


### PR DESCRIPTION
closes https://github.com/namehash/ensnode/issues/1104

`SUBGRAPH_COMPAT` is now user-configurable, reflected in the internal docs

- [ ] need to do a pass over the terraform
- [ ] need to do a pass over the docs site