### PR TITLE
add missing subgraph schema indexes

### DIFF
--- a/packages/ensnode-schema/src/schemas/subgraph.schema.ts
+++ b/packages/ensnode-schema/src/schemas/subgraph.schema.ts
@@ -98,6 +98,7 @@ export const subgraph_domain = onchainTable(
     byOwnerId: index().on(t.ownerId),
     byRegistrantId: index().on(t.registrantId),
     byWrappedOwnerId: index().on(t.wrappedOwnerId),
+    byResolvedAddressId: index().on(t.resolvedAddressId),
   }),
 );
 
@@ -263,6 +264,7 @@ export const subgraph_registration = onchainTable(
   (t) => ({
     byDomainId: index().on(t.domainId),
     byRegistrationDate: index().on(t.registrationDate),
+    byExpiryDate: index().on(t.expiryDate),
   }),
 );
 


### PR DESCRIPTION
## Summary

- added index on `subgraph_domains.resolved_address_id`
- added index on `subgraph_registrations.expiry_date`

---

## Why

- these columns are queried frequently but were missing indexes, causing slow lookups

---

## Testing

- schema-only change; indexes are created automatically by ponder on deploy

---

## Checklist

- [x] This PR does **not** change runtime behavior or semantics
- [x] This PR is low-risk and safe to review quickly