### PR TITLE
Changed `accurateAsOf` in Registrar Actions from optional to required

### DIFF
--- a/.changeset/shy-rabbits-drum.md
+++ b/.changeset/shy-rabbits-drum.md
@@ -1,0 +1,6 @@
+---
+"@ensnode/ensnode-sdk": minor
+"ensapi": minor
+---
+
+Made `accurateAsOf` a required field in the Registrar Actions API response (`RegistrarActionsResponseOk`).

--- a/apps/ensapi/src/handlers/api/explore/registrar-actions-api.ts
+++ b/apps/ensapi/src/handlers/api/explore/registrar-actions-api.ts
@@ -101,8 +101,15 @@ async function fetchRegistrarActions(parentNode: Node | undefined, query: Regist
  */
 app.openapi(getRegistrarActionsRoute, async (c) => {
   try {
+    if (c.var.indexingStatus instanceof Error) {
+      throw new Error("Indexing status has not been loaded yet");
+    }
+
     const query = c.req.valid("query");
     const { registrarActions, pageContext } = await fetchRegistrarActions(undefined, query);
+
+    // Get the accurateAsOf timestamp from the slowest chain indexing cursor
+    const accurateAsOf = c.var.indexingStatus.snapshot.slowestChainIndexingCursor;
 
     // respond with success response
     return c.json(
@@ -110,6 +117,7 @@ app.openapi(getRegistrarActionsRoute, async (c) => {
         responseCode: RegistrarActionsResponseCodes.Ok,
         registrarActions,
         pageContext,
+        accurateAsOf,
       } satisfies RegistrarActionsResponseOk),
     );
   } catch (error) {

--- a/apps/ensapi/src/handlers/api/explore/registrar-actions-api.ts
+++ b/apps/ensapi/src/handlers/api/explore/registrar-actions-api.ts
@@ -101,15 +101,18 @@ async function fetchRegistrarActions(parentNode: Node | undefined, query: Regist
  */
 app.openapi(getRegistrarActionsRoute, async (c) => {
   try {
+    // Defensive: `registrarActionsApiMiddleware` already short-circuits with a
+    // serialized 503 when indexingStatus is an Error, so this branch is
+    // unreachable at runtime — kept only for TypeScript type narrowing.
     if (c.var.indexingStatus instanceof Error) {
       throw new Error("Indexing status has not been loaded yet");
     }
 
+    // Get the accurateAsOf timestamp from the omnichain indexing cursor
+    const accurateAsOf = c.var.indexingStatus.snapshot.omnichainSnapshot.omnichainIndexingCursor;
+
     const query = c.req.valid("query");
     const { registrarActions, pageContext } = await fetchRegistrarActions(undefined, query);
-
-    // Get the accurateAsOf timestamp from the slowest chain indexing cursor
-    const accurateAsOf = c.var.indexingStatus.snapshot.slowestChainIndexingCursor;
 
     // respond with success response
     return c.json(
@@ -171,16 +174,19 @@ app.openapi(getRegistrarActionsRoute, async (c) => {
  */
 app.openapi(getRegistrarActionsByParentNodeRoute, async (c) => {
   try {
+    // Defensive: `registrarActionsApiMiddleware` already short-circuits with a
+    // serialized 503 when indexingStatus is an Error, so this branch is
+    // unreachable at runtime — kept only for TypeScript type narrowing.
     if (c.var.indexingStatus instanceof Error) {
       throw new Error("Indexing status has not been loaded yet");
     }
 
+    // Get the accurateAsOf timestamp from the omnichain indexing cursor
+    const accurateAsOf = c.var.indexingStatus.snapshot.omnichainSnapshot.omnichainIndexingCursor;
+
     const { parentNode } = c.req.valid("param");
     const query = c.req.valid("query");
     const { registrarActions, pageContext } = await fetchRegistrarActions(parentNode, query);
-
-    // Get the accurateAsOf timestamp from the slowest chain indexing cursor
-    const accurateAsOf = c.var.indexingStatus.snapshot.slowestChainIndexingCursor;
 
     // respond with success response
     return c.json(

--- a/packages/ensnode-sdk/src/ensapi/api/registrar-actions/response.ts
+++ b/packages/ensnode-sdk/src/ensapi/api/registrar-actions/response.ts
@@ -56,7 +56,7 @@ export type RegistrarActionsResponseOk = {
    * The {@link UnixTimestamp} of when the data used to build the list of {@link NamedRegistrarAction} was accurate as of.
    *
    * @remarks
-   * **Note:** This value represents the `slowestChainIndexingCursor` from the latest omnichain indexing status
+   * **Note:** This value represents the `omnichainIndexingCursor` from the latest omnichain indexing status
    * snapshot captured by ENSApi. The state returned in the response is guaranteed to be accurate as of this
    * timestamp but may be from a timestamp higher than this value.
    */

--- a/packages/ensnode-sdk/src/ensapi/api/registrar-actions/response.ts
+++ b/packages/ensnode-sdk/src/ensapi/api/registrar-actions/response.ts
@@ -59,12 +59,8 @@ export type RegistrarActionsResponseOk = {
    * **Note:** This value represents the `slowestChainIndexingCursor` from the latest omnichain indexing status
    * snapshot captured by ENSApi. The state returned in the response is guaranteed to be accurate as of this
    * timestamp but may be from a timestamp higher than this value.
-   *
-   * **Temporary:** This field is currently optional to maintain backward compatibility with ENS Awards
-   * using older snapshot NPM packages. This will be changed to required in a future release.
-   * See: https://github.com/namehash/ensnode/issues/1497
    */
-  accurateAsOf?: UnixTimestamp;
+  accurateAsOf: UnixTimestamp;
 };
 
 /**

--- a/packages/ensnode-sdk/src/ensapi/api/registrar-actions/zod-schemas.test.ts
+++ b/packages/ensnode-sdk/src/ensapi/api/registrar-actions/zod-schemas.test.ts
@@ -125,6 +125,12 @@ describe("ENSNode API Schema", () => {
       expect(() => makeRegistrarActionsResponseSchema().parse(validResponseOk)).not.toThrowError();
     });
 
+    it("rejects ResponseOk object missing required accurateAsOf", () => {
+      const { accurateAsOf, ...invalidResponseOk } = validResponseOk;
+
+      expect(() => makeRegistrarActionsResponseSchema().parse(invalidResponseOk)).toThrowError();
+    });
+
     it("can parse valid ResponseError object", () => {
       const parsed = makeRegistrarActionsResponseSchema().parse(validResponseError);
 

--- a/packages/ensnode-sdk/src/ensapi/api/registrar-actions/zod-schemas.test.ts
+++ b/packages/ensnode-sdk/src/ensapi/api/registrar-actions/zod-schemas.test.ts
@@ -126,7 +126,7 @@ describe("ENSNode API Schema", () => {
     });
 
     it("rejects ResponseOk object missing required accurateAsOf", () => {
-      const { accurateAsOf, ...invalidResponseOk } = validResponseOk;
+      const { accurateAsOf: _accurateAsOf, ...invalidResponseOk } = validResponseOk;
 
       expect(() => makeRegistrarActionsResponseSchema().parse(invalidResponseOk)).toThrowError();
     });

--- a/packages/ensnode-sdk/src/ensapi/api/registrar-actions/zod-schemas.ts
+++ b/packages/ensnode-sdk/src/ensapi/api/registrar-actions/zod-schemas.ts
@@ -43,7 +43,7 @@ export const makeRegistrarActionsResponseOkSchema = (
     responseCode: z.literal(RegistrarActionsResponseCodes.Ok),
     registrarActions: z.array(makeNamedRegistrarActionSchema(valueLabel)),
     pageContext: makeResponsePageContextSchema(`${valueLabel}.pageContext`),
-    accurateAsOf: makeUnixTimestampSchema(`${valueLabel}.accurateAsOf`).optional(),
+    accurateAsOf: makeUnixTimestampSchema(`${valueLabel}.accurateAsOf`),
   });
 
 /**


### PR DESCRIPTION
# Registrar Actions: `accurateAsOf`

closes: #1497

## Summary

- `accurateAsOf` is now required in `RegistrarActionsResponseOk` (type + zod schema).
- Restored `accurateAsOf` on the `GET /api/registrar-actions` handler.

---

## Why

- #1484 introduced the field as optional to avoid breaking ENS Awards snapshot NPM packages. That workaround can now be removed.

---

## Testing

- Automatic, CI testing
- Introduced some new tests
- Manual validation

---

## Notes for Reviewer (Optional)

- The unfiltered `GET /api/registrar-actions` endpoint stopped returning `accurateAsOf` after #1673 split the original single `/:parentNode?` handler into two, keeping the logic only in the by-parent-node one. This PR restores it, but the older versions of ENSApi will not return it, and therefore newer client will throw.

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)
