### PR TITLE
fix: subgraph-compat, address invariants, and test to ensure future compat

### DIFF
--- a/apps/ensindexer/src/config/validations.ts
+++ b/apps/ensindexer/src/config/validations.ts
@@ -4,7 +4,12 @@ import { z } from "zod/v4";
 
 import { getENSNamespaceAsFullyDefinedAtCompileTime } from "@/lib/plugin-helpers";
 import { getPlugin } from "@/plugins";
-import { isHttpProtocol, isWebSocketProtocol, uniq } from "@ensnode/ensnode-sdk";
+import {
+  asLowerCaseAddress,
+  isHttpProtocol,
+  isWebSocketProtocol,
+  uniq,
+} from "@ensnode/ensnode-sdk";
 import type { ENSIndexerConfig } from "./types";
 
 // type alias to highlight the input param of Zod's check() method
@@ -131,15 +136,20 @@ export function invariant_validContractConfigs(
   for (const datasourceName of Object.keys(datasources) as DatasourceName[]) {
     const { contracts } = datasources[datasourceName];
 
-    // invariant: `contracts` must provide valid addresses if a filter is not provided
-    const hasAddresses = Object.values(contracts)
-      .filter((contractConfig) => "address" in contractConfig) // only ContractConfigs with `address` defined
-      .every((contractConfig) => isAddress(contractConfig.address as Address)); // must be a valid `Address`
+    // Invariant: `contracts` must provide valid addresses if a filter is not provided
+    for (const [contractName, contractConfig] of Object.entries(contracts)) {
+      if ("address" in contractConfig && typeof contractConfig.address === "string") {
+        // only ContractConfigs with `address` defined
+        const isValidAddress =
+          isAddress(contractConfig.address as Address, { strict: false }) && // must be a valid `Address`
+          contractConfig.address === asLowerCaseAddress(contractConfig.address); // and in lowercase format
 
-    if (!hasAddresses) {
-      throw new Error(
-        `The '${config.namespace}' namespace's '${datasourceName}' Datasource does not define valid addresses. This occurs if the address property of any ContractConfig in the Datasource is malformed (i.e. not a viem#Address). This is only likely to occur if you are actively editing the Datasource and typo'd an address.`,
-      );
+        if (!isValidAddress) {
+          throw new Error(
+            `The '${config.namespace}' namespace's '${datasourceName}' Datasource does not define a valid address for ${contractName}: '${contractConfig.address}'. This occurs if the address property of any ContractConfig in the Datasource is malformed (i.e. not a viem#Address). This is only likely to occur if you are actively editing the Datasource and typo'd an address.`,
+          );
+        }
+      }
     }
   }
 }

--- a/apps/ensindexer/test/config.test.ts
+++ b/apps/ensindexer/test/config.test.ts
@@ -1,7 +1,7 @@
 import { EnvironmentDefaults } from "@/config/environment-defaults";
 import type { RpcConfig } from "@/config/types";
 import { DEFAULT_ENSADMIN_URL, DEFAULT_PORT } from "@/lib/lib-config";
-import { PluginName } from "@ensnode/ensnode-sdk";
+import { ENSNamespaceIds, PluginName, isSubgraphCompatible } from "@ensnode/ensnode-sdk";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const VALID_RPC_URL = "https://eth-mainnet.g.alchemy.com/v2/1234";
@@ -713,6 +713,29 @@ describe("config (minimal base env)", () => {
       });
 
       await expect(getConfig()).resolves.toMatchObject({ plugins: [PluginName.TokenScope] });
+    });
+  });
+
+  describe("SUBGAPH_COMPAT=true", () => {
+    beforeEach(() => {
+      stubEnv({ SUBGRAPH_COMPAT: "true" });
+    });
+
+    it("ens-test-env namespace/labelset is subgraph-compatible", async () => {
+      stubEnv({
+        NAMESPACE: "ens-test-env",
+        LABEL_SET_ID: "ens-test-env",
+        LABEL_SET_VERSION: "0",
+        RPC_URL_15658733: VALID_RPC_URL,
+      });
+      await expect(getConfig()).resolves.toMatchObject({
+        namespace: ENSNamespaceIds.EnsTestEnv,
+        labelSet: {
+          labelSetId: "ens-test-env",
+          labelSetVersion: 0,
+        },
+        isSubgraphCompatible: true,
+      });
     });
   });
 });

--- a/packages/datasources/package.json
+++ b/packages/datasources/package.json
@@ -33,7 +33,8 @@
   "scripts": {
     "prepublish": "tsup",
     "lint": "biome check --write .",
-    "lint:ci": "biome ci"
+    "lint:ci": "biome ci",
+    "test": "vitest"
   },
   "peerDependencies": {
     "viem": "catalog:"
@@ -44,7 +45,8 @@
     "@types/node": "catalog:",
     "tsup": "catalog:",
     "typescript": "catalog:",
-    "viem": "catalog:"
+    "viem": "catalog:",
+    "vitest": "catalog:"
   },
   "dependencies": {
     "@ponder/utils": "catalog:"

--- a/packages/datasources/src/ens-test-env.ts
+++ b/packages/datasources/src/ens-test-env.ts
@@ -42,7 +42,7 @@ export default {
       },
       Registry: {
         abi: root_Registry, // Registry was redeployed, same abi
-        address: "0xb7f8bc63bbcadd18155201308c8f3540b07f84f5e",
+        address: "0xb7f8bc63bbcad18155201308c8f3540b07f84f5e",
         startBlock: 0,
       },
       Resolver: {

--- a/packages/datasources/src/invariants.test.ts
+++ b/packages/datasources/src/invariants.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { Address, isAddress } from "viem";
+import { ContractConfig, ENSNamespaceIds, getENSNamespace } from "./index";
+
+describe("datasource invariants", () => {
+  Object.values(ENSNamespaceIds).forEach((namespace) => {
+    it(`ENSNamespace '${namespace}' should have valid addresses for all contracts`, () => {
+      for (const [datasourceName, datasource] of Object.entries(getENSNamespace(namespace))) {
+        for (const [contractName, contractConfig] of Object.entries(datasource.contracts) as [
+          string,
+          ContractConfig,
+        ][]) {
+          // only ContractConfigs with `address` defined
+          if ("address" in contractConfig && typeof contractConfig.address === "string") {
+            // must be a valid `Address`
+            expect(
+              isAddress(contractConfig.address as Address, { strict: false }),
+              `The ContractConfig '${namespace}' > '${datasourceName}' > '${contractName}' > '${contractConfig.address}' is not a viem#Address. This occurs if the address property of any ContractConfig in the Datasource is malformed (i.e. not a viem#Address).`,
+            ).toBe(true);
+
+            // must be lowercase adddress
+            expect(
+              contractConfig.address === contractConfig.address.toLowerCase(),
+              `The ContractConfig '${namespace}' > '${datasourceName}' > '${contractName}' > '${contractConfig.address}' is not is lowercase format.`,
+            ).toBe(true);
+          }
+        }
+      }
+    });
+  });
+});

--- a/packages/datasources/src/mainnet.ts
+++ b/packages/datasources/src/mainnet.ts
@@ -162,7 +162,7 @@ export default {
        */
       UpgradeableRegistrarController: {
         abi: base_UpgradeableRegistrarController,
-        address: "0xa7d2607c6BD39Ae9521e514026CBB078405Ab322", // a proxy contract
+        address: "0xa7d2607c6bd39ae9521e514026cbb078405ab322", // a proxy contract
         startBlock: 35286620,
       },
 
@@ -175,7 +175,7 @@ export default {
       // NOTE: not indexed, but referenced for Protocol Acceleration
       L2Resolver2: {
         abi: ResolverABI,
-        address: "0x426fA03fB86E510d0Dd9F70335Cf102a98b10875",
+        address: "0x426fa03fb86e510d0dd9f70335cf102a98b10875",
         startBlock: 35286620,
       },
     },

--- a/packages/datasources/src/sepolia.ts
+++ b/packages/datasources/src/sepolia.ts
@@ -155,7 +155,7 @@ export default {
        */
       UpgradeableRegistrarController: {
         abi: base_UpgradeableRegistrarController,
-        address: "0x82c858CDF64b3D893Fe54962680edFDDC37e94C8", // a proxy contract
+        address: "0x82c858cdf64b3d893fe54962680edfddc37e94c8", // a proxy contract
         startBlock: 29896051,
       },
     },

--- a/packages/datasources/vitest.config.ts
+++ b/packages/datasources/vitest.config.ts
@@ -1,0 +1,13 @@
+import { resolve } from "path";
+import { defineProject } from "vitest/config";
+
+export default defineProject({
+  resolve: {
+    alias: {
+      "@": resolve(__dirname, "./src"),
+    },
+  },
+  test: {
+    environment: "node",
+  },
+});

--- a/packages/ensnode-sdk/src/ensindexer/config/helpers.ts
+++ b/packages/ensnode-sdk/src/ensindexer/config/helpers.ts
@@ -1,3 +1,4 @@
+import { ENSNamespaceIds } from "@ensnode/datasources";
 import { type ENSIndexerPublicConfig, PluginName } from "./types";
 
 /**
@@ -7,15 +8,22 @@ import { type ENSIndexerPublicConfig, PluginName } from "./types";
  * @see https://ensnode.io/docs/reference/subgraph-compatibility/
  */
 export function isSubgraphCompatible(
-  config: Pick<ENSIndexerPublicConfig, "plugins" | "labelSet">,
+  config: Pick<ENSIndexerPublicConfig, "namespace" | "plugins" | "labelSet">,
 ): boolean {
   // 1. only the subgraph plugin is active
   const onlySubgraphPluginActivated =
     config.plugins.length === 1 && config.plugins[0] === PluginName.Subgraph;
 
   // 2. label set id must be "subgraph" and version must be 0
-  const labelSetIsSubgraphCompatible =
+  const isSubgraphLabelSet =
     config.labelSet.labelSetId === "subgraph" && config.labelSet.labelSetVersion === 0;
+
+  const isEnsTestEnvLabelSet =
+    config.labelSet.labelSetId === "ens-test-env" && config.labelSet.labelSetVersion === 0;
+
+  // config should be considered subgraph-compatible if in ens-test-env namespace with ens-test-env labelset
+  const labelSetIsSubgraphCompatible =
+    isSubgraphLabelSet || (config.namespace === ENSNamespaceIds.EnsTestEnv && isEnsTestEnvLabelSet);
 
   return onlySubgraphPluginActivated && labelSetIsSubgraphCompatible;
 }

--- a/packages/ensnode-sdk/src/ensindexer/config/zod-schemas.ts
+++ b/packages/ensnode-sdk/src/ensindexer/config/zod-schemas.ts
@@ -134,7 +134,7 @@ export const makeDependencyInfoSchema = (valueLabel: string = "Value") =>
 // Invariant: If config.isSubgraphCompatible, the config must pass isSubgraphCompatible(config)
 export function invariant_isSubgraphCompatibleRequirements(
   ctx: ZodCheckFnInput<
-    Pick<ENSIndexerPublicConfig, "plugins" | "isSubgraphCompatible" | "labelSet">
+    Pick<ENSIndexerPublicConfig, "namespace" | "plugins" | "isSubgraphCompatible" | "labelSet">
   >,
 ) {
   const { value: config } = ctx;


### PR DESCRIPTION
- updated `isSubgraphCompatible` to allow for ens-test-env usage to be subgraph compatible
- added better invariant to test lowercase-ness to the config's addresses
- included that invariant in a test suite for datasources which will throw in the future if it's invalidated