### PR TITLE
fix: throw better error when ensrainbow fails to serve json

### DIFF
--- a/apps/ensindexer/src/lib/version-info.ts
+++ b/apps/ensindexer/src/lib/version-info.ts
@@ -4,11 +4,6 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { prettifyError } from "zod/v4";
-
-import type { ENSIndexerVersionInfo, SerializedENSIndexerVersionInfo } from "@ensnode/ensnode-sdk";
-import { makeENSIndexerVersionInfoSchema } from "@ensnode/ensnode-sdk/internal";
-
 /**
  * Get ENSIndexer version
  */

--- a/packages/ensrainbow-sdk/src/client.test.ts
+++ b/packages/ensrainbow-sdk/src/client.test.ts
@@ -317,40 +317,10 @@ describe("EnsRainbowApiClient", () => {
       expect(response).toEqual(configData);
     });
 
-    it("should throw with server error message when response is not ok", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        statusText: "Internal Server Error",
-        json: () =>
-          Promise.resolve({
-            error: "Database not ready",
-            errorCode: 500,
-          }),
-      });
-
-      await expect(client.config()).rejects.toThrow("Database not ready");
-    });
-
-    it("should throw with fallback message when error body has no error field", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        statusText: "Service Unavailable",
-        json: () => Promise.resolve({}),
-      });
-
-      await expect(client.config()).rejects.toThrow(
-        "Failed to fetch ENSRainbow config: Service Unavailable",
-      );
-    });
-
     it("should throw with fallback message when error body is not valid JSON", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        statusText: "Not Found",
-        json: () => Promise.reject(new SyntaxError("Unexpected token")),
-      });
+      mockFetch.mockResolvedValueOnce({ ok: false, statusText: "Not Found" });
 
-      await expect(client.config()).rejects.toThrow("Failed to fetch ENSRainbow config: Not Found");
+      await expect(client.config()).rejects.toThrow(/Not Found/);
     });
   });
 });

--- a/packages/ensrainbow-sdk/src/client.ts
+++ b/packages/ensrainbow-sdk/src/client.ts
@@ -400,11 +400,7 @@ export class EnsRainbowApiClient implements EnsRainbow.ApiClient {
     const response = await fetch(new URL("/v1/config", this.options.endpointUrl));
 
     if (!response.ok) {
-      const errorMessage = await response
-        .json()
-        .then((data: { error?: string }) => data.error)
-        .catch(() => undefined);
-      throw new Error(errorMessage ?? `Failed to fetch ENSRainbow config: ${response.statusText}`);
+      throw new Error(`Failed to fetch ENSRainbow config: ${response.statusText}`);
     }
 
     return response.json() as Promise<EnsRainbow.ENSRainbowPublicConfig>;


### PR DESCRIPTION
  ## Summary

  - remove testing of error responses for config endpoint, it doesn't return an error response
  - wrap `response.json()` in the error path of `EnsRainbowApiClient.config()` with try-catch so non-JSON error responses (e.g. plain text `404 Not Found`) fall through to the statusText-based fallback message instead of throwing a `SyntaxError`
  - add unit test for the non-JSON error body case

  ---

  ## Why

  - when ENSRainbow returns a non-JSON error response (e.g. plain text `404 Not Found`), `response.json()` throws a `SyntaxError` that propagates unhandled through the ENSIndexer's `/api/config` endpoint, causing the `EnsDbWriterWorker` to crash
   and take down the entire process
  - ran into this in local dev with old ENSRainbow instance

  ---

  ## Testing

  - existing and new unit tests pass (`pnpm test` in `packages/ensrainbow-sdk`, 25 tests)
  - reproduced locally by running `pnpm dev` against a local ENSRainbow that returns `404 Not Found` for `/v1/config`

  ---

  ## Checklist

  - [x] This PR is low-risk and safe to review quickly
