### PR TITLE
feat(ensindexer): extend dependecy info

### DIFF
--- a/apps/ensadmin/package.json
+++ b/apps/ensadmin/package.json
@@ -22,6 +22,7 @@
     "test": "vitest"
   },
   "dependencies": {
+    "@adraffy/ens-normalize": "catalog:",
     "@anthropic-ai/sdk": "^0.60.0",
     "@ensnode/datasources": "workspace:*",
     "@ensnode/ensnode-react": "workspace:*",

--- a/apps/ensadmin/src/app/mock/config-info/data.json
+++ b/apps/ensadmin/src/app/mock/config-info/data.json
@@ -22,6 +22,9 @@
     "dependencyInfo": {
       "nodejs": "22.18.0",
       "ponder": "0.11.43",
+      "ensDb": "0.35.0",
+      "ensIndexer": "0.35.0",
+      "ensNormalize": "1.11.1",
       "ensRainbow": "0.34.0",
       "ensRainbowSchema": 3
     }
@@ -36,6 +39,9 @@
     "dependencyInfo": {
       "nodejs": "22.18.0",
       "ponder": "0.11.43",
+      "ensDb": "0.35.0",
+      "ensIndexer": "0.35.0",
+      "ensNormalize": "1.11.1",
       "ensRainbow": "0.34.0",
       "ensRainbowSchema": 3
     },
@@ -62,6 +68,9 @@
     "dependencyInfo": {
       "nodejs": "22.18.0",
       "ponder": "0.11.43",
+      "ensDb": "0.35.0",
+      "ensIndexer": "0.35.0",
+      "ensNormalize": "1.11.1",
       "ensRainbow": "0.34.0",
       "ensRainbowSchema": 3
     },
@@ -81,6 +90,9 @@
     "dependencyInfo": {
       "nodejs": "22.18.0",
       "ponder": "0.11.43",
+      "ensDb": "0.35.0",
+      "ensIndexer": "0.35.0",
+      "ensNormalize": "1.11.1",
       "ensRainbow": "0.34.0",
       "ensRainbowSchema": 3
     },
@@ -100,6 +112,9 @@
     "dependencyInfo": {
       "nodejs": "22.18.0",
       "ponder": "0.11.43",
+      "ensDb": "0.35.0",
+      "ensIndexer": "0.35.0",
+      "ensNormalize": "1.11.1",
       "ensRainbow": "0.34.0",
       "ensRainbowSchema": 3
     },
@@ -119,6 +134,9 @@
     "dependencyInfo": {
       "nodejs": "22.18.0",
       "ponder": "0.11.43",
+      "ensDb": "0.35.0",
+      "ensIndexer": "0.35.0",
+      "ensNormalize": "1.11.1",
       "ensRainbow": "0.34.0",
       "ensRainbowSchema": 3
     },

--- a/apps/ensindexer/package.json
+++ b/apps/ensindexer/package.json
@@ -23,6 +23,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@adraffy/ens-normalize": "catalog:",
     "@ensdomains/ensjs": "^4.0.2",
     "@ensnode/datasources": "workspace:*",
     "@ensnode/ensnode-schema": "workspace:*",

--- a/apps/ensindexer/src/lib/dependency-info.ts
+++ b/apps/ensindexer/src/lib/dependency-info.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import packageJson from "@/../package.json";
 import { getENSRainbowApiClient } from "@/lib/ensraibow-api-client";
 import { DependencyInfo } from "@ensnode/ensnode-sdk";
 import { makeDependencyInfoSchema } from "@ensnode/ensnode-sdk/internal";
@@ -67,17 +68,30 @@ export async function getDependencyInfo(): Promise<DependencyInfo> {
   const ensRainbowApiClient = getENSRainbowApiClient();
   const { versionInfo: ensRainbowDependencyInfo } = await ensRainbowApiClient.version();
 
+  // ENSRainbow version (fetched from the actual ENSRainbow service instance)
   // use a fallback for backwards compatibility
   const ensRainbowSchema =
     ensRainbowDependencyInfo.dbSchemaVersion ||
     // @ts-ignore
     ensRainbowDependencyInfo.schema_version;
 
+  // ENSIndexer version
+  const ensIndexerVersion = packageJson.version;
+
+  // ENSDb version
+  //
+  // For now ENSIndexer should always set this version number to be the same as
+  // the version number of ENSIndexer
+  const ensDbVersion = ensIndexerVersion;
+
   const schema = makeDependencyInfoSchema();
   const data = {
     ensRainbow: ensRainbowDependencyInfo.version,
     nodejs: process.versions.node,
     ponder: getPackageVersion("ponder"),
+    ensDb: ensDbVersion,
+    ensIndexer: ensIndexerVersion,
+    ensNormalize: getPackageVersion("@adraffy/ens-normalize"),
     ensRainbowSchema,
   } satisfies DependencyInfo;
 

--- a/apps/ensrainbow/package.json
+++ b/apps/ensrainbow/package.json
@@ -29,6 +29,7 @@
     "get-test-data": "DATA_VERSION=test ./download-rainbow-tables.sh"
   },
   "dependencies": {
+    "@adraffy/ens-normalize": "catalog:",
     "@ensnode/ensrainbow-sdk": "workspace:*",
     "@ensnode/ensnode-sdk": "workspace:*",
     "@hono/node-server": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "pnpm": {
     "overrides": {
+      "@adraffy/ens-normalize": "catalog:",
       "@graphiql/react>@headlessui/react": "2.2.0",
       "@eslint/plugin-kit@<0.3.4": ">=0.3.4",
       "esbuild@<=0.24.2": ">=0.25.0",

--- a/packages/ensnode-sdk/src/client.test.ts
+++ b/packages/ensnode-sdk/src/client.test.ts
@@ -74,6 +74,9 @@ const EXAMPLE_CONFIG_RESPONSE = {
   dependencyInfo: {
     nodejs: "22.18.0",
     ponder: "0.11.43",
+    ensDb: "0.32.0",
+    ensIndexer: "0.32.0",
+    ensNormalize: "1.11.1",
     ensRainbow: "0.31.0",
     ensRainbowSchema: 2,
   },

--- a/packages/ensnode-sdk/src/ensindexer/config/conversions.test.ts
+++ b/packages/ensnode-sdk/src/ensindexer/config/conversions.test.ts
@@ -21,10 +21,13 @@ describe("ENSIndexer: Config", () => {
         namespace: "mainnet",
         plugins: [PluginName.Subgraph],
         dependencyInfo: {
-          ensRainbow: "0.32.0",
-          ensRainbowSchema: 2,
           nodejs: "v22.10.12",
           ponder: "0.11.25",
+          ensDb: "0.32.0",
+          ensIndexer: "0.32.0",
+          ensNormalize: "1.11.1",
+          ensRainbow: "0.32.0",
+          ensRainbowSchema: 2,
         },
       } satisfies ENSIndexerPublicConfig;
 
@@ -62,10 +65,13 @@ describe("ENSIndexer: Config", () => {
       namespace: "mainnet",
       plugins: [PluginName.Subgraph],
       dependencyInfo: {
-        ensRainbow: "0.32.0",
-        ensRainbowSchema: 2,
         nodejs: "v22.10.12",
         ponder: "0.11.25",
+        ensDb: "0.32.0",
+        ensIndexer: "0.32.0",
+        ensNormalize: "1.11.1",
+        ensRainbow: "0.32.0",
+        ensRainbowSchema: 2,
       },
     } satisfies SerializedENSIndexerPublicConfig;
 

--- a/packages/ensnode-sdk/src/ensindexer/config/types.ts
+++ b/packages/ensnode-sdk/src/ensindexer/config/types.ts
@@ -27,11 +27,20 @@ export interface DependencyInfo {
   /** Ponder framework version */
   ponder: string;
 
+  /** ENSDB service version */
+  ensDb: string;
+
+  /** ENSIndexer service version */
+  ensIndexer: string;
+
   /** ENSRainbow service version */
   ensRainbow: string;
 
   /** ENSRainbow schema version */
   ensRainbowSchema: number;
+
+  /** ENS Normalize package version */
+  ensNormalize: string;
 }
 
 /**

--- a/packages/ensnode-sdk/src/ensindexer/config/zod-schemas.test.ts
+++ b/packages/ensnode-sdk/src/ensindexer/config/zod-schemas.test.ts
@@ -103,12 +103,18 @@ describe("ENSIndexer: Config", () => {
           makeDependencyInfoSchema().parse({
             nodejs: "v22.22.22",
             ponder: "0.11.25",
+            ensDb: "0.32.0",
+            ensIndexer: "0.32.0",
+            ensNormalize: "1.11.1",
             ensRainbow: "0.32.0",
             ensRainbowSchema: 2,
           } satisfies DependencyInfo),
         ).toStrictEqual({
           nodejs: "v22.22.22",
           ponder: "0.11.25",
+          ensDb: "0.32.0",
+          ensIndexer: "0.32.0",
+          ensNormalize: "1.11.1",
           ensRainbow: "0.32.0",
           ensRainbowSchema: 2,
         } satisfies DependencyInfo);
@@ -118,6 +124,9 @@ describe("ENSIndexer: Config", () => {
             makeDependencyInfoSchema().safeParse({
               nodejs: "",
               ponder: "",
+              ensDb: "",
+              ensIndexer: "",
+              ensNormalize: "",
               ensRainbow: "",
               ensRainbowSchema: -1,
             } satisfies DependencyInfo),
@@ -126,6 +135,12 @@ describe("ENSIndexer: Config", () => {
   → at nodejs
 ✖ Value must be a non-empty string.
   → at ponder
+✖ Value must be a non-empty string.
+  → at ensDb
+✖ Value must be a non-empty string.
+  → at ensIndexer
+✖ Value must be a non-empty string.
+  → at ensNormalize
 ✖ Value must be a non-empty string.
   → at ensRainbow
 ✖ Value must be a positive integer (>0).
@@ -148,6 +163,9 @@ describe("ENSIndexer: Config", () => {
           dependencyInfo: {
             nodejs: "v22.22.22",
             ponder: "0.11.25",
+            ensDb: "0.32.0",
+            ensIndexer: "0.32.0",
+            ensNormalize: "1.11.1",
             ensRainbow: "0.32.0",
             ensRainbowSchema: 2,
           } satisfies DependencyInfo,

--- a/packages/ensnode-sdk/src/ensindexer/config/zod-schemas.ts
+++ b/packages/ensnode-sdk/src/ensindexer/config/zod-schemas.ts
@@ -123,6 +123,9 @@ export const makeDependencyInfoSchema = (valueLabel: string = "Value") =>
     {
       nodejs: makeNonEmptyStringSchema(),
       ponder: makeNonEmptyStringSchema(),
+      ensDb: makeNonEmptyStringSchema(),
+      ensIndexer: makeNonEmptyStringSchema(),
+      ensNormalize: makeNonEmptyStringSchema(),
       ensRainbow: makeNonEmptyStringSchema(),
       ensRainbowSchema: makePositiveIntegerSchema(),
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ importers:
 
   apps/ensadmin:
     dependencies:
+      '@adraffy/ens-normalize':
+        specifier: 1.11.1
+        version: 1.11.1
       '@anthropic-ai/sdk':
         specifier: ^0.60.0
         version: 0.60.0
@@ -236,9 +239,6 @@ importers:
         specifier: 'catalog:'
         version: 2.23.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
     devDependencies:
-      '@adraffy/ens-normalize':
-        specifier: 1.11.1
-        version: 1.11.1
       '@biomejs/biome':
         specifier: 'catalog:'
         version: 1.9.4
@@ -275,6 +275,9 @@ importers:
 
   apps/ensindexer:
     dependencies:
+      '@adraffy/ens-normalize':
+        specifier: 1.11.1
+        version: 1.11.1
       '@ensdomains/ensjs':
         specifier: ^4.0.2
         version: 4.0.2(typescript@5.7.3)(viem@2.23.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7))(zod@3.25.7)
@@ -366,9 +369,6 @@ importers:
         specifier: 'catalog:'
         version: 3.25.7
     devDependencies:
-      '@adraffy/ens-normalize':
-        specifier: 1.11.1
-        version: 1.11.1
       '@biomejs/biome':
         specifier: 'catalog:'
         version: 1.9.4
@@ -387,6 +387,9 @@ importers:
 
   apps/ensrainbow:
     dependencies:
+      '@adraffy/ens-normalize':
+        specifier: 1.11.1
+        version: 1.11.1
       '@ensnode/ensnode-sdk':
         specifier: workspace:*
         version: link:../../packages/ensnode-sdk
@@ -421,9 +424,6 @@ importers:
         specifier: ^17.7.2
         version: 17.7.2
     devDependencies:
-      '@adraffy/ens-normalize':
-        specifier: 1.11.1
-        version: 1.11.1
       '@ensnode/shared-configs':
         specifier: workspace:*
         version: link:../../packages/shared-configs
@@ -12137,14 +12137,6 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@6.3.5(@types/node@20.17.14)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.17
-    optionalDependencies:
-      vite: 6.3.5(@types/node@20.17.14)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0)
-
   '@vitest/mocker@3.2.4(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -17784,7 +17776,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@20.17.14)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0))
+      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,7 @@ catalogs:
       version: 3.25.7
 
 overrides:
+  '@adraffy/ens-normalize': 1.11.1
   '@graphiql/react>@headlessui/react': 2.2.0
   '@eslint/plugin-kit@<0.3.4': '>=0.3.4'
   esbuild@<=0.24.2: '>=0.25.0'
@@ -235,6 +236,9 @@ importers:
         specifier: 'catalog:'
         version: 2.23.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
     devDependencies:
+      '@adraffy/ens-normalize':
+        specifier: 1.11.1
+        version: 1.11.1
       '@biomejs/biome':
         specifier: 'catalog:'
         version: 1.9.4
@@ -362,6 +366,9 @@ importers:
         specifier: 'catalog:'
         version: 3.25.7
     devDependencies:
+      '@adraffy/ens-normalize':
+        specifier: 1.11.1
+        version: 1.11.1
       '@biomejs/biome':
         specifier: 'catalog:'
         version: 1.9.4
@@ -414,6 +421,9 @@ importers:
         specifier: ^17.7.2
         version: 17.7.2
     devDependencies:
+      '@adraffy/ens-normalize':
+        specifier: 1.11.1
+        version: 1.11.1
       '@ensnode/shared-configs':
         specifier: workspace:*
         version: link:../../packages/shared-configs
@@ -829,14 +839,8 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
-  '@adraffy/ens-normalize@1.10.0':
-    resolution: {integrity: sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q==}
-
-  '@adraffy/ens-normalize@1.10.1':
-    resolution: {integrity: sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==}
-
-  '@adraffy/ens-normalize@1.11.0':
-    resolution: {integrity: sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg==}
+  '@adraffy/ens-normalize@1.11.1':
+    resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -8825,11 +8829,7 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@adraffy/ens-normalize@1.10.0': {}
-
-  '@adraffy/ens-normalize@1.10.1': {}
-
-  '@adraffy/ens-normalize@1.11.0': {}
+  '@adraffy/ens-normalize@1.11.1': {}
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -9533,7 +9533,7 @@ snapshots:
 
   '@ensdomains/ensjs@4.0.2(typescript@5.7.3)(viem@2.23.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7))(zod@3.25.7)':
     dependencies:
-      '@adraffy/ens-normalize': 1.10.1
+      '@adraffy/ens-normalize': 1.11.1
       '@ensdomains/address-encoder': 1.1.1
       '@ensdomains/content-hash': 3.1.0-rc.1
       '@ensdomains/dnsprovejs': 0.5.1
@@ -10336,7 +10336,7 @@ snapshots:
 
   '@namehash/ens-utils@1.19.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)':
     dependencies:
-      '@adraffy/ens-normalize': 1.11.0
+      '@adraffy/ens-normalize': 1.11.1
       date-fns: 3.3.1
       decimal.js: 10.4.3
       viem: 2.21.16(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
@@ -10361,7 +10361,7 @@ snapshots:
 
   '@namehash/namekit-react@0.12.0(bufferutil@4.0.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)':
     dependencies:
-      '@adraffy/ens-normalize': 1.11.0
+      '@adraffy/ens-normalize': 1.11.1
       '@headlessui-float/react': 0.11.4(@headlessui/react@1.7.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@headlessui/react': 1.7.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@namehash/ens-utils': 1.19.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7)
@@ -15822,7 +15822,7 @@ snapshots:
 
   ox@0.6.7(typescript@5.7.3)(zod@3.25.7):
     dependencies:
-      '@adraffy/ens-normalize': 1.11.0
+      '@adraffy/ens-normalize': 1.11.1
       '@noble/curves': 1.8.1
       '@noble/hashes': 1.7.1
       '@scure/bip32': 1.6.2
@@ -17621,7 +17621,7 @@ snapshots:
 
   viem@2.21.16(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.7):
     dependencies:
-      '@adraffy/ens-normalize': 1.10.0
+      '@adraffy/ens-normalize': 1.11.1
       '@noble/curves': 1.4.0
       '@noble/hashes': 1.4.0
       '@scure/bip32': 1.4.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ packages:
   - packages/*
 
 catalog:
+  "@adraffy/ens-normalize": 1.11.1
   "@biomejs/biome": ^1.9.4
   "@ponder/utils": 0.2.13
   "@types/node": ^22.14.0


### PR DESCRIPTION
This PR addresses:

- #1102 by
  - [x] enforcing the same version of `@adraffy/ens-normalize` package being used across all `apps/*` in the monorepo, and including `ensNormalize` version in `/api/config` response.
- #1035 by
  - [x] including  `ensNormalize` version in `/api/config` response.
  - [ ] presenting `ensNormalize` version in ENSAdmin.
-  #1153 by
  - [x] including  `ensDb` version, `ensIndexer` version in `/api/config` response.
  - [ ] ensuring that  `ensRainbow` version is not tied to `ensIndexer` version.