### PR TITLE
infra(yellow-env): upsize volume attached to ENSDb

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -119,7 +119,7 @@ module "ensdb" {
 
   render_environment_id = render_project.ensnode.environments["default"].id
   render_region         = local.render_region
-  disk_size_gb          = var.ensdb_disk_size_gb
+  disk_size_gb          = 500
 }
 
 module "ensrainbow" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -21,11 +21,6 @@ variable "render_owner_id" {
   type = string
 }
 
-variable "ensdb_disk_size_gb" {
-  type    = number
-  default = 255
-}
-
 # ENSNode Variables
 
 variable "alchemy_api_key" {


### PR DESCRIPTION
# Lite PR

[Tip: Review docs on the ENSNode PR process](https://ensnode.io/docs/contributing/prs)

## Summary

- This update matches ENSDb setup that was applied before in Green env and Blue env.

---

## Why

- After adding new ENSNode instances for v2 Sepolia, the required database size has grown.

---

## Testing

- Testing requires applying infra updates to Yellow env. No side effects are expected.

---

## Notes for Reviewer (Optional)

- The disk size was defined inline as it's easier to track change this way (when compared to tracking change in GitHub Action Secrets).

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)
