### PR TITLE
add missing index on domain name column

### DIFF
--- a/packages/ensnode-schema/src/schemas/subgraph.schema.ts
+++ b/packages/ensnode-schema/src/schemas/subgraph.schema.ts
@@ -93,6 +93,7 @@ export const subgraph_domain = onchainTable(
     expiryDate: t.bigint(),
   }),
   (t) => ({
+    byName: index().on(t.name),
     byLabelhash: index().on(t.labelhash),
     byParentId: index().on(t.parentId),
     byOwnerId: index().on(t.ownerId),


### PR DESCRIPTION
## Summary

- added a `byName` index on the `name` column of `subgraph_domains` table

## Why

- queries filtering domains by name (e.g. `where: { name: "foo.eth" }`) were doing full table scans — this column had no index despite being a common filter target

## Testing

- not tested directly; this is a declarative schema index addition that ponder applies on next migration
- verified the schema file typechecks

## Checklist

- [x] This PR does **not** change runtime behavior or semantics
- [x] This PR is low-risk and safe to review quickly

🤖 Generated with [Claude Code](https://claude.com/claude-code)