### PR TITLE
fix: use api image for api instances

### DIFF
--- a/.github/workflows/deploy_ensnode.yml
+++ b/.github/workflows/deploy_ensnode.yml
@@ -167,24 +167,24 @@ jobs:
           }
 
           #ALPHA
-          update_service_image  ${RAILWAY_ENVIRONMENT_ID} ${ALPHA_API_SVC_ID}       ${{ env.ENSAPI_DOCKER_IMAGE }}
-          update_service_image  ${RAILWAY_ENVIRONMENT_ID} ${ALPHA_INDEXER_SVC_ID}   ${{ env.ENSINDEXER_DOCKER_IMAGE }}
+          update_service_image  ${RAILWAY_ENVIRONMENT_ID} ${ALPHA_API_SVC_ID}             ${{ env.ENSAPI_DOCKER_IMAGE }}
+          update_service_image  ${RAILWAY_ENVIRONMENT_ID} ${ALPHA_INDEXER_SVC_ID}         ${{ env.ENSINDEXER_DOCKER_IMAGE }}
           #MAINNET
-          update_service_image  ${RAILWAY_ENVIRONMENT_ID} ${MAINNET_API_SVC_ID}     ${{ env.ENSAPI_DOCKER_IMAGE }}
-          update_service_image  ${RAILWAY_ENVIRONMENT_ID} ${MAINNET_INDEXER_SVC_ID} ${{ env.ENSINDEXER_DOCKER_IMAGE }}
+          update_service_image  ${RAILWAY_ENVIRONMENT_ID} ${MAINNET_API_SVC_ID}           ${{ env.ENSAPI_DOCKER_IMAGE }}
+          update_service_image  ${RAILWAY_ENVIRONMENT_ID} ${MAINNET_INDEXER_SVC_ID}       ${{ env.ENSINDEXER_DOCKER_IMAGE }}
           #ALPHA-SEPOLIA
           update_service_image  ${RAILWAY_ENVIRONMENT_ID} ${ALPHA_SEPOLIA_API_SVC_ID}     ${{ env.ENSAPI_DOCKER_IMAGE }}
           update_service_image  ${RAILWAY_ENVIRONMENT_ID} ${ALPHA_SEPOLIA_INDEXER_SVC_ID} ${{ env.ENSINDEXER_DOCKER_IMAGE }}
           #SEPOLIA
-          update_service_image  ${RAILWAY_ENVIRONMENT_ID} ${SEPOLIA_API_SVC_ID}     ${{ env.ENSAPI_DOCKER_IMAGE }}
-          update_service_image  ${RAILWAY_ENVIRONMENT_ID} ${SEPOLIA_INDEXER_SVC_ID} ${{ env.ENSINDEXER_DOCKER_IMAGE }}
+          update_service_image  ${RAILWAY_ENVIRONMENT_ID} ${SEPOLIA_API_SVC_ID}           ${{ env.ENSAPI_DOCKER_IMAGE }}
+          update_service_image  ${RAILWAY_ENVIRONMENT_ID} ${SEPOLIA_INDEXER_SVC_ID}       ${{ env.ENSINDEXER_DOCKER_IMAGE }}
           #HOLESKY
-          update_service_image  ${RAILWAY_ENVIRONMENT_ID} ${HOLESKY_API_SVC_ID}     ${{ env.ENSAPI_DOCKER_IMAGE }}
-          update_service_image  ${RAILWAY_ENVIRONMENT_ID} ${HOLESKY_INDEXER_SVC_ID} ${{ env.ENSINDEXER_DOCKER_IMAGE }}
+          update_service_image  ${RAILWAY_ENVIRONMENT_ID} ${HOLESKY_API_SVC_ID}           ${{ env.ENSAPI_DOCKER_IMAGE }}
+          update_service_image  ${RAILWAY_ENVIRONMENT_ID} ${HOLESKY_INDEXER_SVC_ID}       ${{ env.ENSINDEXER_DOCKER_IMAGE }}
           #ENSRAINBOW
-          update_service_image  ${RAILWAY_ENVIRONMENT_ID} ${ENSRAINBOW_SVC_ID}      ${{ env.ENSRAINBOW_DOCKER_IMAGE }}
+          update_service_image  ${RAILWAY_ENVIRONMENT_ID} ${ENSRAINBOW_SVC_ID}            ${{ env.ENSRAINBOW_DOCKER_IMAGE }}
           #ENSADMIN
-          update_service_image  ${RAILWAY_ENVIRONMENT_ID} ${ENSADMIN_SVC_ID}        ${{ env.ENSADMIN_DOCKER_IMAGE }}
+          update_service_image  ${RAILWAY_ENVIRONMENT_ID} ${ENSADMIN_SVC_ID}              ${{ env.ENSADMIN_DOCKER_IMAGE }}
 
       # Update DATABASE_SCHEMA for each indexer based on input tag
       - name: Update shared environment variable


### PR DESCRIPTION
This change was likely lost during a merge conflict, so hot fixing it back. 