### PR TITLE
ENSv2: Index ENSv1 Manager and Surface via API

### DIFF
--- a/.changeset/strong-baboons-help.md
+++ b/.changeset/strong-baboons-help.md
@@ -2,4 +2,4 @@
 "ensapi": minor
 ---
 
-ENSNode GraphQL API: `ENSv1Domain.manager` is now available, indicating the owner of the Domain's node within the ENSv1 Registry contract.
+ENSNode GraphQL API: `ENSv1Domain.rootRegistryOwner` is now available, indicating the owner of the Domain's node within the ENSv1 Registry contract.

--- a/apps/ensapi/src/graphql-api/schema/domain.ts
+++ b/apps/ensapi/src/graphql-api/schema/domain.ts
@@ -263,15 +263,15 @@ ENSv1DomainRef.implement({
       resolve: (parent) => parent.parentId,
     }),
 
-    ///////////////////////
-    // ENSv1Domain.manager
-    ///////////////////////
-    manager: t.field({
+    /////////////////////////////////
+    // ENSv1Domain.rootRegistryOwner
+    /////////////////////////////////
+    rootRegistryOwner: t.field({
       description:
-        "The manager of this Domain, i.e. the owner() of this Domain within the ENSv1 Registry.",
+        "The rootRegistryOwner of this Domain, i.e. the owner() of this Domain within the ENSv1 Registry.",
       type: AccountRef,
       nullable: true,
-      resolve: (parent) => parent.managerId,
+      resolve: (parent) => parent.rootRegistryOwnerId,
     }),
   }),
 });

--- a/apps/ensindexer/src/plugins/ensv2/handlers/ensv1/ENSv1Registry.ts
+++ b/apps/ensindexer/src/plugins/ensv2/handlers/ensv1/ENSv1Registry.ts
@@ -79,10 +79,10 @@ export default function () {
       .values({ id: domainId, parentId, labelHash })
       .onConflictDoNothing();
 
-    // update manager
+    // update rootRegistryOwner
     await context.db
       .update(schema.v1Domain, { id: domainId })
-      .set({ managerId: interpretAddress(owner) });
+      .set({ rootRegistryOwnerId: interpretAddress(owner) });
 
     // materialize domain owner
     // NOTE: despite Domain.ownerId being materialized from other sources of truth (i.e. Registrars
@@ -107,10 +107,10 @@ export default function () {
 
     const domainId = makeENSv1DomainId(node);
 
-    // set the domain's manager to `owner`
+    // set the domain's rootRegistryOwner to `owner`
     await context.db
       .update(schema.v1Domain, { id: domainId })
-      .set({ managerId: interpretAddress(owner) });
+      .set({ rootRegistryOwnerId: interpretAddress(owner) });
 
     // materialize domain owner
     // NOTE: despite Domain.ownerId being materialized from other sources of truth (i.e. Registrars

--- a/packages/ensnode-schema/src/schemas/ensv2.schema.ts
+++ b/packages/ensnode-schema/src/schemas/ensv2.schema.ts
@@ -174,8 +174,8 @@ export const v1Domain = onchainTable(
     // represents a labelHash
     labelHash: t.hex().notNull().$type<LabelHash>(),
 
-    // may have a `manager` (ENSv1Registry's owner()), zeroAddress interpreted as null
-    managerId: t.hex().$type<Address>(),
+    // may have a `rootRegistryOwner` (ENSv1Registry's owner()), zeroAddress interpreted as null
+    rootRegistryOwnerId: t.hex().$type<Address>(),
 
     // NOTE: Domain-Resolver Relations tracked via Protocol Acceleration plugin
   }),
@@ -193,9 +193,9 @@ export const relations_v1Domain = relations(v1Domain, ({ one, many }) => ({
     references: [v1Domain.id],
   }),
   children: many(v1Domain, { relationName: "parent" }),
-  manager: one(account, {
-    relationName: "manager",
-    fields: [v1Domain.managerId],
+  rootRegistryOwner: one(account, {
+    relationName: "rootRegistryOwner",
+    fields: [v1Domain.rootRegistryOwnerId],
     references: [account.id],
   }),
 

--- a/packages/ensnode-sdk/src/graphql-api/example-queries.ts
+++ b/packages/ensnode-sdk/src/graphql-api/example-queries.ts
@@ -102,7 +102,7 @@ query DomainByName($name: Name!) {
     name
 
     ... on ENSv1Domain {
-      manager { address }
+      rootRegistryOwner { address }
     }
 
     ... on ENSv2Domain {


### PR DESCRIPTION
closes https://github.com/namehash/ensnode/issues/1731

  ## Reviewer Focus (Read This First)

  - the change to `handleTransfer` in `ENSv1Registry.ts` — previously deleted domains on transfer to zero address, which was not technically correct, since they do still exist

  ---

  ## Problem & Motivation

  - ensv1 domains have a concept of a "rootRegistryOwner" (the `owner()` in the ENSv1 Registry), which was not being tracked as a distinct field
  - the previous `handleTransfer` implementation deleted domains when transferred to zero address, which is incorrect — transferring registry ownership to zero doesn't mean the domain ceases to exist

  ---

  ## What Changed (Concrete)

  1. added `rootRegistryOwnerId` column to `v1Domain` schema (`ensv2.schema.ts`)
  2. added `rootRegistryOwner` drizzle relation on `v1Domain` pointing to `Account`
  3. `handleNewOwner` now sets `rootRegistryOwnerId` after upserting the domain
  4. `handleTransfer` no longer deletes domains on zero-address transfer — instead updates `rootRegistryOwnerId` (with `interpretAddress` to normalize zero to null) and always materializes the effective owner
  5. exposed `rootRegistryOwner` field on `ENSv1DomainRef` in the graphql api (`domain.ts`)
  6. added `rootRegistryOwner` inline fragment to example query in `ensnode-sdk`
  7. removed unused `_owner` / `owner` reassignment pattern in `handleTransfer`

  ---

  ## Design & Planning

  - straightforward addition of a tracked field that was previously implicit in registry events
  - no upfront design doc needed — small, self-contained change

  - Planning artifacts: none
  - Reviewed / approved by: n/a

  ---

  ## Self-Review

  - Bugs caught: n/a
  - Logic simplified: collapsed the delete-or-update branch in `handleTransfer` into a single update + materialize path
  - Naming / terminology improved: n/a
  - Dead or unnecessary code removed: removed the unused `_owner` rename pattern; removed the stub (second commit)

  ---

  ## Cross-Codebase Alignment

  - Search terms used: `rootRegistryOwnerId`, `v1Domain`, `handleTransfer`, `handleNewOwner`
  - Reviewed but unchanged: `materializeENSv1DomainEffectiveOwner` — confirmed it handles null correctly
  - Deferred alignment: n/a

  ---

  ## Downstream & Consumer Impact

  - Public APIs affected: `ENSv1Domain` now exposes a nullable `rootRegistryOwner` field via graphql
  - Docs updated: example query updated in `ensnode-sdk`
  - Naming decisions worth calling out: `rootRegistryOwner` aligns with ENS terminology — the registry `owner()` is the "rootRegistryOwner" of a domain, distinct from the effective owner

  ---

  ## Testing Evidence

  - Testing performed: typecheck, lint
  - Known gaps: no unit tests for the new rootRegistryOwner indexing logic
  - What reviewers have to reason about manually: correctness of no longer deleting domains on zero-address transfer

  ---

  ## Scope Reductions

  - Follow-ups: none identified
  - Why they were deferred: n/a

  ---

  ## Risk Analysis

  - Risk areas: schema migration adds a new nullable column — should be non-breaking. removing domain deletion on zero-address transfer changes indexing behavior.
  - Mitigations or rollback options: revert the PR; re-index
  - Named owner if this causes problems: @shrugs

  ---

  ## Pre-Review Checklist (Blocking)

  - [x] I reviewed every line of this diff and understand it end-to-end
  - [x] I'm prepared to defend this PR line-by-line in review
  - [x] I'm comfortable being the on-call owner for this change
  - [x] Relevant changesets are included (or explicitly not required)