### PR TITLE
fix(ensapi): swr cache for indexing status

### DIFF
--- a/apps/ensapi/src/middleware/indexing-status.middleware.ts
+++ b/apps/ensapi/src/middleware/indexing-status.middleware.ts
@@ -25,7 +25,9 @@ export const fetcher = staleWhileRevalidate(
       client.indexingStatus().then((response) => {
         // reject response with 'error' responseCode
         if (response.responseCode === IndexingStatusResponseCodes.Error) {
-          throw new Error("Cannot cache Indexing Status response with 'error' responseCode.");
+          throw new Error(
+            "Received Indexing Status response with 'error' responseCode which will not be cached.",
+          );
         }
 
         // resolve response to be cached


### PR DESCRIPTION
Treats Indexing Status response with `responseCode: error` as a rejected response. This way, the SWR cache will only store response object with `responseCode: ok`.

Related to #1200.