### PR TITLE
Refactor label.value into label.interpreted

### DIFF
--- a/apps/ensapi/src/graphql-api/lib/find-domains.ts
+++ b/apps/ensapi/src/graphql-api/lib/find-domains.ts
@@ -114,7 +114,7 @@ export function findDomains({ name, owner }: DomainFilter) {
         // TODO: determine if it's necessary to additionally escape user input for LIKE operator
         // Note: if label is NULL (unlabeled domain), LIKE returns NULL and filters out the row.
         // This is intentional - we can't match partial text against unknown labels.
-        partial ? like(schema.label.value, `${partial}%`) : undefined,
+        partial ? like(schema.label.interpreted, `${partial}%`) : undefined,
       ),
     );
 
@@ -134,7 +134,7 @@ export function findDomains({ name, owner }: DomainFilter) {
         // TODO: determine if it's necessary to additionally escape user input for LIKE operator
         // Note: if label is NULL (unlabeled domain), LIKE returns NULL and filters out the row.
         // This is intentional - we can't match partial text against unknown labels.
-        partial ? like(schema.label.value, `${partial}%`) : undefined,
+        partial ? like(schema.label.interpreted, `${partial}%`) : undefined,
       ),
     );
 

--- a/apps/ensapi/src/graphql-api/schema/domain.ts
+++ b/apps/ensapi/src/graphql-api/schema/domain.ts
@@ -97,7 +97,7 @@ DomainInterfaceRef.implement({
       type: "String",
       description: "TODO",
       nullable: false,
-      resolve: async ({ label }) => label.value,
+      resolve: ({ label }) => label.interpreted,
     }),
 
     ///////////////
@@ -127,7 +127,7 @@ DomainInterfaceRef.implement({
             );
           }
 
-          return found.label.value;
+          return found.label.interpreted;
         });
 
         return interpretedLabelsToInterpretedName(labels);

--- a/apps/ensindexer/src/lib/ensv2/label-db-helpers.ts
+++ b/apps/ensindexer/src/lib/ensv2/label-db-helpers.ts
@@ -17,12 +17,12 @@ import { labelByLabelHash } from "@/lib/graphnode-helpers";
  */
 export async function ensureLabel(context: Context, label: LiteralLabel) {
   const labelHash = labelhash(label);
-  const interpretedLabel = literalLabelToInterpretedLabel(label);
+  const interpreted = literalLabelToInterpretedLabel(label);
 
   await context.db
     .insert(schema.label)
-    .values({ labelHash, value: interpretedLabel })
-    .onConflictDoUpdate({ value: interpretedLabel });
+    .values({ labelHash, interpreted })
+    .onConflictDoUpdate({ interpreted });
 }
 
 /**
@@ -41,9 +41,6 @@ export async function ensureUnknownLabel(context: Context, labelHash: LabelHash)
   if (healedLabel) return await ensureLabel(context, healedLabel);
 
   // otherwise upsert label entity
-  const interpretedLabel = encodeLabelHash(labelHash) as InterpretedLabel;
-  await context.db
-    .insert(schema.label)
-    .values({ labelHash, value: interpretedLabel })
-    .onConflictDoNothing();
+  const interpreted = encodeLabelHash(labelHash) as InterpretedLabel;
+  await context.db.insert(schema.label).values({ labelHash, interpreted }).onConflictDoNothing();
 }

--- a/packages/ensnode-schema/src/schemas/ensv2.schema.ts
+++ b/packages/ensnode-schema/src/schemas/ensv2.schema.ts
@@ -482,10 +482,10 @@ export const label = onchainTable(
   "labels",
   (t) => ({
     labelHash: t.hex().primaryKey().$type<LabelHash>(),
-    value: t.text().notNull().$type<InterpretedLabel>(),
+    interpreted: t.text().notNull().$type<InterpretedLabel>(),
   }),
   (t) => ({
-    byValue: index().on(t.value),
+    byInterpreted: index().on(t.interpreted),
   }),
 );
 


### PR DESCRIPTION
closes https://github.com/namehash/ensnode/issues/1591

  ## Summary

  - renamed `Label.value` column to `Label.interpreted` in ensv2 schema
  - updated index name from `byValue` to `byInterpreted`
  - updated all usages across ensindexer and ensapi

  ---

  ## Why

  - `value` was a confusing name; the column stores the interpreted form of a label (either the literal label or an encoded labelhash for unknown labels)
  - `interpreted` is more descriptive and consistent with the `InterpretedLabel` type

  ---

  ## Testing

- no behavior change

  ---

  ## Checklist

  - [x] This PR does **not** change runtime behavior or semantics
  - [x] This PR is low-risk and safe to review quickly
