### PR TITLE
rename topic0 to selector in schema and API

### DIFF
--- a/.changeset/shy-wolves-judge.md
+++ b/.changeset/shy-wolves-judge.md
@@ -2,4 +2,4 @@
 "ensapi": minor
 ---
 
-ENSNode GraphQL API: Add `where` filters to all `*.events` connections (`Domain.events`, `Resolver.events`, `Permissions.events`, `Account.events`). Supports filtering by `topic0_in`, `timestamp_gte`, `timestamp_lte`, and `from` (where applicable). Also adds `Account.events` field to find events by transaction sender.
+ENSNode GraphQL API: Add `where` filters to all `*.events` connections (`Domain.events`, `Resolver.events`, `Permissions.events`, `Account.events`). Supports filtering by `selector_in`, `timestamp_gte`, `timestamp_lte`, and `from` (where applicable). Also adds `Account.events` field to find events by transaction sender.

--- a/apps/ensapi/src/graphql-api/lib/find-events/find-events-resolver.ts
+++ b/apps/ensapi/src/graphql-api/lib/find-events/find-events-resolver.ts
@@ -21,8 +21,8 @@ type EventJoinTable =
  * Available filter options for find-events queries.
  */
 interface EventsWhere {
-  /** Filter to events whose first topic matches any of the provided values. */
-  topic0_in?: Hex[] | null;
+  /** Filter to events whose selector (event signature) matches any of the provided values. */
+  selector_in?: Hex[] | null;
   /** Filter to events at or after this timestamp. */
   timestamp_gte?: bigint | null;
   /** Filter to events at or before this timestamp. */
@@ -38,9 +38,9 @@ function eventsWhereConditions(where?: EventsWhere | null): SQL | undefined {
   if (!where) return undefined;
 
   return and(
-    where.topic0_in
-      ? where.topic0_in.length
-        ? inArray(schema.event.topic0, where.topic0_in)
+    where.selector_in
+      ? where.selector_in.length
+        ? inArray(schema.event.selector, where.selector_in)
         : sql`false`
       : undefined,
     typeof where.timestamp_gte === "bigint"

--- a/apps/ensapi/src/graphql-api/schema/event.ts
+++ b/apps/ensapi/src/graphql-api/schema/event.ts
@@ -165,9 +165,10 @@ EventRef.implement({
 export const EventsWhereInput = builder.inputType("EventsWhereInput", {
   description: "Filter conditions for an events connection.",
   fields: (t) => ({
-    topic0_in: t.field({
+    selector_in: t.field({
       type: ["Hex"],
-      description: "Filter to events whose topic0 (event signature) is one of the provided values.",
+      description:
+        "Filter to events whose selector (event signature) is one of the provided values.",
     }),
     timestamp_gte: t.field({
       type: "BigInt",
@@ -190,9 +191,10 @@ export const EventsWhereInput = builder.inputType("EventsWhereInput", {
 export const AccountEventsWhereInput = builder.inputType("AccountEventsWhereInput", {
   description: "Filter conditions for Account.events (where `from` is implied by the Account).",
   fields: (t) => ({
-    topic0_in: t.field({
+    selector_in: t.field({
       type: ["Hex"],
-      description: "Filter to events whose topic0 (event signature) is one of the provided values.",
+      description:
+        "Filter to events whose selector (event signature) is one of the provided values.",
     }),
     timestamp_gte: t.field({
       type: "BigInt",

--- a/apps/ensindexer/src/lib/ensv2/event-db-helpers.ts
+++ b/apps/ensindexer/src/lib/ensv2/event-db-helpers.ts
@@ -57,7 +57,7 @@ export async function ensureEvent(context: Context, event: LogEventBase) {
       // log
       address: event.log.address,
       logIndex: event.log.logIndex,
-      topic0: topics[0],
+      selector: topics[0],
       topics,
       data: event.log.data,
     })

--- a/packages/ensnode-schema/src/schemas/ensv2.schema.ts
+++ b/packages/ensnode-schema/src/schemas/ensv2.schema.ts
@@ -117,12 +117,12 @@ export const event = onchainTable(
     // log
     address: t.hex().notNull().$type<Address>(),
     logIndex: t.integer().notNull().$type<number>(),
-    topic0: t.hex().notNull().$type<Hash>(),
+    selector: t.hex().notNull().$type<Hash>(),
     topics: t.hex().array().notNull().$type<[Hash, ...Hash[]]>(),
     data: t.hex().notNull(),
   }),
   (t) => ({
-    byTopic0: index().on(t.topic0),
+    bySelector: index().on(t.selector),
     byFrom: index().on(t.from),
     byTimestamp: index().on(t.timestamp),
   }),


### PR DESCRIPTION
## Summary

- renamed `topic0` column to `selector` in the ensv2 event schema (including DB index `byTopic0` → `bySelector`)
- renamed `topic0_in` filter to `selector_in` in all GraphQL `EventsWhereInput` / `AccountEventsWhereInput` types and the underlying resolver logic
- updated changeset description to reflect the new name

## Why

- `selector` more accurately describes what topic0 represents (the event signature / selector), aligning the API terminology with its semantic meaning

## Testing

- `pnpm typecheck` — all packages pass
- `pnpm lint` — clean
- no runtime behavior change; purely a naming refactor across 5 files

## Checklist

- [x] This PR does **not** change runtime behavior or semantics
- [x] This PR is low-risk and safe to review quickly

Closes #1759

🤖 Generated with [Claude Code](https://claude.com/claude-code)