### PR TITLE
fix(deps): override axios to >=1.13.5 to patch DoS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
       "tar@<7.5.7": "^7.5.7",
       "lodash@<=4.17.22": "^4.17.23",
       "lodash-es@<=4.17.22": "^4.17.23",
-      "fast-xml-parser@>=4.3.6 <=5.3.3": "^5.3.4"
+      "fast-xml-parser@>=4.3.6 <=5.3.3": "^5.3.4",
+      "axios@<=1.13.4": "^1.13.5"
     },
     "ignoredBuiltDependencies": [
       "bun"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,7 @@ overrides:
   lodash@<=4.17.22: ^4.17.23
   lodash-es@<=4.17.22: ^4.17.23
   fast-xml-parser@>=4.3.6 <=5.3.3: ^5.3.4
+  axios@<=1.13.4: ^1.13.5
 
 patchedDependencies:
   '@changesets/assemble-release-plan@6.0.9':
@@ -4701,8 +4702,8 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
-  axios@1.13.1:
-    resolution: {integrity: sha512-hU4EGxxt+j7TQijx1oYdAjw4xuIp1wRQSsbMFwSthCWeBQur1eF+qJ5iQ5sN3Tw8YRzQNKb8jszgBdMDVqwJcw==}
+  axios@1.13.5:
+    resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -5785,8 +5786,8 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data@4.0.4:
-    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
   fraction.js@4.3.7:
@@ -10553,7 +10554,7 @@ snapshots:
       '@iconify/types': 2.0.0
       '@iconify/utils': 2.3.0
       '@types/tar': 6.1.13
-      axios: 1.13.1
+      axios: 1.13.5
       cheerio: 1.0.0
       domhandler: 5.0.3
       extract-zip: 2.0.1
@@ -13337,10 +13338,10 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  axios@1.13.1:
+  axios@1.13.5:
     dependencies:
       follow-redirects: 1.15.11
-      form-data: 4.0.4
+      form-data: 4.0.5
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
@@ -14400,7 +14401,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data@4.0.4:
+  form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8


### PR DESCRIPTION
Adds pnpm override for axios@<=1.13.4 to resolve GHSA-43fc-jf86-j433 (Denial of Service via __proto__ key in mergeConfig), affecting the transitive path: docs/ensnode.io > astro-icon > @iconify/tools > axios.
