### PR TITLE
ENSDb SDK enhancements

### DIFF
--- a/.changeset/dry-trams-brush.md
+++ b/.changeset/dry-trams-brush.md
@@ -1,0 +1,5 @@
+---
+"ensapi": minor
+---
+
+Updated response data model for `/api/config` route to include `ensDbPublicConfig` field.

--- a/.changeset/heavy-laws-sing.md
+++ b/.changeset/heavy-laws-sing.md
@@ -1,0 +1,5 @@
+---
+"@ensnode/ensnode-sdk": minor
+---
+
+Introduced the `EnsDbPublicConfig` data model.

--- a/.changeset/social-dryers-find.md
+++ b/.changeset/social-dryers-find.md
@@ -1,0 +1,5 @@
+---
+"@ensnode/ensdb-sdk": minor
+---
+
+Added `getEnsDbPublicConfig` method to `EnsDbReader` class.

--- a/apps/ensapi/package.json
+++ b/apps/ensapi/package.json
@@ -13,7 +13,7 @@
   "homepage": "https://github.com/namehash/ensnode/tree/main/apps/ensapi",
   "scripts": {
     "start": "tsx src/index.ts",
-    "dev": "ENSINDEXER_SCHEMA_NAME=public tsx watch --env-file ./.env.local src/index.ts",
+    "dev": "tsx watch --env-file ./.env.local src/index.ts",
     "test": "vitest",
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "lint": "biome check --write .",

--- a/apps/ensapi/package.json
+++ b/apps/ensapi/package.json
@@ -13,7 +13,7 @@
   "homepage": "https://github.com/namehash/ensnode/tree/main/apps/ensapi",
   "scripts": {
     "start": "tsx src/index.ts",
-    "dev": "tsx watch --env-file ./.env.local src/index.ts",
+    "dev": "ENSINDEXER_SCHEMA_NAME=public tsx watch --env-file ./.env.local src/index.ts",
     "test": "vitest",
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "lint": "biome check --write .",

--- a/apps/ensapi/src/config/config.schema.test.ts
+++ b/apps/ensapi/src/config/config.schema.test.ts
@@ -2,11 +2,16 @@ import packageJson from "@/../package.json" with { type: "json" };
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { type ENSIndexerPublicConfig, PluginName } from "@ensnode/ensnode-sdk";
+import {
+  type ENSIndexerPublicConfig,
+  type EnsDbPublicConfig,
+  PluginName,
+} from "@ensnode/ensnode-sdk";
 import type { RpcConfig } from "@ensnode/ensnode-sdk/internal";
 
 vi.mock("@/lib/ensdb/singleton", () => ({
   ensDbClient: {
+    getEnsDbPublicConfig: vi.fn(async () => ENSDB_PUBLIC_CONFIG),
     getEnsIndexerPublicConfig: vi.fn(async () => ENSINDEXER_PUBLIC_CONFIG),
   },
 }));
@@ -29,6 +34,11 @@ const BASE_ENV = {
   DATABASE_URL: "postgresql://user:password@localhost:5432/mydb",
   RPC_URL_1: VALID_RPC_URL,
 } satisfies EnsApiEnvironment;
+
+const ENSDB_PUBLIC_CONFIG = {
+  postgresVersion: "17.4",
+  rootSchemaVersion: "1.0.0",
+} satisfies EnsDbPublicConfig;
 
 const ENSINDEXER_PUBLIC_CONFIG = {
   namespace: "mainnet",
@@ -58,6 +68,7 @@ describe("buildConfigFromEnvironment", () => {
       databaseUrl: BASE_ENV.DATABASE_URL,
       theGraphApiKey: undefined,
 
+      ensDbPublicConfig: ENSDB_PUBLIC_CONFIG,
       ensIndexerPublicConfig: ENSINDEXER_PUBLIC_CONFIG,
       namespace: ENSINDEXER_PUBLIC_CONFIG.namespace,
       ensIndexerSchemaName: ENSINDEXER_PUBLIC_CONFIG.databaseSchemaName,
@@ -150,6 +161,7 @@ describe("buildEnsApiPublicConfig", () => {
     const mockConfig = {
       port: ENSApi_DEFAULT_PORT,
       databaseUrl: BASE_ENV.DATABASE_URL,
+      ensDbPublicConfig: ENSDB_PUBLIC_CONFIG,
       ensIndexerPublicConfig: ENSINDEXER_PUBLIC_CONFIG,
       namespace: ENSINDEXER_PUBLIC_CONFIG.namespace,
       ensIndexerSchemaName: ENSINDEXER_PUBLIC_CONFIG.databaseSchemaName,
@@ -173,6 +185,7 @@ describe("buildEnsApiPublicConfig", () => {
         canFallback: false,
         reason: "not-subgraph-compatible",
       },
+      ensDbPublicConfig: ENSDB_PUBLIC_CONFIG,
       ensIndexerPublicConfig: ENSINDEXER_PUBLIC_CONFIG,
     });
   });
@@ -181,6 +194,7 @@ describe("buildEnsApiPublicConfig", () => {
     const mockConfig = {
       port: ENSApi_DEFAULT_PORT,
       databaseUrl: BASE_ENV.DATABASE_URL,
+      ensDbPublicConfig: ENSDB_PUBLIC_CONFIG,
       ensIndexerPublicConfig: ENSINDEXER_PUBLIC_CONFIG,
       namespace: ENSINDEXER_PUBLIC_CONFIG.namespace,
       ensIndexerSchemaName: ENSINDEXER_PUBLIC_CONFIG.databaseSchemaName,
@@ -210,6 +224,7 @@ describe("buildEnsApiPublicConfig", () => {
     const mockConfig = {
       port: ENSApi_DEFAULT_PORT,
       databaseUrl: BASE_ENV.DATABASE_URL,
+      ensDbPublicConfig: ENSDB_PUBLIC_CONFIG,
       ensIndexerPublicConfig: {
         ...ENSINDEXER_PUBLIC_CONFIG,
         plugins: ["subgraph"],

--- a/apps/ensapi/src/config/config.schema.ts
+++ b/apps/ensapi/src/config/config.schema.ts
@@ -12,6 +12,7 @@ import {
   makeENSIndexerPublicConfigSchema,
   OptionalPortNumberSchema,
   RpcConfigsSchema,
+  schemaEnsDbPublicConfig,
   TheGraphApiKeySchema,
 } from "@ensnode/ensnode-sdk/internal";
 
@@ -47,6 +48,7 @@ const EnsApiConfigSchema = z
     namespace: ENSNamespaceSchema,
     rpcConfigs: RpcConfigsSchema,
     ensIndexerPublicConfig: makeENSIndexerPublicConfigSchema("ensIndexerPublicConfig"),
+    ensDbPublicConfig: schemaEnsDbPublicConfig,
     customReferralProgramEditionConfigSetUrl: CustomReferralProgramEditionConfigSetUrlSchema,
   })
   .extend(EnsDbConfigSchema.shape)
@@ -86,12 +88,18 @@ export async function buildConfigFromEnvironment(env: EnsApiEnvironment): Promis
       },
     );
 
+    // TODO: transfer the responsibility of fetching
+    // the ENSDb Public Config to a middleware layer as well,
+    // similar to the ENSIndexer Public Config, as per:
+    // https://github.com/namehash/ensnode/issues/1806
+    const ensDbPublicConfig = await ensDbClient.getEnsDbPublicConfig();
     const rpcConfigs = buildRpcConfigsFromEnv(env, ensIndexerPublicConfig.namespace);
 
     return EnsApiConfigSchema.parse({
       port: env.PORT,
       databaseUrl: env.DATABASE_URL,
       theGraphApiKey: env.THEGRAPH_API_KEY,
+      ensDbPublicConfig,
       ensIndexerPublicConfig,
       namespace: ensIndexerPublicConfig.namespace,
       ensIndexerSchemaName: ensIndexerPublicConfig.databaseSchemaName,
@@ -128,6 +136,7 @@ export function buildEnsApiPublicConfig(config: EnsApiConfig): EnsApiPublicConfi
       theGraphApiKey: config.theGraphApiKey ? "<API_KEY>" : undefined,
       isSubgraphCompatible: config.ensIndexerPublicConfig.isSubgraphCompatible,
     }),
+    ensDbPublicConfig: config.ensDbPublicConfig,
     ensIndexerPublicConfig: config.ensIndexerPublicConfig,
   };
 }

--- a/docs/docs.ensnode.io/ensapi-openapi.json
+++ b/docs/docs.ensnode.io/ensapi-openapi.json
@@ -69,6 +69,14 @@
                         }
                       ]
                     },
+                    "ensDbPublicConfig": {
+                      "type": "object",
+                      "properties": {
+                        "postgresVersion": { "type": "string", "minLength": 1 },
+                        "rootSchemaVersion": { "type": "string", "minLength": 1 }
+                      },
+                      "required": ["postgresVersion", "rootSchemaVersion"]
+                    },
                     "ensIndexerPublicConfig": {
                       "type": "object",
                       "properties": {
@@ -146,7 +154,12 @@
                       ]
                     }
                   },
-                  "required": ["version", "theGraphFallback", "ensIndexerPublicConfig"]
+                  "required": [
+                    "version",
+                    "theGraphFallback",
+                    "ensDbPublicConfig",
+                    "ensIndexerPublicConfig"
+                  ]
                 }
               }
             }

--- a/packages/ensdb-sdk/src/client/ensdb-reader.test.ts
+++ b/packages/ensdb-sdk/src/client/ensdb-reader.test.ts
@@ -5,13 +5,17 @@ import {
   serializeEnsIndexerPublicConfig,
 } from "@ensnode/ensnode-sdk";
 
+import { ENSDB_ROOT_SCHEMA_VERSION } from "../config";
 import * as ensDbClientMock from "./ensdb-client.mock";
 import { EnsDbReader } from "./ensdb-reader";
 
 const whereMock = vi.fn(async () => [] as Array<{ value: unknown }>);
 const fromMock = vi.fn(() => ({ where: whereMock }));
 const selectMock = vi.fn(() => ({ from: fromMock }));
-const drizzleClientMock = { select: selectMock } as any;
+const executeMock = vi.fn(async () => ({
+  rows: [] as Array<{ setting_server_version: string | number }>,
+}));
+const drizzleClientMock = { select: selectMock, execute: executeMock } as any;
 
 vi.mock("drizzle-orm/node-postgres", () => ({
   drizzle: vi.fn(() => drizzleClientMock),
@@ -83,6 +87,68 @@ describe("EnsDbReader", () => {
       await expect(createEnsDbReader().getIndexingStatusSnapshot()).resolves.toStrictEqual(
         expected,
       );
+    });
+  });
+
+  describe("getEnsDbPublicConfig", () => {
+    beforeEach(() => {
+      executeMock.mockClear();
+    });
+
+    it("returns public config with postgres version and root schema version", async () => {
+      executeMock.mockImplementation(async () => ({
+        rows: [{ setting_server_version: "17.4 (Debian 17.4-1.pgdg120+2)" }],
+      }));
+
+      const result = await createEnsDbReader().getEnsDbPublicConfig();
+
+      expect(result).toStrictEqual({
+        postgresVersion: "17.4",
+        rootSchemaVersion: ENSDB_ROOT_SCHEMA_VERSION,
+      });
+      expect(executeMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("throws when server version setting is not a string", async () => {
+      executeMock.mockImplementation(async () => ({
+        rows: [{ setting_server_version: 17.4 }],
+      }));
+
+      await expect(createEnsDbReader().getEnsDbPublicConfig()).rejects.toThrowError(
+        "Unexpected type for server_version setting: number",
+      );
+    });
+
+    it("throws when postgres version is empty", async () => {
+      executeMock.mockImplementation(async () => ({
+        rows: [{ setting_server_version: "" }],
+      }));
+
+      await expect(createEnsDbReader().getEnsDbPublicConfig()).rejects.toThrowError(
+        "PostgreSQL version must be a non-empty string.",
+      );
+    });
+  });
+
+  describe("getters", () => {
+    it("returns the drizzle client", () => {
+      const reader = createEnsDbReader();
+      expect(reader.ensDb).toBe(drizzleClientMock);
+    });
+
+    it("returns the ensIndexerSchema", () => {
+      const reader = createEnsDbReader();
+      expect(reader.ensIndexerSchema).toBeDefined();
+    });
+
+    it("returns the ensIndexerSchemaName", () => {
+      const reader = createEnsDbReader();
+      expect(reader.ensIndexerSchemaName).toBe(ensDbClientMock.ensIndexerSchemaName);
+    });
+
+    it("returns the ensNodeSchema", () => {
+      const reader = createEnsDbReader();
+      expect(reader.ensNodeSchema).toBeDefined();
     });
   });
 });

--- a/packages/ensdb-sdk/src/client/ensdb-reader.ts
+++ b/packages/ensdb-sdk/src/client/ensdb-reader.ts
@@ -1,12 +1,15 @@
-import { and, eq } from "drizzle-orm/sql";
+import { and, eq, sql } from "drizzle-orm/sql";
 
 import {
   type CrossChainIndexingStatusSnapshot,
   deserializeCrossChainIndexingStatusSnapshot,
   deserializeEnsIndexerPublicConfig,
+  type EnsDbPublicConfig,
   type EnsIndexerPublicConfig,
+  validateEnsDbPublicConfig,
 } from "@ensnode/ensnode-sdk";
 
+import { ENSDB_ROOT_SCHEMA_VERSION } from "../config";
 import {
   type AbstractEnsIndexerSchema,
   buildEnsDbDrizzleClient,
@@ -127,6 +130,19 @@ export class EnsDbReader<
   }
 
   /**
+   * Get ENSDb Public Config
+   */
+  async getEnsDbPublicConfig(): Promise<EnsDbPublicConfig> {
+    const postgresVersion = await this.getPgVersion();
+    const rootSchemaVersion = ENSDB_ROOT_SCHEMA_VERSION;
+
+    return validateEnsDbPublicConfig({
+      postgresVersion,
+      rootSchemaVersion,
+    });
+  }
+
+  /**
    * Get ENSDb Version
    *
    * @returns the existing record, or `undefined`.
@@ -207,5 +223,30 @@ export class EnsDbReader<
     throw new Error(
       `There must be exactly one ENSNodeMetadata record for ('${this.ensIndexerSchemaName}', '${metadata.key}') composite key`,
     );
+  }
+
+  /**
+   * Get PostgreSQL version for ENSDb instance.
+   */
+  private async getPgVersion(): Promise<string> {
+    const queryResult = await this.ensDb.execute(
+      sql`SELECT current_setting('server_version') as setting_server_version;`,
+    );
+    const serverVersionSetting = queryResult.rows[0]?.setting_server_version;
+
+    if (typeof serverVersionSetting !== "string") {
+      throw new Error(`Unexpected type for server_version setting: ${typeof serverVersionSetting}`);
+    }
+
+    // Extract version number from full version string,
+    // which is typically in the format "17.4 (Debian 17.4-1.pgdg120+2)".
+    // We just want the "17.4" part for the PostgreSQL version.
+    const [pgVersion = ""] = serverVersionSetting.split(" ");
+
+    if (pgVersion.length === 0) {
+      throw new Error(`PostgreSQL version must be a non-empty string.`);
+    }
+
+    return pgVersion;
   }
 }

--- a/packages/ensdb-sdk/src/config/index.ts
+++ b/packages/ensdb-sdk/src/config/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Version of the Root Schema definition for ENSDb.
+ *
+ * The Root Schema definition is a union of all
+ * the individual schema definitions in ENSDb:
+ * - The "abstract" ENSIndexer Schema definition
+ * - ENSNode Schema definition
+ * - (future) other schemas related to ENSDb
+ */
+export const ENSDB_ROOT_SCHEMA_VERSION = "1.0.0";

--- a/packages/ensdb-sdk/src/index.ts
+++ b/packages/ensdb-sdk/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./client";
+export * from "./config";

--- a/packages/ensdb-sdk/src/lib/drizzle.ts
+++ b/packages/ensdb-sdk/src/lib/drizzle.ts
@@ -119,16 +119,16 @@ type EnsDbSchema<ConcreteEnsIndexerSchema extends AbstractEnsIndexerSchema> =
   ConcreteEnsIndexerSchema & EnsNodeSchema;
 
 /**
- * Build ENSDb Schema for Drizzle client
+ * Build ENSDb Root Schema for Drizzle client
  *
  * Uses the provided "concrete" ENSIndexer Schema definition to build
- * the ENSDb Schema.
+ * the ENSDb Root Schema.
  *
  * @param concreteEnsIndexerSchema - The "concrete" ENSIndexer Schema definition.
- * @returns The ENSDb Schema definition for use in building
+ * @returns The ENSDb Root Schema definition for use in building
  *          a Drizzle client for ENSDb.
  */
-function buildEnsDbSchema<ConcreteEnsIndexerSchema extends AbstractEnsIndexerSchema>(
+function buildEnsDbRootSchema<ConcreteEnsIndexerSchema extends AbstractEnsIndexerSchema>(
   concreteEnsIndexerSchema: ConcreteEnsIndexerSchema,
 ): EnsDbSchema<ConcreteEnsIndexerSchema> {
   return {
@@ -160,11 +160,11 @@ export function buildEnsDbDrizzleClient<ConcreteEnsIndexerSchema extends Abstrac
   concreteEnsIndexerSchema: ConcreteEnsIndexerSchema,
   logger?: DrizzleLogger,
 ): EnsDbDrizzleClient<ConcreteEnsIndexerSchema> {
-  const ensDbSchema = buildEnsDbSchema<ConcreteEnsIndexerSchema>(concreteEnsIndexerSchema);
+  const ensDbRootSchema = buildEnsDbRootSchema<ConcreteEnsIndexerSchema>(concreteEnsIndexerSchema);
 
   return drizzle({
     connection: connectionString,
-    schema: ensDbSchema,
+    schema: ensDbRootSchema,
     casing: "snake_case",
     logger,
   });

--- a/packages/ensnode-sdk/src/ensapi/client.test.ts
+++ b/packages/ensnode-sdk/src/ensapi/client.test.ts
@@ -63,6 +63,10 @@ const EXAMPLE_CONFIG_RESPONSE = {
     canFallback: false,
     reason: "no-api-key",
   },
+  ensDbPublicConfig: {
+    postgresVersion: "17.4",
+    rootSchemaVersion: "1.0.0",
+  },
   ensIndexerPublicConfig: {
     ensRainbowPublicConfig: {
       version: "0.31.0",

--- a/packages/ensnode-sdk/src/ensapi/config/conversions.test.ts
+++ b/packages/ensnode-sdk/src/ensapi/config/conversions.test.ts
@@ -14,6 +14,10 @@ const MOCK_ENSAPI_PUBLIC_CONFIG = {
     canFallback: false,
     reason: "no-api-key",
   },
+  ensDbPublicConfig: {
+    postgresVersion: "17.4",
+    rootSchemaVersion: "1.0.0",
+  },
   ensIndexerPublicConfig: {
     namespace: ENSNamespaceIds.Mainnet,
     databaseSchemaName: "ensapi",
@@ -48,6 +52,10 @@ describe("ENSApi Config Serialization/Deserialization", () => {
         theGraphFallback: {
           canFallback: false,
           reason: "no-api-key",
+        },
+        ensDbPublicConfig: {
+          postgresVersion: "17.4",
+          rootSchemaVersion: "1.0.0",
         },
         ensIndexerPublicConfig: {
           namespace: ENSNamespaceIds.Mainnet,

--- a/packages/ensnode-sdk/src/ensapi/config/serialize.ts
+++ b/packages/ensnode-sdk/src/ensapi/config/serialize.ts
@@ -8,11 +8,12 @@ import type { EnsApiPublicConfig } from "./types";
 export function serializeEnsApiPublicConfig(
   config: EnsApiPublicConfig,
 ): SerializedEnsApiPublicConfig {
-  const { version, theGraphFallback, ensIndexerPublicConfig } = config;
+  const { version, theGraphFallback, ensDbPublicConfig, ensIndexerPublicConfig } = config;
 
   return {
     version,
     theGraphFallback,
+    ensDbPublicConfig,
     ensIndexerPublicConfig: serializeEnsIndexerPublicConfig(ensIndexerPublicConfig),
   } satisfies SerializedEnsApiPublicConfig;
 }

--- a/packages/ensnode-sdk/src/ensapi/config/types.ts
+++ b/packages/ensnode-sdk/src/ensapi/config/types.ts
@@ -1,3 +1,4 @@
+import type { EnsDbPublicConfig } from "../../ensdb/ensdb-public-config";
 import type { EnsIndexerPublicConfig } from "../../ensindexer/config/types";
 import type { TheGraphCannotFallbackReason, TheGraphFallback } from "../../shared/config/thegraph";
 
@@ -29,6 +30,15 @@ export interface EnsApiPublicConfig {
    * namespace, plugins, version info, etc.
    */
   ensIndexerPublicConfig: EnsIndexerPublicConfig;
+
+  /**
+   * ENSDb public config
+   *
+   * Contains ENSDb-specific public configuration, including:
+   * - Postgres version,
+   * - ENSDb Root Schema version.
+   */
+  ensDbPublicConfig: EnsDbPublicConfig;
 }
 
 /**

--- a/packages/ensnode-sdk/src/ensapi/config/zod-schemas.ts
+++ b/packages/ensnode-sdk/src/ensapi/config/zod-schemas.ts
@@ -1,5 +1,6 @@
 import { z } from "zod/v4";
 
+import { schemaEnsDbPublicConfig } from "../../ensdb/zod-schemas/ensdb-public-config";
 import {
   makeEnsIndexerPublicConfigSchema,
   makeSerializedEnsIndexerPublicConfigSchema,
@@ -22,6 +23,7 @@ export function makeEnsApiPublicConfigSchema(valueLabel?: string) {
   return z.object({
     version: z.string().min(1, `${label}.version must be a non-empty string`),
     theGraphFallback: TheGraphFallbackSchema,
+    ensDbPublicConfig: schemaEnsDbPublicConfig,
     ensIndexerPublicConfig: makeEnsIndexerPublicConfigSchema(`${label}.ensIndexerPublicConfig`),
   });
 }
@@ -39,6 +41,7 @@ export function makeSerializedEnsApiPublicConfigSchema(valueLabel?: string) {
   return z.object({
     version: z.string().min(1, `${label}.version must be a non-empty string`),
     theGraphFallback: TheGraphFallbackSchema,
+    ensDbPublicConfig: schemaEnsDbPublicConfig,
     ensIndexerPublicConfig: makeSerializedEnsIndexerPublicConfigSchema(
       `${label}.ensIndexerPublicConfig`,
     ),

--- a/packages/ensnode-sdk/src/ensdb/ensdb-public-config.ts
+++ b/packages/ensnode-sdk/src/ensdb/ensdb-public-config.ts
@@ -1,0 +1,11 @@
+export interface EnsDbPublicConfig {
+  /**
+   * Version of Postgres in the ENSDb instance.
+   */
+  postgresVersion: string;
+
+  /**
+   * Root schema version for ENSNode tables in the ENSDb instance.
+   */
+  rootSchemaVersion: string;
+}

--- a/packages/ensnode-sdk/src/ensdb/index.ts
+++ b/packages/ensnode-sdk/src/ensdb/index.ts
@@ -1,0 +1,2 @@
+export * from "./ensdb-public-config";
+export * from "./validate/ensdb-public-config";

--- a/packages/ensnode-sdk/src/ensdb/validate/ensdb-public-config.ts
+++ b/packages/ensnode-sdk/src/ensdb/validate/ensdb-public-config.ts
@@ -1,0 +1,24 @@
+import { prettifyError } from "zod/v4";
+
+import type { Unvalidated } from "../../shared/types";
+import type { EnsDbPublicConfig } from "../ensdb-public-config";
+import { schemaEnsDbPublicConfig } from "../zod-schemas/ensdb-public-config";
+
+/**
+ * Validate ENSDb Public Config.
+ *
+ * @param unvalidatedConfig The unvalidated ENSDb Public Config to validate.
+ * @returns The validated ENSDb Public Config.
+ * @throws Error if the provided config is invalid, with details on validation errors.
+ */
+export function validateEnsDbPublicConfig(
+  unvalidatedConfig: Unvalidated<EnsDbPublicConfig>,
+): EnsDbPublicConfig {
+  const validationResult = schemaEnsDbPublicConfig.safeParse(unvalidatedConfig);
+
+  if (!validationResult.success) {
+    throw new Error(`Invalid ENSDb Public Config: \n${prettifyError(validationResult.error)}\n`);
+  }
+
+  return validationResult.data;
+}

--- a/packages/ensnode-sdk/src/ensdb/zod-schemas/ensdb-public-config.ts
+++ b/packages/ensnode-sdk/src/ensdb/zod-schemas/ensdb-public-config.ts
@@ -1,0 +1,6 @@
+import { z } from "zod/v4";
+
+export const schemaEnsDbPublicConfig = z.object({
+  postgresVersion: z.string().min(1, "PostgreSQL version must be a non-empty string."),
+  rootSchemaVersion: z.string().min(1, "Root Schema version must be a non-empty string."),
+});

--- a/packages/ensnode-sdk/src/index.ts
+++ b/packages/ensnode-sdk/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./ens";
 export * from "./ensapi";
+export * from "./ensdb";
 export * from "./ensindexer";
 export * from "./ensrainbow";
 export * from "./ensv2";

--- a/packages/ensnode-sdk/src/internal.ts
+++ b/packages/ensnode-sdk/src/internal.ts
@@ -19,6 +19,7 @@ export * from "./ensapi/api/resolution/zod-schemas";
 export * from "./ensapi/api/shared/errors/zod-schemas";
 export * from "./ensapi/api/shared/pagination/zod-schemas";
 export * from "./ensapi/config/zod-schemas";
+export * from "./ensdb/zod-schemas/ensdb-public-config";
 export * from "./ensindexer/config/zod-schemas";
 export * from "./graphql-api/example-queries";
 export * from "./registrars/zod-schemas";


### PR DESCRIPTION
# Lite PR

[Tip: Review docs on the ENSNode PR process](https://ensnode.io/docs/contributing/prs)

## Summary

- Created `EnsDbPublicConfig` data model in ENSNode SDK.
- Created `ENSDB_ROOT_SCHEMA_VERSION` const shared from ENSDb SDK.
- Introduced the idea of "ENSDb Root Schema" to reference the schema definition that consists of the "abstract" ENSIndexer Schema definition and ENSNode Schema definition.
- Added `getEnsDbPublicConfig()` method on `EnsDbReader` class.
- Extended `EnsApiPublicConfig` data model with `ensDbPublicConfig` field.
- Added `ensApiPublicConfig` field to response data model for `/api/config` route.

---

## Why

- We need to present the following ENSDb version info in ENSAdmin:
  - Postrges version
  - ENSDb Root Schema version
- We want to enable ENSDb consumers to be able to work with given ENSDb instance based on the version of the "ENSDb Root Schema". I imagine that the version could be maintained following semantic versioning, so many clients could continue using the evergreen "ENSDb Root Schema".
---

## Testing

- Ran static code checks and testing suite.
- Ran a local instance of ENSApi and observe how `http://localhost:4334/api/config` response includes the correct `ensDbPublicConfig` field.
```
"ensDbPublicConfig": {
    "postgresVersion": "17.4",
    "rootSchemaVersion": "1.0.0"
  },
```

---

## Notes for Reviewer (Optional)

- Please review commit-by-commit.
- Resolves #1833 

---

## Pre-Review Checklist (Blocking)

- This PR does not introduce significant changes and is low-risk to review quickly.
  - I groupped updates in multiple commits, hope that allows for a quick review 👍 
- [x] Relevant changesets are included (or are not required)
