### PR TITLE
fix: use raw params correctly

### DIFF
--- a/apps/ensapi/src/handlers/resolution-api.ts
+++ b/apps/ensapi/src/handlers/resolution-api.ts
@@ -69,7 +69,7 @@ app.get(
     "query",
     z
       .object({
-        selection: params.selection,
+        ...params.selectionParams.shape,
         trace: params.trace,
         accelerate: params.accelerate,
       })


### PR DESCRIPTION
hotfix for invalid resolution api query param validation schema introduced in #1338 