### PR TITLE
Refactor/referral plugin indepdent

### DIFF
--- a/apps/ensindexer/src/lib/referrals-helpers.ts
+++ b/apps/ensindexer/src/lib/referrals-helpers.ts
@@ -58,9 +58,9 @@ export async function handleRegistrationReferral(
     id: event.id,
 
     // referral data
-    referrerId: referrer,
-    refereeId: referee,
-    domainId: node,
+    referrer,
+    referee,
+    node,
     baseCost,
     premium,
     total,
@@ -105,9 +105,9 @@ export async function handleRenewalReferral(
     id: event.id,
 
     // referral data
-    referrerId: referrer,
-    refereeId: referee,
-    domainId: node,
+    referrer,
+    referee,
+    node,
     cost,
 
     // metadata

--- a/packages/ensnode-schema/src/referrals.schema.ts
+++ b/packages/ensnode-schema/src/referrals.schema.ts
@@ -3,7 +3,6 @@
  */
 
 import { index, onchainTable, relations } from "ponder";
-import { domain, account } from "./subgraph.schema";
 
 /**
  * A RegistrationReferral tracks individual occurences of referrals for ENS name registrations.
@@ -42,16 +41,6 @@ export const ext_registrationReferral_relations = relations(
       fields: [ext_registrationReferral.referrerId],
       references: [ext_referrer.id],
     }),
-    // RegistrationReferral references one Account (as referee)
-    referee: one(account, {
-      fields: [ext_registrationReferral.refereeId],
-      references: [account.id],
-    }),
-    // RegistrationReferral references one Domain
-    domain: one(domain, {
-      fields: [ext_registrationReferral.domainId],
-      references: [domain.id],
-    }),
   }),
 );
 
@@ -88,25 +77,6 @@ export const ext_renewalReferral_relations = relations(ext_renewalReferral, ({ o
     fields: [ext_renewalReferral.referrerId],
     references: [ext_referrer.id],
   }),
-  // RenewalReferral references one Account (as referee)
-  referee: one(account, {
-    fields: [ext_renewalReferral.refereeId],
-    references: [account.id],
-  }),
-  // RenewalReferral references one Domain
-  domain: one(domain, {
-    fields: [ext_renewalReferral.domainId],
-    references: [domain.id],
-  }),
-}));
-
-// add Domain relations
-export const ext_referrals_domain_relations = relations(domain, ({ one, many }) => ({
-  // Domain has many RegistrationReferrals
-  registrationReferrals: many(ext_registrationReferral),
-
-  // Domain has many RenewalReferrals
-  renewalReferrals: many(ext_renewalReferral),
 }));
 
 /**

--- a/packages/ensnode-schema/src/referrals.schema.ts
+++ b/packages/ensnode-schema/src/referrals.schema.ts
@@ -13,9 +13,9 @@ export const ext_registrationReferral = onchainTable(
     // keyed by any arbitrary unique id, usually `event.id`
     id: t.text().primaryKey(),
 
-    referrerId: t.hex().notNull(),
-    domainId: t.text().notNull(),
-    refereeId: t.hex().notNull(),
+    referrer: t.hex().notNull(),
+    node: t.text().notNull(),
+    referee: t.hex().notNull(),
     baseCost: t.bigint().notNull(),
     premium: t.bigint().notNull(),
     total: t.bigint().notNull(),
@@ -28,17 +28,17 @@ export const ext_registrationReferral = onchainTable(
     timestamp: t.bigint().notNull(),
   }),
   (t) => ({
-    byRefereeId: index().on(t.refereeId),
-    byReferrerId: index().on(t.referrerId),
+    byReferee: index().on(t.referee),
+    byReferrer: index().on(t.referrer),
   }),
 );
 
 export const ext_registrationReferral_relations = relations(
   ext_registrationReferral,
   ({ one, many }) => ({
-    // RegistrationReferral references one Referrer
+    // RegistrationReferral belongs to Referrer
     referrer: one(ext_referrer, {
-      fields: [ext_registrationReferral.referrerId],
+      fields: [ext_registrationReferral.referrer],
       references: [ext_referrer.id],
     }),
   }),
@@ -53,9 +53,9 @@ export const ext_renewalReferral = onchainTable(
     // keyed by any arbitrary unique id, usually `event.id`
     id: t.text().primaryKey(),
 
-    referrerId: t.hex().notNull(),
-    refereeId: t.hex().notNull(),
-    domainId: t.text().notNull(),
+    referrer: t.hex().notNull(),
+    referee: t.hex().notNull(),
+    node: t.text().notNull(),
     cost: t.bigint().notNull(),
 
     // chainId the transaction occurred on
@@ -66,22 +66,23 @@ export const ext_renewalReferral = onchainTable(
     timestamp: t.bigint().notNull(),
   }),
   (t) => ({
-    byRefereeId: index().on(t.refereeId),
-    byReferrerId: index().on(t.referrerId),
+    byReferee: index().on(t.referee),
+    byReferrer: index().on(t.referrer),
   }),
 );
 
 export const ext_renewalReferral_relations = relations(ext_renewalReferral, ({ one, many }) => ({
-  // RenewalReferral references one Referrer
+  // RenewalReferral belongs to Referrer
   referrer: one(ext_referrer, {
-    fields: [ext_renewalReferral.referrerId],
+    fields: [ext_renewalReferral.referrer],
     references: [ext_referrer.id],
   }),
 }));
 
 /**
- * Referrer represents an individual referrer, keyed by their onchain address. It holds aggregate
- * statistics about referrals, namely the total value (in wei) they've referred to the ENS protocol.
+ * Referrer represents an individual referrer, keyed by unique `referrer` id (bytes32). It holds
+ * aggregate statistics about referrals, namely the total value (in wei) they've referred to the
+ * ENS protocol.
  */
 export const ext_referrer = onchainTable(
   "ext_referral_totals",


### PR DESCRIPTION
closes https://github.com/namehash/ensnode/issues/1110

tokenscope and protocol-acceleration plugins are already core-schema-independent. for referrals plugin i

1. in first commit, just removed references to core schema
2. in second commit, proposed a cleaner set of column names now that the schema is not tied to the subgraph core schema

i could be convinced that we should keep `referrerId` instead of `referrer` because it's an in-plugin relationship but i like the cleanliness of `referrer` `¯\_(ツ)_/¯`