### PR TITLE
feat(cicd): split ENSNode deploy scripts per platform

### DIFF
--- a/.github/workflows/deploy_ensnode_blue_green.yml
+++ b/.github/workflows/deploy_ensnode_blue_green.yml
@@ -1,4 +1,4 @@
-name: "Deploy: ENSNode to Railway and Render Environments"
+name: "Deploy: ENSNode to Blue/Green Environment on Railway platform"
 
 on:
   workflow_dispatch:
@@ -228,37 +228,6 @@ jobs:
           redeploy_service  ${RAILWAY_ENVIRONMENT_ID} ${ENSRAINBOW_SVC_ID}
           #ENSADMIN
           redeploy_service  ${RAILWAY_ENVIRONMENT_ID} ${ENSADMIN_SVC_ID}
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: 1.6.0
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE}}
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Terraform Init
-        run: terraform init
-        working-directory: terraform
-
-      - name: Terraform workspace
-        run: terraform workspace select ${{env.TF_VAR_render_environment}}
-        working-directory: terraform
-
-      - name: Terraform Validate
-        run: terraform validate
-        working-directory: terraform
-
-      - name: Terraform Plan
-        run: terraform plan -out=tfplan
-        working-directory: terraform
-
-      - name: Terraform Apply
-        run: terraform apply -auto-approve tfplan
-        working-directory: terraform
 
       - uses: ./.github/actions/send_slack_notification
         with:

--- a/.github/workflows/deploy_ensnode_yellow.yml
+++ b/.github/workflows/deploy_ensnode_yellow.yml
@@ -1,0 +1,91 @@
+name: "Deploy: ENSNode to Yellow Environment on Render platform"
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Docker Image Tag (also used for schema name generation)"
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy-environment:
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    env:
+      TARGET_ENVIRONMENT: "yellow"
+      ENSINDEXER_DOCKER_IMAGE: "ghcr.io/namehash/ensnode/ensindexer:${{ inputs.tag }}"
+      ENSAPI_DOCKER_IMAGE: "ghcr.io/namehash/ensnode/ensapi:${{ inputs.tag }}"
+      ENSRAINBOW_DOCKER_IMAGE: "ghcr.io/namehash/ensnode/ensrainbow:${{ inputs.tag }}"
+      ENSADMIN_DOCKER_IMAGE: "ghcr.io/namehash/ensnode/ensadmin:${{ inputs.tag }}"
+      # Terraform related envs
+
+      # AWS_REGION is required for aws-actions/configure-aws-credentials@v4
+      # Terraform keeps it's state inside S3 bucket. This bucket needs to be created before running Terraform apply.
+      # AWS_REGION should be the same as Terraform S3 bucket state region.
+      AWS_REGION: us-east-1
+      TF_VAR_ensnode_version: ${{ inputs.tag }}
+      TF_VAR_ensindexer_label_set_id: ${{ vars.LABEL_SET_ID }}
+      TF_VAR_ensindexer_label_set_version: ${{ vars.LABEL_SET_VERSION }}
+      TF_VAR_ensrainbow_label_set_id: ${{ vars.LABEL_SET_ID }}
+      TF_VAR_ensrainbow_label_set_version: ${{ vars.LABEL_SET_VERSION }}
+      TF_VAR_db_schema_version: ${{ vars.DB_SCHEMA_VERSION }}
+      TF_VAR_anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+      # For now only one Terraform environment is active. In future this will be calculated based on workflow input.
+      TF_VAR_render_environment: "yellow"
+      TF_VAR_render_api_key: ${{ secrets.RENDER_API_KEY }}
+      TF_VAR_render_owner_id: ${{ secrets.RENDER_OWNER_ID }}
+      TF_VAR_alchemy_api_key: ${{ secrets.ALCHEMY_API_KEY }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Check if Docker images exists
+        run: |
+          docker manifest inspect ${{ env.ENSINDEXER_DOCKER_IMAGE }} || { echo "Given docker image does not exist: ${{ env.ENSINDEXER_DOCKER_IMAGE }}"; exit 1; }
+          docker manifest inspect ${{ env.ENSAPI_DOCKER_IMAGE }} || { echo "Given docker image does not exist: ${{ env.ENSAPI_DOCKER_IMAGE }}"; exit 1; }
+          docker manifest inspect ${{ env.ENSRAINBOW_DOCKER_IMAGE }} || { echo "Given docker image does not exist: ${{ env.ENSRAINBOW_DOCKER_IMAGE }}"; exit 1; }
+          docker manifest inspect ${{ env.ENSADMIN_DOCKER_IMAGE }} || { echo "Given docker image does not exist: ${{ env.ENSADMIN_DOCKER_IMAGE }}"; exit 1; }
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.6.0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE}}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Terraform Init
+        run: terraform init
+        working-directory: terraform
+
+      - name: Terraform workspace
+        run: terraform workspace select ${{env.TF_VAR_render_environment}}
+        working-directory: terraform
+
+      - name: Terraform Validate
+        run: terraform validate
+        working-directory: terraform
+
+      - name: Terraform Plan
+        run: terraform plan -out=tfplan
+        working-directory: terraform
+
+      - name: Terraform Apply
+        run: terraform apply -auto-approve tfplan
+        working-directory: terraform
+
+      - uses: ./.github/actions/send_slack_notification
+        with:
+          slack_webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          slack_title: ${{ env.SLACK_TITLE }}
+          slack_message: "✅ Deploy ENSNode completed"


### PR DESCRIPTION
This PR splits CI/CD workflows for deploying ENSNode by the target platform:
- Railway (Blue, Green)
- Render (Yellow)