### PR TITLE
hotfix: remove indexes on text columns

### DIFF
--- a/packages/ensnode-schema/src/subgraph.schema.ts
+++ b/packages/ensnode-schema/src/subgraph.schema.ts
@@ -84,7 +84,6 @@ export const domain = onchainTable(
     expiryDate: t.bigint(),
   }),
   (t) => ({
-    byId: index().on(t.id),
     byLabelhash: index().on(t.labelhash),
     byParentId: index().on(t.parentId),
     byOwnerId: index().on(t.ownerId),
@@ -143,15 +142,9 @@ export const domainRelations = relations(domain, ({ one, many }) => ({
  * Account
  */
 
-export const account = onchainTable(
-  "accounts",
-  (t) => ({
-    id: t.hex().primaryKey(),
-  }),
-  (t) => ({
-    byId: index().on(t.id),
-  }),
-);
+export const account = onchainTable("accounts", (t) => ({
+  id: t.hex().primaryKey(),
+}));
 
 export const accountRelations = relations(account, ({ many }) => ({
   domains: many(domain),
@@ -200,7 +193,6 @@ export const resolver = onchainTable(
     name: t.text(),
   }),
   (t) => ({
-    byId: index().on(t.id),
     byDomainId: index().on(t.domainId),
   }),
 );
@@ -263,7 +255,6 @@ export const registration = onchainTable(
     labelName: t.text(),
   }),
   (t) => ({
-    byId: index().on(t.id),
     byDomainId: index().on(t.domainId),
     byRegistrationDate: index().on(t.registrationDate),
   }),
@@ -321,7 +312,6 @@ export const wrappedDomain = onchainTable(
     name: t.text(),
   }),
   (t) => ({
-    byId: index().on(t.id),
     byDomainId: index().on(t.domainId),
   }),
 );

--- a/packages/ensnode-schema/src/subgraph.schema.ts
+++ b/packages/ensnode-schema/src/subgraph.schema.ts
@@ -84,11 +84,9 @@ export const domain = onchainTable(
     expiryDate: t.bigint(),
   }),
   (t) => ({
-    byName: index().on(t.name),
-    byLabelName: index().on(t.labelName),
+    byId: index().on(t.id),
     byLabelhash: index().on(t.labelhash),
     byParentId: index().on(t.parentId),
-    bySubdomainCount: index().on(t.subdomainCount),
     byOwnerId: index().on(t.ownerId),
     byRegistrantId: index().on(t.registrantId),
     byWrappedOwnerId: index().on(t.wrappedOwnerId),
@@ -145,9 +143,15 @@ export const domainRelations = relations(domain, ({ one, many }) => ({
  * Account
  */
 
-export const account = onchainTable("accounts", (t) => ({
-  id: t.hex().primaryKey(),
-}));
+export const account = onchainTable(
+  "accounts",
+  (t) => ({
+    id: t.hex().primaryKey(),
+  }),
+  (t) => ({
+    byId: index().on(t.id),
+  }),
+);
 
 export const accountRelations = relations(account, ({ many }) => ({
   domains: many(domain),
@@ -196,7 +200,8 @@ export const resolver = onchainTable(
     name: t.text(),
   }),
   (t) => ({
-    idx: index().on(t.domainId),
+    byId: index().on(t.id),
+    byDomainId: index().on(t.domainId),
   }),
 );
 
@@ -258,7 +263,8 @@ export const registration = onchainTable(
     labelName: t.text(),
   }),
   (t) => ({
-    idx: index().on(t.domainId),
+    byId: index().on(t.id),
+    byDomainId: index().on(t.domainId),
     byRegistrationDate: index().on(t.registrationDate),
   }),
 );
@@ -315,7 +321,8 @@ export const wrappedDomain = onchainTable(
     name: t.text(),
   }),
   (t) => ({
-    idx: index().on(t.domainId),
+    byId: index().on(t.id),
+    byDomainId: index().on(t.domainId),
   }),
 );
 


### PR DESCRIPTION
- `error: index row requires 23456 bytes, maximum size is 8191` likely caused by domain.name and/or labelName 
- renamed `idx` to `byDomainId` to match new pattern
- removed irrelevant index on subdomain count