### PR TITLE
fix: update ENSv1Registry address in ens-test-env devnet config

### DIFF
--- a/packages/datasources/src/ens-test-env.ts
+++ b/packages/datasources/src/ens-test-env.ts
@@ -48,7 +48,7 @@ export default {
       },
       ENSv1Registry: {
         abi: root_Registry, // Registry was redeployed, same abi
-        address: "0x9a676e781a523b5d0c0e43731313a708cb607508",
+        address: "0x5fc8d32690cc91d4c39d9d3abcbd16989f875707",
         startBlock: 0,
       },
       Resolver: {


### PR DESCRIPTION
## Summary
- Updated ENSv1Registry address from `0x9a676e781a523b5d0c0e43731313a708cb607508` (RootRegistry) to `0x5fc8d32690cc91d4c39d9d3abcbd16989f875707` (LegacyENSRegistry)
- The previous address was incorrectly pointing to the RootRegistry instead of the LegacyENSRegistry

## Test plan
- [ ] Verify devnet indexing works correctly with the updated address

🤖 Generated with [Claude Code](https://claude.com/claude-code)