### PR TITLE
WIP Set max character count for `byName` index in `subgraph_domains` table

### DIFF
--- a/.changeset/funky-mails-roll.md
+++ b/.changeset/funky-mails-roll.md
@@ -1,0 +1,5 @@
+---
+"@ensnode/ensdb-sdk": patch
+---
+
+Updated the max character count (length constraint) for the `byName` partial index defined on the `subgraph_domains` table in the "abstract" ENSIndexer Schema.

--- a/packages/ensdb-sdk/src/ensindexer-abstract/subgraph.schema.ts
+++ b/packages/ensdb-sdk/src/ensindexer-abstract/subgraph.schema.ts
@@ -11,24 +11,6 @@ import { monkeypatchCollate } from "../lib/collate";
  */
 
 /**
- * Maximum character count for the `subgraph_domain.name` partial index.
- *
- * PostgreSQL B-tree indexes have a maximum size of 8,191 bytes (8KB) per entry.
- * Without a limit, index creation fails for entries exceeding this size.
- * For example, spam domain records with thousands of characters in `name` column
- * cause index creation to fail.
- *
- * UTF-8 uses 1-4 bytes per character. For the safe maximum of 4 bytes:
- * 8,191 ÷ 4 = ~2,000 characters would be the upper bound.
- *
- * We use 255, which is sufficient for virtually all ENS names in practice.
- * This is implemented as a partial index with WHERE length(name) <= 255,
- * which excludes oversized spam entries while still allowing normal lookups
- * (e.g. where: { name: "foo.eth" }) to use the index.
- */
-const BY_NAME_INDEX_MAX_CHARS = 255;
-
-/**
  * Domain
  */
 
@@ -111,7 +93,23 @@ export const subgraph_domain = onchainTable(
     expiryDate: t.bigint(),
   }),
   (t) => ({
-    byName: index().on(t.name).where(sql`length(${t.name}) <= ${BY_NAME_INDEX_MAX_CHARS}`),
+    /**
+     * Maximum character length for the `subgraph_domain.name` partial index.
+     *
+     * PostgreSQL B-tree indexes have a maximum size of 8,191 bytes (8KB) per entry.
+     * Without a limit, index creation fails for entries exceeding this size.
+     * For example, spam domain records with thousands of characters in `name` column
+     * cause index creation to fail.
+     *
+     * UTF-8 uses 1-4 bytes per character. For the safe maximum of 4 bytes:
+     * 8,191 ÷ 4 = ~2,000 characters would be the upper bound.
+     *
+     * We use 255, which is sufficient for virtually all ENS names in practice.
+     * This is implemented as a partial index with WHERE length(name) <= 255,
+     * which excludes oversized spam entries while still allowing normal lookups
+     * (e.g. where: { name: "foo.eth" }) to use the index.
+     */
+    byName: index().on(t.name).where(sql`length(${t.name}) <= 255`),
     byLabelhash: index().on(t.labelhash),
     byParentId: index().on(t.parentId),
     byOwnerId: index().on(t.ownerId),

--- a/packages/ensdb-sdk/src/ensindexer-abstract/subgraph.schema.ts
+++ b/packages/ensdb-sdk/src/ensindexer-abstract/subgraph.schema.ts
@@ -11,7 +11,7 @@ import { monkeypatchCollate } from "../lib/collate";
  */
 
 /**
- * Maximum character count for the `subgraph_domain.name` index.
+ * Maximum character count for the `subgraph_domain.name` partial index.
  *
  * PostgreSQL B-tree indexes have a maximum size of 8,191 bytes (8KB) per entry.
  * Without a limit, index creation fails for entries exceeding this size.
@@ -22,9 +22,9 @@ import { monkeypatchCollate } from "../lib/collate";
  * 8,191 ÷ 4 = ~2,000 characters would be the upper bound.
  *
  * We use 255, which is sufficient for virtually all ENS names in practice.
- * This handles known spam entries (~6,800 chars)
- * by indexing only their first 255 characters, which is acceptable since
- * these represent abusive data not meaningful to index fully.
+ * This is implemented as a partial index with WHERE length(name) <= 255,
+ * which excludes oversized spam entries while still allowing normal lookups
+ * (e.g. where: { name: "foo.eth" }) to use the index.
  */
 const BY_NAME_INDEX_MAX_CHARS = 255;
 
@@ -111,7 +111,7 @@ export const subgraph_domain = onchainTable(
     expiryDate: t.bigint(),
   }),
   (t) => ({
-    byName: index().on(sql`left(${t.name}, ${BY_NAME_INDEX_MAX_CHARS})`),
+    byName: index().on(t.name).where(sql`length(${t.name}) <= ${BY_NAME_INDEX_MAX_CHARS}`),
     byLabelhash: index().on(t.labelhash),
     byParentId: index().on(t.parentId),
     byOwnerId: index().on(t.ownerId),

--- a/packages/ensdb-sdk/src/ensindexer-abstract/subgraph.schema.ts
+++ b/packages/ensdb-sdk/src/ensindexer-abstract/subgraph.schema.ts
@@ -1,4 +1,4 @@
-import { index, onchainTable, relations } from "ponder";
+import { index, onchainTable, relations, sql } from "ponder";
 import type { Address } from "viem";
 
 import { monkeypatchCollate } from "../lib/collate";
@@ -9,6 +9,24 @@ import { monkeypatchCollate } from "../lib/collate";
  * When the subgraph_prefix is stripped and the resulting schema is paired with @ensnode/ponder-subgraph,
  * the resulting GraphQL API is fully compatible with the legacy ENS Subgraph.
  */
+
+/**
+ * Maximum character count for the `subgraph_domain.name` index.
+ *
+ * PostgreSQL B-tree indexes have a maximum size of 8,191 bytes (8KB) per entry.
+ * Without a limit, index creation fails for entries exceeding this size.
+ * For example, spam domain records with thousands of characters in `name` column
+ * cause index creation to fail.
+ *
+ * UTF-8 uses 1-4 bytes per character. For the safe maximum of 4 bytes:
+ * 8,191 ÷ 4 = ~2,000 characters would be the upper bound.
+ *
+ * We use 255, which is sufficient for virtually all ENS names in practice.
+ * This handles known spam entries (~6,800 chars)
+ * by indexing only their first 255 characters, which is acceptable since
+ * these represent abusive data not meaningful to index fully.
+ */
+const BY_NAME_INDEX_MAX_CHARS = 255;
 
 /**
  * Domain
@@ -93,7 +111,7 @@ export const subgraph_domain = onchainTable(
     expiryDate: t.bigint(),
   }),
   (t) => ({
-    byName: index().on(t.name),
+    byName: index().on(sql`left(${t.name}, ${BY_NAME_INDEX_MAX_CHARS})`),
     byLabelhash: index().on(t.labelhash),
     byParentId: index().on(t.parentId),
     byOwnerId: index().on(t.ownerId),


### PR DESCRIPTION
# Lite PR

[Tip: Review docs on the ENSNode PR process](https://ensnode.io/docs/contributing/prs)

## Summary

- `byName` index will have a character limit set to `255` charaters

---

## Why

- For ENSIndexer Mainnet instance running in Yellow env, Ponder could not transition from backfill phase to realtime phase
  - Ponder was failing to create indexes in ENSDb with the following error message
    ```
    06:06:57.641 WARN  Failed database query query=create_indexes query_id=71db0ec7 (13ms)
    error: index row requires 23456 bytes, maximum size is 8191
    ```
- The error was caused by `byName` index in `"mainnetSchema-1.8.0".subgraph_domains` table. The record with `id = '0x4582fc2e65acd0aaa8ea28b11addac0838d7dbcd7054553f7337c71afa002f6b'` has a very long name, that far exceeds the `byName` index limit.
---

## Testing

- Testing will happen in the Yellow env, as soon as we publisht the ENSNode v1.8.1 release

---

## Notes for Reviewer (Optional)

- The root cause analysis and the idea for the fix have been covered in [this Slack thread](https://namehash.slack.com/archives/C086Z6FNBHN/p1774334795293889?thread_ts=1774332923.237389&cid=C086Z6FNBHN)
- The `byName` index has been introduced just recently. That's why we see the error just now, after deploying a new release to Yellow env.
  - #1747

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)
