### PR TITLE
fix(ci): enable skipping comments in PR description checks

### DIFF
--- a/.github/workflows/require_pr_description_checks.yml
+++ b/.github/workflows/require_pr_description_checks.yml
@@ -12,3 +12,4 @@ jobs:
       - uses: mheap/require-checklist-action@v2
         with:
           requireChecklist: false # If this is true and there are no checklists detected, the action will fail
+          skipComments: true # Stop checking comments for checklists. AI Review Agents may add comments that interfere with checklist detection.


### PR DESCRIPTION
# Lite PR

[Tip: Review docs on the ENSNode PR process](https://ensnode.io/docs/contributing/prs)

## Summary

- Added option to skip comment checks for checklists to comments from AI Review Agents do not interfere with the checklist detection.

---

## Why

- PR checklist workflow would fail each time an AI Review Agent would add a comment including unchecked checkboxes.

---

## Testing

- To be tested after merge.

---

## Notes for Reviewer (Optional)

- Anything non-obvious or worth a heads-up.

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)
