### PR TITLE
ENSAnalytics Changeset Fix

### DIFF
--- a/.changeset/proud-times-leave.md
+++ b/.changeset/proud-times-leave.md
@@ -1,5 +1,5 @@
 ---
-"@ensnode/ensapi": minor
+"ensapi": minor
 "@ensnode/ensnode-sdk": minor
 ---
 


### PR DESCRIPTION
Hotfix of the changeset CI issue. In the `proud-times-leave.md` changeset file, we had `"@ensnode/ensapi"` instead of `"ensapi"`, leading to the package mismatch when being processed.