### PR TITLE
chore(docs): ENS Referral Program changes

### DIFF
--- a/docs/ensnode.io/src/components/organisms/Footer.tsx
+++ b/docs/ensnode.io/src/components/organisms/Footer.tsx
@@ -22,8 +22,8 @@ const footerProducts = [
     href: "https://ensadmin.io",
   },
   {
-    name: "ENSv2 Referral Programs",
-    href: "https://namehashlabs.org/ens-v2-referral-programs",
+    name: "ENS Referral Program",
+    href: "https://ensawards.org/ens-referral-awards",
   },
   {
     name: "ENSAwards",

--- a/docs/ensrainbow.io/src/components/organisms/Footer.tsx
+++ b/docs/ensrainbow.io/src/components/organisms/Footer.tsx
@@ -23,8 +23,8 @@ const footerProducts = [
     href: "https://admin.ensnode.io",
   },
   {
-    name: "ENSv2 Referral Programs",
-    href: "https://namehashlabs.org/ens-v2-referral-programs",
+    name: "ENS Referral Program",
+    href: "https://ensawards.org/ens-referral-awards",
   },
   {
     name: "ENSAwards",


### PR DESCRIPTION
Changes to the `Footer` components in ensnode.io & ensrainbow.io requested [here](https://docs.google.com/document/d/1gy_Kc_eaR9ihWoPhsrIgzQ9EVVTjBZ0ULpLzoxtUwug/edit?usp=sharing).

They include the change in naming of the footer's related item that now links to `ensawards.org` instead of `namehashlabs.org`

Since it's the UX change (and a small one at that), I've decided not to include the `changeset`