### PR TITLE
fix(deps): resolve devalue prototype pollution vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
       "minimatch@<10.2.3": ">=10.2.3",
       "rollup@>=4.0.0 <4.59.0": ">=4.59.0",
       "svgo@>=3.0.0 <3.3.3": "^3.3.3",
-      "ponder>@hono/node-server@<1.19.10": "^1.19.10"
+      "ponder>@hono/node-server@<1.19.10": "^1.19.10",
+      "devalue@<5.6.4": "^5.6.4"
     },
     "ignoredBuiltDependencies": [
       "bun"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,7 @@ overrides:
   rollup@>=4.0.0 <4.59.0: '>=4.59.0'
   svgo@>=3.0.0 <3.3.3: ^3.3.3
   ponder>@hono/node-server@<1.19.10: ^1.19.10
+  devalue@<5.6.4: ^5.6.4
 
 patchedDependencies:
   '@changesets/assemble-release-plan@6.0.9':
@@ -5488,8 +5489,8 @@ packages:
     resolution: {integrity: sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==}
     engines: {node: '>=18'}
 
-  devalue@5.6.3:
-    resolution: {integrity: sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg==}
+  devalue@5.6.4:
+    resolution: {integrity: sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -13534,7 +13535,7 @@ snapshots:
       cssesc: 3.0.0
       debug: 4.4.3
       deterministic-object-hash: 2.0.2
-      devalue: 5.6.3
+      devalue: 5.6.4
       diff: 5.2.2
       dlv: 1.1.3
       dset: 3.1.4
@@ -14406,7 +14407,7 @@ snapshots:
     dependencies:
       base-64: 1.0.0
 
-  devalue@5.6.3: {}
+  devalue@5.6.4: {}
 
   devlop@1.1.0:
     dependencies:


### PR DESCRIPTION
## Summary
- adds `pnpm.overrides` entry for `devalue@<5.6.4` → `^5.6.4` to fix [GHSA-cfw5-2vxh-hr84](https://github.com/advisories/GHSA-cfw5-2vxh-hr84) (prototype pollution in `devalue.parse` and `devalue.unflatten`)
- transitive dependency via `astro` → `devalue`; astro's range (`^5.6.2`) allows the fix but the lockfile pinned an older version

## Test plan
- [x] `pnpm audit --audit-level=moderate` returns no vulnerabilities
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)