### PR TITLE
Add release-npm-rc workflow

### DIFF
--- a/.github/workflows/release-npm-rc.yml
+++ b/.github/workflows/release-npm-rc.yml
@@ -1,0 +1,51 @@
+name: Release NPM RC
+
+on:
+  workflow_dispatch:
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  publish-rc:
+    name: Publish Release Candidate Packages to NPM
+    if: github.repository == 'namehash/ensnode'
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: useblacksmith/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Enter pre-release mode
+        run: pnpm changeset pre enter rc
+
+      - name: Version packages
+        run: pnpm changeset version
+
+      - name: Build packages
+        run: pnpm packages:prepublish
+
+      - name: Publish to NPM with rc tag
+        run: pnpm changeset publish --tag rc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Summary
+        run: |
+          echo "✅ Release candidate packages published to NPM with 'rc' tag"
+          echo ""
+          echo "Install with: pnpm install @ensnode/package-name@rc"
+

--- a/docs/ensnode.io/src/content/docs/docs/contributing/releases.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/contributing/releases.mdx
@@ -28,3 +28,20 @@ The `changesets/bot` will automatically comment on your PR to either remind you 
 ## Upon a New Release
 
 Upon the publishing of a new release, your change will be included in the produced packages/images and your contributions will be referenced in the GitHub Release notes.
+
+## Publishing Release Candidates (RC) of packages to NPM
+
+Publishing release candidates (RCs) of packages to NPM supports apps outside of the ENSNode monorepo to make use of prerelease packages for testing new ENSNode versions before making a full ENSNode release. Package RCs are published to NPM with the `rc` dist-tag:
+
+1. Ensure your changesets are committed to `main`
+2. Navigate to [Actions > Release NPM RC](https://github.com/namehash/ensnode/actions/workflows/npm-release-rc.yml)
+3. Click "Run workflow" and select the `main` branch
+4. RC packages are published to NPM with the `rc` tag (e.g., `1.0.0-rc.0`)
+5. Install RCs with: `npm install @ensnode/package-name@rc`
+
+**Important notes:**
+- NPM Package RC versions are ephemeral - they don't create commits or modify the repository
+- Each workflow run increments the RC version (rc.0, rc.1, rc.2, etc.)
+- Docker images are NOT built for RCs
+- No GitHub releases or tags are created for RCs
+- The `main` branch remains unchanged with regular versions


### PR DESCRIPTION
Goal: Enable us to publish release candidates of packages to NPM so that work on our latest prerelease packages can be done outside of the ENSNode monorepo. Ex: inside ENSAwards.