### PR TITLE
fix(ensadmin): dialog animation style

### DIFF
--- a/apps/ensadmin/src/components/ui/dialog.tsx
+++ b/apps/ensadmin/src/components/ui/dialog.tsx
@@ -38,7 +38,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
         className,
       )}
       {...props}


### PR DESCRIPTION
# Lite PR

[Tip: Review docs on the ENSNode PR process](https://ensnode.io/docs/contributing/prs)

## Summary

- Removed `slide-in-from-*` / `slide-out-to-*` animation classes from the Dialog component that were conflicting with the `translate-x-[-50%]` centering transform, causing the dialog to visually slide in from the left instead of appearing from center.

---

## Why

The shadcn/ui Dialog's slide animation classes combined with the existing `-50%` translate used for centering, effectively doubling the horizontal offset and producing a slide-from-left entrance. The dialog now uses only fade + zoom, which is the expected center-origin behavior.

---




## Testing

Before:

https://github.com/user-attachments/assets/2adea58d-8843-499c-8348-5eb434f5d004



After:
![CleanShot 2026-03-29 at 17 09 06](https://github.com/user-attachments/assets/f8ea60cb-9d3a-4257-ac53-5776e63045d5)



---

## Notes for Reviewer (Optional)

- Anything non-obvious or worth a heads-up.

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)
