### PR TITLE
feat(apps/ensadmin): migrate to static export

### DIFF
--- a/apps/ensadmin/src/app/layout.tsx
+++ b/apps/ensadmin/src/app/layout.tsx
@@ -17,6 +17,7 @@ const siteName = "ENSAdmin";
 const title = "ENSAdmin";
 const description = "Explore the ENS Protocol like never before";
 
+// Static metadata for static export compatibility
 export const metadata: Metadata = {
   title: title,
   description: description,


### PR DESCRIPTION
Not ready for review - WIP

Closes #1162 

I'm pushing this PR early to test the build on Vercel works the same as before, but now without RSC (Next will still use `?rsc` in params though), in preparation to migrating to Tanstack Router*

ENSAdmin now:
1. **Build**: `pnpm build` creates a static export in the `out` directory
2. **Docker**: nginx serves the static files with SPA routing support
3. **Vercel**: Automatically detects and deploys the static export to their CDN
4. **Local**: `pnpm dev` works as normal

## Todo

- [x] Create issue for adding the AI API to EnsAPI
- [x] Create issue for restoring AI functionality to ENSAdmin
- [ ] Duplicate (until release)/Remove (after release) `ENSADMIN_PUBLIC_URL` to `NEXT_PUBLIC_ENSADMIN_PUBLIC_URL` environment variable on Vercel/Railway.
- [ ] Remove `NEXT_BUILD_OUTPUT_STANDALONE` environment variable from Vercel/Railway/Render.

- [x] Merge https://github.com/namehash/ensnode/pull/1184
- [x] Merge https://github.com/namehash/ensnode/pull/1191
- [x] Merge https://github.com/namehash/ensnode/pull/1190