### PR TITLE
feat(ensnode-sdk) waiting helpers

### DIFF
--- a/.changeset/slick-files-rush.md
+++ b/.changeset/slick-files-rush.md
@@ -1,0 +1,5 @@
+---
+"@ensnode/ensnode-sdk": minor
+---
+
+Added waiting helpers that allow halting runtime until certain event happens.

--- a/packages/ensnode-sdk/src/index.ts
+++ b/packages/ensnode-sdk/src/index.ts
@@ -27,5 +27,6 @@ export * from "./shared/serialize";
 export * from "./shared/serialized-types";
 export * from "./shared/types";
 export * from "./shared/url";
+export * from "./shared/wait";
 export * from "./tokenscope";
 export * from "./tracing";

--- a/packages/ensnode-sdk/src/shared/wait.test.ts
+++ b/packages/ensnode-sdk/src/shared/wait.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { wait, waitForCondition } from "./wait";
+
+describe("wait", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("wait()", () => {
+    it("resolves after the specified time", async () => {
+      // arrange
+      let resolved = false;
+      const promise = wait(50).then(() => {
+        resolved = true;
+      });
+
+      // assert - not resolved yet
+      expect(resolved).toBe(false);
+
+      // act - advance time
+      await vi.advanceTimersByTimeAsync(50);
+      await promise;
+
+      // assert - resolved
+      expect(resolved).toBe(true);
+    });
+
+    it("resolves immediately for zero milliseconds", async () => {
+      // arrange
+      let resolved = false;
+      const promise = wait(0).then(() => {
+        resolved = true;
+      });
+
+      // act - flush promises
+      await vi.advanceTimersByTimeAsync(0);
+      await promise;
+
+      // assert - resolved immediately
+      expect(resolved).toBe(true);
+    });
+  });
+
+  describe("waitForCondition()", () => {
+    it("resolves when condition is met on first check", async () => {
+      // arrange
+      let calls = 0;
+      const condition = async () => {
+        calls++;
+        return true;
+      };
+
+      // act
+      const promise = waitForCondition(condition, { intervalMs: 10, timeoutMs: 100 });
+      await vi.advanceTimersByTimeAsync(0);
+      await promise;
+
+      // assert
+      expect(calls).toBe(1);
+    });
+
+    it("resolves when condition becomes true after multiple checks", async () => {
+      // arrange
+      let calls = 0;
+      const condition = async () => {
+        calls++;
+        return calls >= 3;
+      };
+
+      // act
+      const promise = waitForCondition(condition, { intervalMs: 10, timeoutMs: 100 });
+      // Condition checked at time 0, returns false
+      await vi.advanceTimersByTimeAsync(0);
+      // Wait 10ms, condition checked again
+      await vi.advanceTimersByTimeAsync(10);
+      // Wait 10ms, condition checked again
+      await vi.advanceTimersByTimeAsync(10);
+      await promise;
+
+      // assert
+      expect(calls).toBe(3);
+    });
+
+    it("throws error when timeout is reached", async () => {
+      // arrange
+      const condition = async () => false;
+
+      // act & assert
+      const promise = waitForCondition(condition, { intervalMs: 10, timeoutMs: 50 });
+
+      // Attach assertion handler before running timers to avoid unhandled rejection
+      const assertion = expect(promise).rejects.toThrowError("Timeout while waiting for condition");
+
+      // Run all pending timers to trigger the timeout
+      await vi.runAllTimersAsync();
+
+      await assertion;
+    });
+
+    it("ignores errors from condition function and continues retrying", async () => {
+      // arrange
+      let calls = 0;
+      const condition = async () => {
+        calls++;
+        if (calls < 3) {
+          throw new Error("Temporary error");
+        }
+        return true;
+      };
+
+      // act
+      const promise = waitForCondition(condition, { intervalMs: 10, timeoutMs: 100 });
+      await vi.advanceTimersByTimeAsync(0); // First call, throws
+      await vi.advanceTimersByTimeAsync(10); // Second call, throws
+      await vi.advanceTimersByTimeAsync(10); // Third call, returns true
+      await promise;
+
+      // assert
+      expect(calls).toBe(3);
+    });
+
+    it("throws timeout error if condition keeps throwing until timeout", async () => {
+      // arrange
+      const condition = async () => {
+        throw new Error("Always fails");
+      };
+
+      // act & assert
+      const promise = waitForCondition(condition, { intervalMs: 10, timeoutMs: 50 });
+
+      // Attach assertion handler before running timers to avoid unhandled rejection
+      const assertion = expect(promise).rejects.toThrowError("Timeout while waiting for condition");
+
+      // Run all pending timers to trigger the timeout
+      await vi.runAllTimersAsync();
+
+      await assertion;
+    });
+
+    it("uses default options when none provided", async () => {
+      // arrange
+      let calls = 0;
+      const condition = async () => {
+        calls++;
+        return true;
+      };
+
+      // act
+      const promise = waitForCondition(condition);
+      await vi.advanceTimersByTimeAsync(0);
+      await promise;
+
+      // assert
+      expect(calls).toBe(1);
+    });
+
+    it("respects custom intervalMs", async () => {
+      // arrange
+      let calls = 0;
+      const timestamps: number[] = [];
+      const condition = async () => {
+        calls++;
+        timestamps.push(Date.now());
+        return calls >= 3;
+      };
+
+      // act
+      const promise = waitForCondition(condition, { intervalMs: 50, timeoutMs: 500 });
+      await vi.advanceTimersByTimeAsync(0); // First check
+      await vi.advanceTimersByTimeAsync(50); // Second check
+      await vi.advanceTimersByTimeAsync(50); // Third check, condition met
+      await promise;
+
+      // assert
+      expect(calls).toBe(3);
+      // With fake timers, Date.now() advances by the same amount
+      expect(timestamps[1] - timestamps[0]).toBe(50);
+      expect(timestamps[2] - timestamps[1]).toBe(50);
+    });
+  });
+});

--- a/packages/ensnode-sdk/src/shared/wait.ts
+++ b/packages/ensnode-sdk/src/shared/wait.ts
@@ -1,0 +1,67 @@
+import { secondsToMilliseconds } from "date-fns";
+
+/**
+ * Waits for the specified number of milliseconds.
+ *
+ * @param ms The number of milliseconds to wait.
+ * @returns A promise that resolves after the specified delay.
+ */
+export async function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export interface WaitForConditionOptions {
+  /**
+   * Interval in milliseconds between condition checks.
+   */
+  intervalMs?: number;
+
+  /**
+   * Maximum time in milliseconds to wait for the condition before timing out.
+   * If the timeout is reached, the returned promise will be rejected with
+   * an error.
+   */
+  timeoutMs?: number;
+}
+
+const DEFAULT_WAIT_FOR_CONDITION_OPTIONS = {
+  intervalMs: secondsToMilliseconds(1),
+  timeoutMs: secondsToMilliseconds(30),
+} as const satisfies WaitForConditionOptions;
+
+/**
+ * Waits for a specified condition function to return true,
+ * checking at regular intervals until a timeout is reached.
+ *
+ * @param conditionFn The condition function to evaluate.
+ * @param options Optional settings for interval and timeout.
+ * @returns A promise that resolves when the condition is met or rejects on timeout.
+ */
+export async function waitForCondition(
+  conditionFn: () => Promise<boolean>,
+  options?: WaitForConditionOptions,
+): Promise<void> {
+  const {
+    intervalMs = DEFAULT_WAIT_FOR_CONDITION_OPTIONS.intervalMs,
+    timeoutMs = DEFAULT_WAIT_FOR_CONDITION_OPTIONS.timeoutMs,
+  } = options || {};
+
+  const startTime = Date.now();
+
+  while (true) {
+    try {
+      if (await conditionFn()) {
+        // Condition is met, resolve the promise and exit the loop
+        return;
+      }
+    } catch {
+      // Ignore errors from the condition function and continue retrying until timeout
+    }
+
+    if (Date.now() - startTime >= timeoutMs) {
+      throw new Error("Timeout while waiting for condition");
+    }
+
+    await wait(intervalMs);
+  }
+}


### PR DESCRIPTION
# Lite PR

[Tip: Review docs on the ENSNode PR process](https://ensnode.io/docs/contributing/prs)

## Summary

- Added waiting helpers that allow halting runtime until certain event happens.
  - `wait()` that allows waiting a certain amount of time
  - `waitForCondition()` that allows waiting until a certain condition turns `ture`

---

## Why

- ENSDb Writer Worker has a dependency on ENSIndexer API to be available. With the waiting helpers, it's going to be easy to model as:
```ts
await waitForCondition(() =>
  ensIndexerClient.config().then(() => true).catch(() => false)
);
```

---

## Testing

- Static code checks (lint, typecheck) + extended testing suite were all OK.

---

## Notes for Reviewer (Optional)

- Anything non-obvious or worth a heads-up.

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)
