### PR TITLE
feat(apps/ensadmin): use "connect" inside splash button

### DIFF
--- a/apps/ensadmin/src/app/page.tsx
+++ b/apps/ensadmin/src/app/page.tsx
@@ -21,7 +21,7 @@ export default function SplashPage() {
           </p>
 
           <Button asChild size="lg">
-            <Link href="/connection">View My Connection</Link>
+            <Link href="/connection">Connect</Link>
           </Button>
         </div>
       </div>


### PR DESCRIPTION
I didn't include a changeset since the previous release hasn't gone live with the splash screen (which already has its own changeset).

Closes #1237