### PR TITLE
WIP ENSDb schema: off-chain

### DIFF
--- a/apps/ensindexer/drizzle.config.ts
+++ b/apps/ensindexer/drizzle.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  dialect: "postgresql",
+  schema: "./drizzle.schema.ts",
+  out: "./drizzle",
+  dbCredentials: {
+    url: "postgresql://dbuser:abcd1234@localhost:54320/ensnode_local_ponder_0_16",
+  },
+});

--- a/apps/ensindexer/drizzle.schema.ts
+++ b/apps/ensindexer/drizzle.schema.ts
@@ -1,0 +1,1 @@
+export * from "@ensnode/ensnode-schema/offchain";

--- a/apps/ensindexer/drizzle/0000_orange_veda.sql
+++ b/apps/ensindexer/drizzle/0000_orange_veda.sql
@@ -1,0 +1,6 @@
+CREATE SCHEMA "offchain";
+--> statement-breakpoint
+CREATE TABLE "offchain"."ensnode_metadata" (
+	"key" text PRIMARY KEY NOT NULL,
+	"value" jsonb NOT NULL
+);

--- a/apps/ensindexer/drizzle/meta/0000_snapshot.json
+++ b/apps/ensindexer/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,46 @@
+{
+  "id": "771c3fcb-f4ef-439b-b931-1a2bf77a117a",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "offchain.ensnode_metadata": {
+      "name": "ensnode_metadata",
+      "schema": "offchain",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "offchain": "offchain"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/ensindexer/drizzle/meta/_journal.json
+++ b/apps/ensindexer/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1772604594657,
+      "tag": "0000_orange_veda",
+      "breakpoints": true
+    }
+  ]
+}

--- a/apps/ensindexer/package.json
+++ b/apps/ensindexer/package.json
@@ -47,6 +47,7 @@
     "@types/dns-packet": "^5.6.5",
     "@types/node": "catalog:",
     "@types/pg": "8.16.0",
+    "drizzle-kit": "0.30.1",
     "typescript": "catalog:",
     "vitest": "catalog:"
   }

--- a/apps/ensindexer/src/lib/ensdb-client/ensdb-client.ts
+++ b/apps/ensindexer/src/lib/ensdb-client/ensdb-client.ts
@@ -1,7 +1,8 @@
 import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+import { migrate } from "drizzle-orm/node-postgres/migrator";
 import { eq, sql } from "drizzle-orm/sql";
 
-import { ensNodeMetadata } from "@ensnode/ensnode-schema";
+import { ensNodeMetadata } from "@ensnode/ensnode-schema/offchain";
 import {
   type CrossChainIndexingStatusSnapshot,
   deserializeCrossChainIndexingStatusSnapshot,
@@ -63,6 +64,10 @@ export class EnsDbClient implements EnsDbClientQuery, EnsDbClientMutation {
       databaseUrl,
       schema,
     });
+  }
+
+  async runMigrations(migrationsFolder: string): Promise<void> {
+    await migrate(this.db, { migrationsFolder });
   }
 
   /**
@@ -176,25 +181,15 @@ export class EnsDbClient implements EnsDbClientQuery, EnsDbClientMutation {
   private async upsertEnsNodeMetadata<
     EnsNodeMetadataType extends SerializedEnsNodeMetadata = SerializedEnsNodeMetadata,
   >(metadata: EnsNodeMetadataType): Promise<void> {
-    await this.db.transaction(async (tx) => {
-      // Ponder live-query triggers insert into live_query_tables.
-      // Because this worker writes outside the Ponder runtime connection pool,
-      // the temp table must be ensured to exist on this connection. Without this,
-      // the upsert would fail with "relation 'live_query_tables' does not exist" error.
-      await tx.execute(
-        sql`CREATE TEMP TABLE IF NOT EXISTS live_query_tables (table_name TEXT PRIMARY KEY)`,
-      );
-
-      await tx
-        .insert(ensNodeMetadata)
-        .values({
-          key: metadata.key,
-          value: metadata.value,
-        })
-        .onConflictDoUpdate({
-          target: ensNodeMetadata.key,
-          set: { value: metadata.value },
-        });
-    });
+    await this.db
+      .insert(ensNodeMetadata)
+      .values({
+        key: metadata.key,
+        value: metadata.value,
+      })
+      .onConflictDoUpdate({
+        target: ensNodeMetadata.key,
+        set: { value: metadata.value },
+      });
   }
 }

--- a/apps/ensindexer/src/lib/ensdb-writer-worker/ensdb-writer-worker.test.ts
+++ b/apps/ensindexer/src/lib/ensdb-writer-worker/ensdb-writer-worker.test.ts
@@ -60,6 +60,7 @@ describe("EnsDbWriterWorker", () => {
 
     const ensDbClient = {
       getEnsIndexerPublicConfig: vi.fn().mockResolvedValue(undefined),
+      runMigrations: vi.fn().mockResolvedValue(undefined),
       upsertEnsDbVersion: vi.fn().mockResolvedValue(undefined),
       upsertEnsIndexerPublicConfig: vi.fn().mockResolvedValue(undefined),
       upsertIndexingStatusSnapshot: vi.fn().mockResolvedValue(undefined),
@@ -79,6 +80,7 @@ describe("EnsDbWriterWorker", () => {
     await worker.run();
 
     // assert - verify initial upserts happened
+    expect(ensDbClient.runMigrations).toHaveBeenCalledTimes(1);
     expect(ensDbClient.upsertEnsDbVersion).toHaveBeenCalledWith(publicConfig.versionInfo.ensDb);
     expect(ensDbClient.upsertEnsIndexerPublicConfig).toHaveBeenCalledWith(publicConfig);
 
@@ -99,6 +101,7 @@ describe("EnsDbWriterWorker", () => {
 
     const ensDbClient = {
       getEnsIndexerPublicConfig: vi.fn().mockResolvedValue(publicConfig),
+      runMigrations: vi.fn().mockResolvedValue(undefined),
       upsertEnsDbVersion: vi.fn().mockResolvedValue(undefined),
       upsertEnsIndexerPublicConfig: vi.fn().mockResolvedValue(undefined),
       upsertIndexingStatusSnapshot: vi.fn().mockResolvedValue(undefined),
@@ -148,6 +151,7 @@ describe("EnsDbWriterWorker", () => {
 
     const ensDbClient = {
       getEnsIndexerPublicConfig: vi.fn().mockResolvedValue(undefined),
+      runMigrations: vi.fn().mockResolvedValue(undefined),
       upsertEnsDbVersion: vi.fn().mockResolvedValue(undefined),
       upsertEnsIndexerPublicConfig: vi.fn().mockResolvedValue(undefined),
       upsertIndexingStatusSnapshot: vi.fn().mockResolvedValue(undefined),
@@ -196,6 +200,7 @@ describe("EnsDbWriterWorker", () => {
 
     const ensDbClient = {
       getEnsIndexerPublicConfig: vi.fn().mockResolvedValue(undefined),
+      runMigrations: vi.fn().mockResolvedValue(undefined),
       upsertEnsDbVersion: vi.fn().mockResolvedValue(undefined),
       upsertEnsIndexerPublicConfig: vi.fn().mockResolvedValue(undefined),
       upsertIndexingStatusSnapshot,
@@ -245,6 +250,7 @@ describe("EnsDbWriterWorker", () => {
 
     const ensDbClient = {
       getEnsIndexerPublicConfig: vi.fn().mockResolvedValue(undefined),
+      runMigrations: vi.fn().mockResolvedValue(undefined),
       upsertEnsDbVersion: vi.fn().mockResolvedValue(undefined),
       upsertEnsIndexerPublicConfig: vi.fn().mockResolvedValue(undefined),
       upsertIndexingStatusSnapshot: vi.fn().mockResolvedValue(undefined),
@@ -283,6 +289,7 @@ describe("EnsDbWriterWorker", () => {
 
     const ensDbClient = {
       getEnsIndexerPublicConfig: vi.fn().mockResolvedValue(storedConfig),
+      runMigrations: vi.fn().mockResolvedValue(undefined),
       upsertEnsDbVersion: vi.fn().mockResolvedValue(undefined),
       upsertEnsIndexerPublicConfig: vi.fn().mockResolvedValue(undefined),
       upsertIndexingStatusSnapshot: vi.fn().mockResolvedValue(undefined),
@@ -315,6 +322,7 @@ describe("EnsDbWriterWorker", () => {
 
     const ensDbClient = {
       getEnsIndexerPublicConfig: vi.fn().mockResolvedValue(undefined),
+      runMigrations: vi.fn().mockResolvedValue(undefined),
       upsertEnsDbVersion: vi.fn().mockResolvedValue(undefined),
       upsertEnsIndexerPublicConfig: vi.fn().mockResolvedValue(undefined),
       upsertIndexingStatusSnapshot: vi.fn().mockResolvedValue(undefined),
@@ -344,6 +352,7 @@ describe("EnsDbWriterWorker", () => {
 
     const ensDbClient = {
       getEnsIndexerPublicConfig: vi.fn().mockRejectedValue(dbError),
+      runMigrations: vi.fn().mockResolvedValue(undefined),
       upsertEnsDbVersion: vi.fn().mockResolvedValue(undefined),
       upsertEnsIndexerPublicConfig: vi.fn().mockResolvedValue(undefined),
       upsertIndexingStatusSnapshot: vi.fn().mockResolvedValue(undefined),
@@ -399,6 +408,7 @@ describe("EnsDbWriterWorker", () => {
 
     const ensDbClient = {
       getEnsIndexerPublicConfig: vi.fn().mockResolvedValue(undefined),
+      runMigrations: vi.fn().mockResolvedValue(undefined),
       upsertEnsDbVersion: vi.fn().mockResolvedValue(undefined),
       upsertEnsIndexerPublicConfig: vi.fn().mockResolvedValue(undefined),
       upsertIndexingStatusSnapshot: vi

--- a/apps/ensindexer/src/lib/ensdb-writer-worker/ensdb-writer-worker.ts
+++ b/apps/ensindexer/src/lib/ensdb-writer-worker/ensdb-writer-worker.ts
@@ -1,3 +1,6 @@
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { getUnixTime, secondsToMilliseconds } from "date-fns";
 import pRetry from "p-retry";
 
@@ -20,6 +23,14 @@ import type { IndexingStatusBuilder } from "@/lib/indexing-status-builder/indexi
  * the Indexing Status Snapshot record into ENSDb.
  */
 const INDEXING_STATUS_RECORD_UPDATE_INTERVAL: Duration = 1;
+
+const defaultMigrationsFolder = fileURLToPath(new URL("../../../drizzle", import.meta.url));
+
+const resolveMigrationsFolder = (): string => {
+  const envValue = process.env.ENSDB_MIGRATIONS_FOLDER;
+  const migrationsFolder = envValue ? resolve(envValue) : defaultMigrationsFolder;
+  return migrationsFolder;
+};
 
 /**
  * ENSDb Writer Worker
@@ -84,6 +95,11 @@ export class EnsDbWriterWorker {
     if (this.isRunning) {
       throw new Error("EnsDbWriterWorker is already running");
     }
+
+    const migrationsFolder = resolveMigrationsFolder();
+    console.log(`[EnsDbWriterWorker]: Running ENSDb migrations from ${migrationsFolder}...`);
+    await this.ensDbClient.runMigrations(migrationsFolder);
+    console.log(`[EnsDbWriterWorker]: ENSDb migrations completed`);
 
     // Fetch data required for task 1 and task 2.
     const inMemoryConfig = await this.getValidatedEnsIndexerPublicConfig();

--- a/packages/ensnode-schema/package.json
+++ b/packages/ensnode-schema/package.json
@@ -16,7 +16,8 @@
     "Ponder"
   ],
   "exports": {
-    ".": "./src/ponder.schema.ts"
+    ".": "./src/ponder.schema.ts",
+    "./offchain": "./src/offchain.schema.ts"
   },
   "files": [
     "dist"
@@ -40,9 +41,13 @@
     "ponder": "catalog:",
     "viem": "catalog:"
   },
+  "peerDependencies": {
+    "drizzle-orm": "catalog:"
+  },
   "devDependencies": {
     "@ensnode/ensnode-sdk": "workspace:",
     "@ensnode/shared-configs": "workspace:*",
+    "drizzle-orm": "catalog:",
     "tsup": "catalog:",
     "typescript": "catalog:"
   }

--- a/packages/ensnode-schema/src/offchain.schema.ts
+++ b/packages/ensnode-schema/src/offchain.schema.ts
@@ -1,0 +1,1 @@
+export * from "./schemas/ensnode-metadata.schema";

--- a/packages/ensnode-schema/src/ponder.schema.ts
+++ b/packages/ensnode-schema/src/ponder.schema.ts
@@ -2,7 +2,6 @@
  * Merge the various sub-schemas into a single ponder (drizzle) schema.
  */
 
-export * from "./schemas/ensnode-metadata.schema";
 export * from "./schemas/ensv2.schema";
 export * from "./schemas/protocol-acceleration.schema";
 export * from "./schemas/registrars.schema";

--- a/packages/ensnode-schema/src/schemas/ensnode-metadata.schema.ts
+++ b/packages/ensnode-schema/src/schemas/ensnode-metadata.schema.ts
@@ -2,7 +2,9 @@
  * Schema Definitions that hold metadata about the ENSNode instance.
  */
 
-import { onchainTable } from "ponder";
+import { pgSchema } from "drizzle-orm/pg-core";
+
+export const offchainSchema = pgSchema("offchain");
 
 /**
  * ENSNode Metadata
@@ -12,7 +14,7 @@ import { onchainTable } from "ponder";
  * - `EnsNodeMetadataEnsIndexerPublicConfig`
  * - `EnsNodeMetadataEnsIndexerIndexingStatus`
  */
-export const ensNodeMetadata = onchainTable("ensnode_metadata", (t) => ({
+export const ensNodeMetadata = offchainSchema.table("ensnode_metadata", (t) => ({
   /**
    * Key
    *

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -521,6 +521,9 @@ importers:
       '@types/pg':
         specifier: 8.16.0
         version: 8.16.0
+      drizzle-kit:
+        specifier: 0.30.1
+        version: 0.30.1
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -876,6 +879,9 @@ importers:
       '@ensnode/shared-configs':
         specifier: workspace:*
         version: link:../shared-configs
+      drizzle-orm:
+        specifier: 'catalog:'
+        version: 0.41.0(@electric-sql/pglite@0.2.13)(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))(@types/pg@8.16.0)(kysely@0.26.3)(pg@8.16.3)
       tsup:
         specifier: 'catalog:'
         version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1617,6 +1623,9 @@ packages:
     resolution: {integrity: sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A==}
     engines: {node: '>=14'}
 
+  '@drizzle-team/brocli@0.10.2':
+    resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
+
   '@electric-sql/pglite@0.2.13':
     resolution: {integrity: sha512-YRY806NnScVqa21/1L1vaysSQ+0/cAva50z7vlwzaGiBOTS9JhdzIRHN0KfgMhobFAphbznZJ7urMso4RtMBIQ==}
 
@@ -1677,6 +1686,14 @@ packages:
   '@envelop/types@5.2.1':
     resolution: {integrity: sha512-CsFmA3u3c2QoLDTfEpGr4t25fjMU31nyvse7IzWTvb0ZycuPjMjb0fjlheh+PbhBYb9YLugnT2uY6Mwcg1o+Zg==}
     engines: {node: '>=18.0.0'}
+
+  '@esbuild-kit/core-utils@3.3.2':
+    resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
+    deprecated: 'Merged into tsx: https://tsx.is'
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
+    deprecated: 'Merged into tsx: https://tsx.is'
 
   '@esbuild/aix-ppc64@0.25.11':
     resolution: {integrity: sha512-Xt1dOL13m8u0WE8iplx9Ibbm+hFAO0GsU2P34UNoDGvZYkY8ifSiy6Zuc1lYxfG7svWE2fzqCUmFp5HCn51gJg==}
@@ -4738,6 +4755,9 @@ packages:
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
@@ -5392,6 +5412,10 @@ packages:
     resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
     engines: {node: '>=10'}
 
+  drizzle-kit@0.30.1:
+    resolution: {integrity: sha512-HmA/NeewvHywhJ2ENXD3KvOuM/+K2dGLJfxVfIHsGwaqKICJnS+Ke2L6UcSrSrtMJLJaT0Im1Qv4TFXfaZShyw==}
+    hasBin: true
+
   drizzle-orm@0.41.0:
     resolution: {integrity: sha512-7A4ZxhHk9gdlXmTdPj/lREtP+3u8KvZ4yEN6MYVxBzZGex5Wtdc+CWSbu7btgF6TB0N+MNPrvW7RKBbxJchs/Q==}
     peerDependencies:
@@ -5564,6 +5588,11 @@ packages:
 
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
+
+  esbuild-register@3.6.0:
+    resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
+    peerDependencies:
+      esbuild: '>=0.25.0'
 
   esbuild@0.25.11:
     resolution: {integrity: sha512-KohQwyzrKTQmhXDW1PjCv3Tyspn9n5GcY2RTDqeORIdIJY8yKIF7sTSopFmn/wpMPW4rdPXI0UE5LJLuq3bx0Q==}
@@ -7766,8 +7795,15 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
   source-map@0.5.6:
     resolution: {integrity: sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==}
+    engines: {node: '>=0.10.0'}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
   source-map@0.7.6:
@@ -9854,6 +9890,8 @@ snapshots:
 
   '@ctrl/tinycolor@4.2.0': {}
 
+  '@drizzle-team/brocli@0.10.2': {}
+
   '@electric-sql/pglite@0.2.13': {}
 
   '@emmetio/abbreviation@2.3.3':
@@ -9948,6 +9986,16 @@ snapshots:
     dependencies:
       '@whatwg-node/promise-helpers': 1.3.2
       tslib: 2.8.1
+
+  '@esbuild-kit/core-utils@3.3.2':
+    dependencies:
+      esbuild: 0.27.2
+      source-map-support: 0.5.21
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    dependencies:
+      '@esbuild-kit/core-utils': 3.3.2
+      get-tsconfig: 4.13.0
 
   '@esbuild/aix-ppc64@0.25.11':
     optional: true
@@ -13350,6 +13398,8 @@ snapshots:
 
   buffer-crc32@0.2.13: {}
 
+  buffer-from@1.1.2: {}
+
   buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
@@ -13995,6 +14045,15 @@ snapshots:
 
   dotenv@8.6.0: {}
 
+  drizzle-kit@0.30.1:
+    dependencies:
+      '@drizzle-team/brocli': 0.10.2
+      '@esbuild-kit/esm-loader': 2.6.5
+      esbuild: 0.27.2
+      esbuild-register: 3.6.0(esbuild@0.27.2)
+    transitivePeerDependencies:
+      - supports-color
+
   drizzle-orm@0.41.0(@electric-sql/pglite@0.2.13)(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))(@types/pg@8.16.0)(kysely@0.26.3)(pg@8.16.3):
     optionalDependencies:
       '@electric-sql/pglite': 0.2.13
@@ -14087,6 +14146,13 @@ snapshots:
       acorn: 8.15.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
+
+  esbuild-register@3.6.0(esbuild@0.27.2):
+    dependencies:
+      debug: 4.4.3
+      esbuild: 0.27.2
+    transitivePeerDependencies:
+      - supports-color
 
   esbuild@0.25.11:
     optionalDependencies:
@@ -17054,7 +17120,14 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  source-map-support@0.5.21:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
   source-map@0.5.6: {}
+
+  source-map@0.6.1: {}
 
   source-map@0.7.6: {}
 


### PR DESCRIPTION
# Lite PR

[Tip: Review docs on the ENSNode PR process](https://ensnode.io/docs/contributing/prs)

## Summary

- Splits ENSNode schemas into "on-chain" (managed by Ponder runtime) and "off-chain" (managed by ENSIndexer runtime).
- For ENSIndexer:
  - Sets up Drizzle migrations directory, config file, schema file.

---

## Why

- We might need to separate ENSDb Writer Worker from Ponder's on-chain tables.

---

## Testing

- I set up migrations with `pnpm -F ensindexer exec drizzle-kit generate --config drizzle.config.ts`
- I set `databaseSchemaName` to `offchain` before passing it as a consturctor param to `EnsDbClient`.
- I ran the ENSIndexer instance locally, all worked fine untill I changed the list of plugins. Then, obviously, the ENSIndexer Public Config stored in ENSDb was not compatible with the in-memory one (due to differences in `plugins` config field).

---

## Notes for Reviewer (Optional)

- This is a demo PR, not intended to be merged as-is.

---

## Pre-Review Checklist (Blocking)

- [ ] This PR does not introduce significant changes and is low-risk to review quickly.
- [ ] Relevant changesets are included (or are not required)
