### PR TITLE
add generate openapi script to support all APIs generating OpenAPI specs

### DIFF
--- a/docs/docs.ensnode.io/package.json
+++ b/docs/docs.ensnode.io/package.json
@@ -13,7 +13,7 @@
   "homepage": "https://github.com/namehash/ensnode/tree/main/docs/docs.ensnode.io",
   "scripts": {
     "mint": "pnpm dlx mint@^4.1.0",
-    "generate:openapi": "pnpm --filter ensapi exec tsx --tsconfig tsconfig.json ../../scripts/generate-ensapi-openapi.ts"
+    "generate:openapi": "pnpm --filter ensapi exec tsx --tsconfig tsconfig.json ../../scripts/generate-openapi.ts --out ../../docs/docs.ensnode.io/ensapi-openapi.json"
   },
   "packageManager": "pnpm@10.28.0"
 }

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -1,9 +1,19 @@
 /**
- * Generates a static OpenAPI 3.1 JSON document for ENSApi.
+ * Generates a static OpenAPI 3.1 JSON document for an app.
  *
- * Usage: pnpm generate:openapi
+ * This script is app-agnostic — it imports `generateOpenApi31Document` from
+ * `@/openapi-document`, which resolves to whichever app context the script
+ * is executed in (controlled by `--filter <app>` in the calling script).
  *
- * Output: docs/docs.ensnode.io/ensapi-openapi.json
+ * Usage:
+ *   pnpm --filter <app> exec tsx --tsconfig tsconfig.json \
+ *     ../../scripts/generate-openapi.ts --out <output-path>
+ *
+ * Example:
+ *   pnpm --filter ensapi exec tsx --tsconfig tsconfig.json \
+ *     ../../scripts/generate-openapi.ts --out ../../docs/docs.ensnode.io/ensapi-openapi.json
+ *
+ * The --out path is resolved relative to the app's root directory.
  *
  * This script has no runtime dependencies — it calls generateOpenApi31Document()
  * which uses only stub route handlers and static metadata.
@@ -12,12 +22,23 @@
 import { execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { parseArgs } from "node:util";
 
 import { generateOpenApi31Document } from "@/openapi-document";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const outputPath = resolve(__dirname, "..", "docs", "docs.ensnode.io", "ensapi-openapi.json");
+const { values } = parseArgs({
+  options: {
+    out: { type: "string" },
+  },
+  strict: true,
+});
+
+if (!values.out) {
+  console.error("Error: --out <path> is required.");
+  process.exit(1);
+}
+
+const outputPath = resolve(values.out);
 
 // Generate the document (no additional servers for the static spec)
 const document = generateOpenApi31Document();


### PR DESCRIPTION
# Lite PR

[Tip: Review docs on the ENSNode PR process](https://ensnode.io/docs/contributing/prs)

## Summary

- Supports https://github.com/namehash/ensnode/issues/1601

---

## Why

- The previous `generate-ensapi-openapi.ts` script was hardcoded to ENSApi with a fixed output path. 
- This change makes the script app-agnostic so it can be reused by any app that exposes an `@/openapi-document` module. 
- The output path is now specified via a `--out` CLI flag instead of being baked in.

---

## Testing

- Verified the existing `generate:openapi` npm script in `docs/docs.ensnode.io/package.json` still produces the same `ensapi-openapi.json` output with the updated command.

---

## Notes for Reviewer (Optional)

- The script was renamed from `generate-ensapi-openapi.ts` to `generate-openapi.ts` to reflect its generic.
- The `--out` flag is resolved relative to the app's root directory (i.e. the cwd when executed via `pnpm --filter <app> exec`).
- Tthe script still uses the same `generateOpenApi31Document()` import and prettier formatting.

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [ ] Relevant changesets are included (or are not required)
