### PR TITLE
Narrative Overhaul: reserve top-level package names

### DIFF
--- a/packages/enscli/README.md
+++ b/packages/enscli/README.md
@@ -1,0 +1,5 @@
+# enscli
+
+This package name is reserved for the [ENSNode](https://ensnode.io) project by [NameHash Labs](https://namehashlabs.org).
+
+For more information, visit [ensnode.io](https://ensnode.io).

--- a/packages/enscli/package.json
+++ b/packages/enscli/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "enscli",
+  "version": "0.0.1",
+  "description": "Reserved for the ENSNode project by NameHash Labs. See https://ensnode.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/namehash/ensnode.git",
+    "directory": "packages/enscli"
+  },
+  "license": "MIT",
+  "homepage": "https://ensnode.io"
+}

--- a/packages/enskit/README.md
+++ b/packages/enskit/README.md
@@ -1,0 +1,5 @@
+# enskit
+
+This package name is reserved for the [ENSNode](https://ensnode.io) project by [NameHash Labs](https://namehashlabs.org).
+
+For more information, visit [ensnode.io](https://ensnode.io).

--- a/packages/enskit/package.json
+++ b/packages/enskit/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "enskit",
+  "version": "0.0.1",
+  "description": "Reserved for the ENSNode project by NameHash Labs. See https://ensnode.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/namehash/ensnode.git",
+    "directory": "packages/enskit"
+  },
+  "license": "MIT",
+  "homepage": "https://ensnode.io"
+}

--- a/packages/enssdk/README.md
+++ b/packages/enssdk/README.md
@@ -1,0 +1,5 @@
+# enssdk
+
+This package name is reserved for the [ENSNode](https://ensnode.io) project by [NameHash Labs](https://namehashlabs.org).
+
+For more information, visit [ensnode.io](https://ensnode.io).

--- a/packages/enssdk/package.json
+++ b/packages/enssdk/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "enssdk",
+  "version": "0.0.1",
+  "description": "Reserved for the ENSNode project by NameHash Labs. See https://ensnode.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/namehash/ensnode.git",
+    "directory": "packages/enssdk"
+  },
+  "license": "MIT",
+  "homepage": "https://ensnode.io"
+}

--- a/packages/ensskills/README.md
+++ b/packages/ensskills/README.md
@@ -1,0 +1,5 @@
+# ensskills
+
+This package name is reserved for the [ENSNode](https://ensnode.io) project by [NameHash Labs](https://namehashlabs.org).
+
+For more information, visit [ensnode.io](https://ensnode.io).

--- a/packages/ensskills/package.json
+++ b/packages/ensskills/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "ensskills",
+  "version": "0.0.1",
+  "description": "Reserved for the ENSNode project by NameHash Labs. See https://ensnode.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/namehash/ensnode.git",
+    "directory": "packages/ensskills"
+  },
+  "license": "MIT",
+  "homepage": "https://ensnode.io"
+}


### PR DESCRIPTION
- these stub packages have been published
  - `enssdk`
  - `enskit`
  - `ensskills`
- this package is pending exception because it was too similar to the existing `ens-cli`
  - `enscli`

The PR creates the stubbed packages and can be merged once `enscli` ownership is granted. 

currently owned by `shrugs-namehash`, but access to the packages has been granted to `@ensnode` so our CI should continue to publish these successfully.

In the near future, these can be built upon into actual packages and then published normally. 