### PR TITLE
fix(cd): update plugins configuration

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -60,7 +60,7 @@ locals {
       ensnode_indexer_type     = "alpha-sepolia"
       ensnode_environment_name = var.render_environment
       database_schema          = "alphaSepoliaSchema-${var.ensnode_version}"
-      plugins                  = "subgraph,basenames,lineanames,protocol-acceleration,referrals"
+      plugins                  = "subgraph,basenames,lineanames,referrals"
       namespace                = "sepolia"
       render_instance_plan     = "starter"
       subgraph_compat          = false


### PR DESCRIPTION
The `protocol-acceleration` plugin cannot be activated for `sepolia` ENS Namespace.

<details><summary>Error log</summary>

```
10:13:21 AM ERROR build      Error while executing 'ponder.config.ts':
Error: Failed to parse environment configuration: 
✖ Requested plugin 'protocol-acceleration' cannot be activated for the sepolia ENS namespace. protocol-acceleration specifies dependent datasources: [ensroot, basenames, lineanames, threedns-optimism, threedns-base, reverse-resolver-root, reverse-resolver-base, reverse-resolver-linea, reverse-resolver-optimism, reverse-resolver-arbitrum, reverse-resolver-scroll], but available datasources in the sepolia namespace are: [ensroot, basenames, lineanames, reverse-resolver-root, reverse-resolver-base, reverse-resolver-optimism, reverse-resolver-arbitrum, reverse-resolver-scroll, reverse-resolver-linea, seaport].
    at buildConfigFromEnvironment (/app/apps/ensindexer/src/config/config.schema.ts:263:13)
    at /app/apps/ensindexer/src/config/index.ts:4:16
  261 |   } catch (error) {
  262 |     if (error instanceof ZodError) {
> 263 |       throw new Error(
      |             ^
  264 |         "Failed to parse environment configuration: \n" + prettifyError(error) + "\n",
  265 |       );
  266 |     }
10:13:21 AM WARN  process    Failed initial build, starting shutdown sequence
```
</details> 