### PR TITLE
fix: add correct ensv1 and ensv2 addresses to sepolia-v2 namespace

### DIFF
--- a/packages/datasources/src/sepolia-v2.ts
+++ b/packages/datasources/src/sepolia-v2.ts
@@ -33,8 +33,7 @@ export default {
    * ENS Root contracts deployed on Sepolia for the ENSv1 + ENSv2 test deployment.
    *
    * NOTE: `UniversalRegistrarRenewalWithReferrer` is a placeholder entry required by the typesystem
-   * due to the registrar plugin; it does not exist on Sepolia V2 and therefore uses the zero address
-   * and a `startBlock` of 0.
+   * due to the registrar plugin; it does not exist on Sepolia V2 and therefore uses the zero address.
    */
   [DatasourceNames.ENSRoot]: {
     chain: sepolia,


### PR DESCRIPTION


  ## Summary

  - adds complete `ENSRoot` datasource config for sepolia-v2 (previously inherited from sepolia, which was incorrect)
  - adds `ReverseResolverRoot` datasource with all reverse resolver addresses
  - fixes `ENSv2Root` and `ENSv2ETHRegistry` contract addresses and start blocks to match the temp testing deployment

  ---

  ## Why

  - sepolia-v2 was incorrectly inheriting ensv1 addresses from the standard sepolia deployment
  - the temp ensv2 testing deployment has its own dedicated ensv1 contracts that need to be indexed

  ---

  ## Testing

  - config-only change; addresses verified against deployment records
  - will be validated during indexing of sepolia-v2 namespace

  ---

  ## Notes for Reviewer (Optional)

  - `UniversalRegistrarRenewalWithReferrer` uses `zeroAddress` as a placeholder since this contract doesn't exist in the sepolia-v2 deployment but is required by the `registrars` plugin and refactoring that is out-of-scope

  ---

  ## Checklist

  - [x] This PR does **not** change runtime behavior or semantics
  - [x] This PR is low-risk and safe to review quickly
