### PR TITLE
fix(ensindexer): hot-reload safe writer worker

### DIFF
--- a/.changeset/fix-ensindexer-hot-reload.md
+++ b/.changeset/fix-ensindexer-hot-reload.md
@@ -1,0 +1,6 @@
+---
+"ensindexer": patch
+"@ensnode/ponder-sdk": patch
+---
+
+ENSIndexer in dev mode no longer crashes during hot reloading due to EnsDbWriterWorker failure.

--- a/apps/ensindexer/src/lib/ensdb-writer-worker/ensdb-writer-worker.test.ts
+++ b/apps/ensindexer/src/lib/ensdb-writer-worker/ensdb-writer-worker.test.ts
@@ -364,4 +364,69 @@ describe("EnsDbWriterWorker", () => {
       await worker.stop();
     });
   });
+
+  describe("cancellation - stopRequested and skip-overlap", () => {
+    it("stop() during run() startup causes run() to reject with AbortError", async () => {
+      // arrange — make upsertEnsDbVersion block until we release it
+      let resolveUpsert!: () => void;
+      const upsertPromise = new Promise<void>((resolve) => {
+        resolveUpsert = resolve;
+      });
+      const ensDbClient = createMockEnsDbWriter({
+        upsertEnsDbVersion: vi.fn().mockReturnValue(upsertPromise),
+      });
+      const worker = createMockEnsDbWriterWorker({ ensDbClient });
+
+      // act — start run, then stop while it's blocked on upsertEnsDbVersion
+      const runPromise = worker.run();
+      await worker.stop();
+      resolveUpsert();
+
+      // assert — run rejects with AbortError
+      await expect(runPromise).rejects.toThrow("Worker stop requested");
+
+      // the interval was never armed
+      expect(worker.isRunning).toBe(false);
+    });
+
+    it("skips overlapping snapshot ticks when a prior upsert is still in flight", async () => {
+      // arrange — make upsertIndexingStatusSnapshot block until released
+      let resolveSnapshot!: () => void;
+      const snapshotPromise = new Promise<void>((resolve) => {
+        resolveSnapshot = resolve;
+      });
+      const omnichainSnapshot = createMockOmnichainSnapshot();
+      const crossChainSnapshot = createMockCrossChainSnapshot({ omnichainSnapshot });
+      vi.mocked(buildCrossChainIndexingStatusSnapshotOmnichain).mockReturnValue(crossChainSnapshot);
+
+      const ensDbClient = createMockEnsDbWriter({
+        upsertIndexingStatusSnapshot: vi.fn().mockReturnValueOnce(snapshotPromise),
+      });
+      const worker = createMockEnsDbWriterWorker({
+        ensDbClient,
+        indexingStatusBuilder: createMockIndexingStatusBuilder(omnichainSnapshot),
+      });
+
+      await worker.run();
+
+      // act — first tick starts the slow upsert
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(ensDbClient.upsertIndexingStatusSnapshot).toHaveBeenCalledTimes(1);
+
+      // second + third ticks should be skipped (still in flight)
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(ensDbClient.upsertIndexingStatusSnapshot).toHaveBeenCalledTimes(1);
+
+      // release the slow upsert
+      resolveSnapshot();
+      await vi.advanceTimersByTimeAsync(0);
+
+      // next tick should fire again
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(ensDbClient.upsertIndexingStatusSnapshot).toHaveBeenCalledTimes(2);
+
+      // cleanup
+      await worker.stop();
+    });
+  });
 });

--- a/apps/ensindexer/src/lib/ensdb-writer-worker/ensdb-writer-worker.test.ts
+++ b/apps/ensindexer/src/lib/ensdb-writer-worker/ensdb-writer-worker.test.ts
@@ -78,7 +78,7 @@ describe("EnsDbWriterWorker", () => {
       );
 
       // cleanup
-      worker.stop();
+      await worker.stop();
     });
 
     it("throws when stored config is incompatible", async () => {
@@ -129,7 +129,7 @@ describe("EnsDbWriterWorker", () => {
       expect(ensDbClient.upsertEnsIndexerPublicConfig).toHaveBeenCalledWith(mockPublicConfig);
 
       // cleanup
-      worker.stop();
+      await worker.stop();
     });
 
     it("throws error when worker is already running", async () => {
@@ -143,7 +143,7 @@ describe("EnsDbWriterWorker", () => {
       await expect(worker.run()).rejects.toThrow("EnsDbWriterWorker is already running");
 
       // cleanup
-      worker.stop();
+      await worker.stop();
     });
 
     it("throws error when config fetch fails", async () => {
@@ -193,7 +193,7 @@ describe("EnsDbWriterWorker", () => {
       expect(publicConfigBuilder.getPublicConfig).toHaveBeenCalledTimes(1);
 
       // cleanup
-      worker.stop();
+      await worker.stop();
     });
 
     it("calls pRetry for config fetch with retry logic", async () => {
@@ -213,7 +213,7 @@ describe("EnsDbWriterWorker", () => {
       expect(ensDbClient.upsertEnsIndexerPublicConfig).toHaveBeenCalledWith(mockPublicConfig);
 
       // cleanup
-      worker.stop();
+      await worker.stop();
     });
   });
 
@@ -230,7 +230,7 @@ describe("EnsDbWriterWorker", () => {
 
       const callCountBeforeStop = upsertIndexingStatusSnapshot.mock.calls.length;
 
-      worker.stop();
+      await worker.stop();
 
       // advance time after stop
       await vi.advanceTimersByTimeAsync(2000);
@@ -255,7 +255,7 @@ describe("EnsDbWriterWorker", () => {
       expect(worker.isRunning).toBe(true);
 
       // act - stop worker
-      worker.stop();
+      await worker.stop();
 
       // assert - not running after stop
       expect(worker.isRunning).toBe(false);
@@ -303,7 +303,7 @@ describe("EnsDbWriterWorker", () => {
       expect(ensDbClient.upsertIndexingStatusSnapshot).toHaveBeenCalledWith(crossChainSnapshot);
 
       // cleanup
-      worker.stop();
+      await worker.stop();
     });
 
     it("recovers from errors and continues upserting snapshots", async () => {
@@ -361,7 +361,7 @@ describe("EnsDbWriterWorker", () => {
       expect(ensDbClient.upsertIndexingStatusSnapshot).toHaveBeenCalledTimes(3);
 
       // cleanup
-      worker.stop();
+      await worker.stop();
     });
   });
 });

--- a/apps/ensindexer/src/lib/ensdb-writer-worker/ensdb-writer-worker.ts
+++ b/apps/ensindexer/src/lib/ensdb-writer-worker/ensdb-writer-worker.ts
@@ -193,6 +193,10 @@ export class EnsDbWriterWorker {
   private checkCancellation(signal?: AbortSignal): void {
     signal?.throwIfAborted();
     if (this.stopRequested) {
+      // Match what `AbortSignal.throwIfAborted()` throws — a DOMException
+      // with `name === "AbortError"` — so callers' `isAbortError` checks
+      // treat both abort sources (external signal and internal stop)
+      // identically.
       throw new DOMException("Worker stop requested", "AbortError");
     }
   }

--- a/apps/ensindexer/src/lib/ensdb-writer-worker/ensdb-writer-worker.ts
+++ b/apps/ensindexer/src/lib/ensdb-writer-worker/ensdb-writer-worker.ts
@@ -44,6 +44,15 @@ export class EnsDbWriterWorker {
   private inFlightSnapshot: Promise<unknown> | undefined;
 
   /**
+   * Set by {@link stop} to signal an in-progress {@link run} that it should
+   * bail before scheduling the recurring interval. Required because the
+   * external `signal` parameter to `run` may not be aborted in every
+   * cancellation path (e.g. a defensive caller-driven `stop()` in singleton
+   * cleanup).
+   */
+  private stopRequested = false;
+
+  /**
    * ENSDb Client instance used by the worker to interact with ENSDb.
    */
   private ensDbClient: EnsDbWriter;
@@ -109,16 +118,17 @@ export class EnsDbWriterWorker {
       throw new Error("EnsDbWriterWorker is already running");
     }
 
-    signal?.throwIfAborted();
+    this.stopRequested = false;
+    this.checkCancellation(signal);
 
     // Fetch data required for task 1 and task 2.
     const inMemoryConfig = await this.getValidatedEnsIndexerPublicConfig();
-    signal?.throwIfAborted();
+    this.checkCancellation(signal);
 
     // Task 1: upsert ENSDb version into ENSDb.
     logger.debug({ msg: "Upserting ENSDb version", module: "EnsDbWriterWorker" });
     await this.ensDbClient.upsertEnsDbVersion(inMemoryConfig.versionInfo.ensDb);
-    signal?.throwIfAborted();
+    this.checkCancellation(signal);
     logger.info({
       msg: "Upserted ENSDb version",
       ensDbVersion: inMemoryConfig.versionInfo.ensDb,
@@ -131,7 +141,7 @@ export class EnsDbWriterWorker {
       module: "EnsDbWriterWorker",
     });
     await this.ensDbClient.upsertEnsIndexerPublicConfig(inMemoryConfig);
-    signal?.throwIfAborted();
+    this.checkCancellation(signal);
     logger.info({
       msg: "Upserted ENSIndexer public config",
       module: "EnsDbWriterWorker",
@@ -159,10 +169,12 @@ export class EnsDbWriterWorker {
   /**
    * Stop the ENSDb Writer Worker
    *
-   * Stops all recurring tasks in the worker and waits for any in-flight
-   * snapshot upsert to settle. Safe to call when not running.
+   * Cancels any in-progress {@link run} startup, stops all recurring tasks,
+   * and waits for any in-flight snapshot upsert to settle. Safe to call when
+   * not running.
    */
   public async stop(): Promise<void> {
+    this.stopRequested = true;
     if (this.indexingStatusInterval) {
       clearInterval(this.indexingStatusInterval);
       this.indexingStatusInterval = null;
@@ -171,6 +183,17 @@ export class EnsDbWriterWorker {
       // Errors are already logged inside upsertIndexingStatusSnapshot; swallow here.
       await this.inFlightSnapshot.catch(() => {});
       this.inFlightSnapshot = undefined;
+    }
+  }
+
+  /**
+   * Throw an `AbortError` if cancellation has been requested either via the
+   * caller's `AbortSignal` or via an internal {@link stop} call.
+   */
+  private checkCancellation(signal?: AbortSignal): void {
+    signal?.throwIfAborted();
+    if (this.stopRequested) {
+      throw new DOMException("Worker stop requested", "AbortError");
     }
   }
 

--- a/apps/ensindexer/src/lib/ensdb-writer-worker/ensdb-writer-worker.ts
+++ b/apps/ensindexer/src/lib/ensdb-writer-worker/ensdb-writer-worker.ts
@@ -109,8 +109,9 @@ export class EnsDbWriterWorker {
    *               shutting down.
    * @throws Error if the worker is already running, or
    *         if the in-memory ENSIndexer Public Config could not be fetched, or
-   *         if the in-memory ENSIndexer Public Config is incompatible with the stored config in ENSDb, or
-   *         if `signal` is aborted before the recurring interval is scheduled.
+   *         if the in-memory ENSIndexer Public Config is incompatible with the stored config in ENSDb.
+   * @throws DOMException with `name === "AbortError"` if `signal` is aborted
+   *         or if {@link stop} is called before the recurring interval is scheduled.
    */
   public async run(signal?: AbortSignal): Promise<void> {
     // Do not allow multiple concurrent runs of the worker

--- a/apps/ensindexer/src/lib/ensdb-writer-worker/ensdb-writer-worker.ts
+++ b/apps/ensindexer/src/lib/ensdb-writer-worker/ensdb-writer-worker.ts
@@ -93,22 +93,32 @@ export class EnsDbWriterWorker {
    * 3) A recurring attempt to upsert serialized representation of
    *    {@link CrossChainIndexingStatusSnapshot} into ENSDb.
    *
+   * @param signal Optional AbortSignal that, if aborted, causes `run` to bail
+   *               between its async setup steps. Use this to prevent the worker
+   *               from finishing initialization (and starting the recurring
+   *               interval) after the surrounding API instance has begun
+   *               shutting down.
    * @throws Error if the worker is already running, or
    *         if the in-memory ENSIndexer Public Config could not be fetched, or
-   *         if the in-memory ENSIndexer Public Config is incompatible with the stored config in ENSDb.
+   *         if the in-memory ENSIndexer Public Config is incompatible with the stored config in ENSDb, or
+   *         if `signal` is aborted before the recurring interval is scheduled.
    */
-  public async run(): Promise<void> {
+  public async run(signal?: AbortSignal): Promise<void> {
     // Do not allow multiple concurrent runs of the worker
     if (this.isRunning) {
       throw new Error("EnsDbWriterWorker is already running");
     }
 
+    signal?.throwIfAborted();
+
     // Fetch data required for task 1 and task 2.
     const inMemoryConfig = await this.getValidatedEnsIndexerPublicConfig();
+    signal?.throwIfAborted();
 
     // Task 1: upsert ENSDb version into ENSDb.
     logger.debug({ msg: "Upserting ENSDb version", module: "EnsDbWriterWorker" });
     await this.ensDbClient.upsertEnsDbVersion(inMemoryConfig.versionInfo.ensDb);
+    signal?.throwIfAborted();
     logger.info({
       msg: "Upserted ENSDb version",
       ensDbVersion: inMemoryConfig.versionInfo.ensDb,
@@ -121,14 +131,21 @@ export class EnsDbWriterWorker {
       module: "EnsDbWriterWorker",
     });
     await this.ensDbClient.upsertEnsIndexerPublicConfig(inMemoryConfig);
+    signal?.throwIfAborted();
     logger.info({
       msg: "Upserted ENSIndexer public config",
       module: "EnsDbWriterWorker",
     });
 
     // Task 3: recurring upsert of Indexing Status Snapshot into ENSDb.
+    // Skip overlapping ticks so a slow upsert can't pile up concurrent
+    // ENSDb writes. With skip-overlap there is at most one in-flight
+    // upsert at a time, which `stop()` then has a single promise to await.
     this.indexingStatusInterval = setInterval(() => {
-      this.inFlightSnapshot = this.upsertIndexingStatusSnapshot();
+      if (this.inFlightSnapshot) return;
+      this.inFlightSnapshot = this.upsertIndexingStatusSnapshot().finally(() => {
+        this.inFlightSnapshot = undefined;
+      });
     }, secondsToMilliseconds(INDEXING_STATUS_RECORD_UPDATE_INTERVAL));
   }
 

--- a/apps/ensindexer/src/lib/ensdb-writer-worker/ensdb-writer-worker.ts
+++ b/apps/ensindexer/src/lib/ensdb-writer-worker/ensdb-writer-worker.ts
@@ -38,6 +38,12 @@ export class EnsDbWriterWorker {
   private indexingStatusInterval: ReturnType<typeof setInterval> | null = null;
 
   /**
+   * Tracks the most recently launched snapshot upsert so that {@link stop}
+   * can wait for any in-flight work to settle before returning.
+   */
+  private inFlightSnapshot: Promise<unknown> | undefined;
+
+  /**
    * ENSDb Client instance used by the worker to interact with ENSDb.
    */
   private ensDbClient: EnsDbWriter;
@@ -121,10 +127,9 @@ export class EnsDbWriterWorker {
     });
 
     // Task 3: recurring upsert of Indexing Status Snapshot into ENSDb.
-    this.indexingStatusInterval = setInterval(
-      () => this.upsertIndexingStatusSnapshot(),
-      secondsToMilliseconds(INDEXING_STATUS_RECORD_UPDATE_INTERVAL),
-    );
+    this.indexingStatusInterval = setInterval(() => {
+      this.inFlightSnapshot = this.upsertIndexingStatusSnapshot();
+    }, secondsToMilliseconds(INDEXING_STATUS_RECORD_UPDATE_INTERVAL));
   }
 
   /**
@@ -137,12 +142,18 @@ export class EnsDbWriterWorker {
   /**
    * Stop the ENSDb Writer Worker
    *
-   * Stops all recurring tasks in the worker.
+   * Stops all recurring tasks in the worker and waits for any in-flight
+   * snapshot upsert to settle. Safe to call when not running.
    */
-  public stop(): void {
+  public async stop(): Promise<void> {
     if (this.indexingStatusInterval) {
       clearInterval(this.indexingStatusInterval);
       this.indexingStatusInterval = null;
+    }
+    if (this.inFlightSnapshot) {
+      // Errors are already logged inside upsertIndexingStatusSnapshot; swallow here.
+      await this.inFlightSnapshot.catch(() => {});
+      this.inFlightSnapshot = undefined;
     }
   }
 

--- a/apps/ensindexer/src/lib/ensdb-writer-worker/singleton.ts
+++ b/apps/ensindexer/src/lib/ensdb-writer-worker/singleton.ts
@@ -77,14 +77,17 @@ export async function startEnsDbWriterWorker(): Promise<void> {
     .run(abortSignal)
     // Handle any uncaught errors from the worker
     .catch(async (error) => {
-      // Treat as a clean stop only when BOTH the captured shutdown signal
-      // is aborted AND the error is an AbortError. Either condition alone
-      // could mask a real failure: a non-AbortError thrown after Ponder
-      // killed the signal is still a bug worth surfacing, and an
-      // AbortError without our signal aborted means it came from
-      // somewhere else (e.g. a reactive-getter race) and shouldn't be
-      // silently swallowed.
-      if (abortSignal.aborted && isAbortError(error)) {
+      // Treat as a clean stop when the error is an AbortError AND the
+      // worker was intentionally stopped — either because Ponder aborted
+      // the captured shutdown signal, or because this worker has been
+      // superseded in the singleton (the defensive stale-instance
+      // cleanup path inside `startEnsDbWriterWorker` calls
+      // `worker.stop()` on the old worker, which causes its `run()` to
+      // throw AbortError without `abortSignal.aborted` necessarily
+      // being true). Requiring `isAbortError(error)` keeps unrelated
+      // failures from being silently swallowed.
+      const intentionallyStopped = abortSignal.aborted || ensDbWriterWorker !== worker;
+      if (intentionallyStopped && isAbortError(error)) {
         await gracefulShutdown(worker, "API shutdown (run aborted)");
         return;
       }

--- a/apps/ensindexer/src/lib/ensdb-writer-worker/singleton.ts
+++ b/apps/ensindexer/src/lib/ensdb-writer-worker/singleton.ts
@@ -1,40 +1,86 @@
 import { ensDbClient } from "@/lib/ensdb/singleton";
 import { indexingStatusBuilder } from "@/lib/indexing-status-builder/singleton";
 import { localPonderClient } from "@/lib/local-ponder-client";
+import { localPonderContext } from "@/lib/local-ponder-context";
 import { logger } from "@/lib/logger";
 import { publicConfigBuilder } from "@/lib/public-config-builder/singleton";
 
 import { EnsDbWriterWorker } from "./ensdb-writer-worker";
 
-let ensDbWriterWorker: EnsDbWriterWorker;
+let ensDbWriterWorker: EnsDbWriterWorker | undefined;
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
 
 /**
- * Starts the EnsDbWriterWorker in a new asynchronous context.
+ * Start (or restart) the EnsDbWriterWorker.
  *
- * The worker will run indefinitely until it is stopped via {@link EnsDbWriterWorker.stop},
- * for example in response to a process termination signal or an internal error, at
- * which point it will attempt to gracefully shut down.
+ * Called from `apps/ensindexer/ponder/src/api/index.ts` on every Ponder
+ * API exec. Ponder re-executes the API entry file on hot reload, but this
+ * module is cached by vite-node, so module-level state survives across
+ * reloads. This function therefore must:
  *
- * @throws Error if the worker is already running when this function is called.
+ *   1. Be idempotent — treat a re-call as "the previous instance is dead,
+ *      replace it" rather than throwing.
+ *   2. Re-bind reload-scoped resources (e.g. `apiShutdown`) fresh from
+ *      `localPonderContext` on every call. Never hoist them to module
+ *      scope. See `local-ponder-context.ts` for the staleness contract.
  */
-export function startEnsDbWriterWorker() {
-  if (typeof ensDbWriterWorker !== "undefined") {
-    throw new Error("EnsDbWriterWorker has already been initialized");
+export async function startEnsDbWriterWorker(): Promise<void> {
+  // Defensively reset any prior instance. The apiShutdown.add() callback
+  // from the previous API exec is the primary cleanup path on hot reload;
+  // this is a safety net for cases where the callback didn't run (e.g.
+  // unexpected shutdown ordering).
+  if (ensDbWriterWorker) {
+    await ensDbWriterWorker.stop();
+    ensDbWriterWorker = undefined;
   }
 
-  ensDbWriterWorker = new EnsDbWriterWorker(
+  const worker = new EnsDbWriterWorker(
     ensDbClient,
     publicConfigBuilder,
     indexingStatusBuilder,
     localPonderClient,
   );
+  ensDbWriterWorker = worker;
 
-  ensDbWriterWorker
+  // Read apiShutdown FRESH from the reactive context. Ponder kills and
+  // replaces this on every dev-mode hot reload, so this read MUST happen
+  // inside the function call (not at module scope).
+  const apiShutdown = localPonderContext.apiShutdown;
+
+  apiShutdown.add(async () => {
+    logger.info({
+      msg: "Stopping EnsDbWriterWorker due to API shutdown",
+      module: "EnsDbWriterWorker",
+    });
+    await worker.stop();
+    if (ensDbWriterWorker === worker) {
+      ensDbWriterWorker = undefined;
+    }
+  });
+
+  worker
     .run()
     // Handle any uncaught errors from the worker
-    .catch((error) => {
-      // Abort the worker on error to trigger cleanup
-      ensDbWriterWorker.stop();
+    .catch(async (error) => {
+      // If Ponder has begun shutting down our API instance (hot reload or
+      // graceful shutdown), the abort propagates through in-flight fetches
+      // as an AbortError. Treat that as a clean stop, not a worker failure.
+      if (apiShutdown.abortController.signal.aborted || isAbortError(error)) {
+        logger.info({
+          msg: "EnsDbWriterWorker stopped due to API shutdown",
+          module: "EnsDbWriterWorker",
+        });
+        return;
+      }
+
+      // Real worker error — clean up and trigger non-zero exit.
+      await worker.stop();
+      if (ensDbWriterWorker === worker) {
+        ensDbWriterWorker = undefined;
+      }
 
       logger.error({
         msg: "EnsDbWriterWorker encountered an error",

--- a/apps/ensindexer/src/lib/ensdb-writer-worker/singleton.ts
+++ b/apps/ensindexer/src/lib/ensdb-writer-worker/singleton.ts
@@ -77,11 +77,14 @@ export async function startEnsDbWriterWorker(): Promise<void> {
     .run(abortSignal)
     // Handle any uncaught errors from the worker
     .catch(async (error) => {
-      // If Ponder has begun shutting down our API instance (hot reload or
-      // graceful shutdown), the abort propagates through in-flight fetches
-      // (or `signal.throwIfAborted()`) as an AbortError. Treat that as a
-      // clean stop, not a worker failure.
-      if (abortSignal.aborted || isAbortError(error)) {
+      // Treat as a clean stop only when BOTH the captured shutdown signal
+      // is aborted AND the error is an AbortError. Either condition alone
+      // could mask a real failure: a non-AbortError thrown after Ponder
+      // killed the signal is still a bug worth surfacing, and an
+      // AbortError without our signal aborted means it came from
+      // somewhere else (e.g. a reactive-getter race) and shouldn't be
+      // silently swallowed.
+      if (abortSignal.aborted && isAbortError(error)) {
         await gracefulShutdown(worker, "API shutdown (run aborted)");
         return;
       }
@@ -94,8 +97,9 @@ export async function startEnsDbWriterWorker(): Promise<void> {
         error,
       });
 
-      // Re-throw the error to ensure the application shuts down with a non-zero exit code.
+      // Set a non-zero exit code so the process terminates with failure.
+      // Don't rethrow — this catch handler is on a fire-and-forget promise,
+      // so a rethrow becomes an unhandled rejection.
       process.exitCode = 1;
-      throw error;
     });
 }

--- a/apps/ensindexer/src/lib/ensdb-writer-worker/singleton.ts
+++ b/apps/ensindexer/src/lib/ensdb-writer-worker/singleton.ts
@@ -1,7 +1,7 @@
 import { ensDbClient } from "@/lib/ensdb/singleton";
 import { indexingStatusBuilder } from "@/lib/indexing-status-builder/singleton";
 import { localPonderClient } from "@/lib/local-ponder-client";
-import { localPonderContext } from "@/lib/local-ponder-context";
+import { getApiShutdown } from "@/lib/local-ponder-context";
 import { logger } from "@/lib/logger";
 import { publicConfigBuilder } from "@/lib/public-config-builder/singleton";
 
@@ -65,10 +65,10 @@ export async function startEnsDbWriterWorker(): Promise<void> {
   );
   ensDbWriterWorker = worker;
 
-  // Read apiShutdown FRESH from the reactive context. Ponder kills and
+  // Read apiShutdown FRESH via getApiShutdown(). Ponder kills and
   // replaces this on every dev-mode hot reload, so this read MUST happen
   // inside the function call (not at module scope).
-  const apiShutdown = localPonderContext.apiShutdown;
+  const apiShutdown = getApiShutdown();
   const abortSignal = apiShutdown.abortController.signal;
 
   apiShutdown.add(() => gracefulShutdown(worker, "API shutdown"));

--- a/apps/ensindexer/src/lib/ensdb-writer-worker/singleton.ts
+++ b/apps/ensindexer/src/lib/ensdb-writer-worker/singleton.ts
@@ -20,18 +20,22 @@ function isAbortError(error: unknown): boolean {
 }
 
 /**
- * Stop the given worker (if it is still the active singleton) and clear the
- * singleton reference. Safe to call multiple times.
+ * Stop the given worker and, if it is still the active singleton, clear the
+ * singleton reference BEFORE awaiting shutdown. Clearing first ensures that
+ * if `stop()` causes an in-progress `run()` to reject with AbortError, the
+ * catch discriminator immediately sees `ensDbWriterWorker !== worker` and
+ * classifies it as an intentional stop rather than a fatal error.
+ * Safe to call multiple times.
  */
 async function gracefulShutdown(worker: EnsDbWriterWorker, reason: string): Promise<void> {
   logger.info({
     msg: `Stopping EnsDbWriterWorker: ${reason}`,
     module: "EnsDbWriterWorker",
   });
-  await worker.stop();
   if (ensDbWriterWorker === worker) {
     ensDbWriterWorker = undefined;
   }
+  await worker.stop();
 }
 
 /**

--- a/apps/ensindexer/src/lib/ensdb-writer-worker/singleton.ts
+++ b/apps/ensindexer/src/lib/ensdb-writer-worker/singleton.ts
@@ -89,7 +89,13 @@ export async function startEnsDbWriterWorker(): Promise<void> {
         return;
       }
 
-      // Real worker error — clean up and trigger non-zero exit.
+      // Real worker error — clean up and fail-fast. The worker is a startup
+      // invariant for the API layer; leaving the process half-alive (just
+      // setting `process.exitCode`) would let ensindexer keep serving with a
+      // dead writer. We can't rethrow because this `.catch()` is on a
+      // fire-and-forget promise, so a rethrow becomes an unhandled rejection
+      // instead of reaching a top-level handler — call `process.exit(1)` to
+      // terminate immediately.
       await gracefulShutdown(worker, "uncaught error");
 
       logger.error({
@@ -97,9 +103,6 @@ export async function startEnsDbWriterWorker(): Promise<void> {
         error,
       });
 
-      // Set a non-zero exit code so the process terminates with failure.
-      // Don't rethrow — this catch handler is on a fire-and-forget promise,
-      // so a rethrow becomes an unhandled rejection.
-      process.exitCode = 1;
+      process.exit(1);
     });
 }

--- a/apps/ensindexer/src/lib/ensdb-writer-worker/singleton.ts
+++ b/apps/ensindexer/src/lib/ensdb-writer-worker/singleton.ts
@@ -10,7 +10,13 @@ import { EnsDbWriterWorker } from "./ensdb-writer-worker";
 let ensDbWriterWorker: EnsDbWriterWorker | undefined;
 
 function isAbortError(error: unknown): boolean {
-  return error instanceof Error && error.name === "AbortError";
+  // `fetch` aborts reject with a `DOMException` whose `name === "AbortError"`,
+  // which is not always `instanceof Error` across runtimes. Check by name.
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as { name?: unknown }).name === "AbortError"
+  );
 }
 
 /**

--- a/apps/ensindexer/src/lib/ensdb-writer-worker/singleton.ts
+++ b/apps/ensindexer/src/lib/ensdb-writer-worker/singleton.ts
@@ -14,6 +14,21 @@ function isAbortError(error: unknown): boolean {
 }
 
 /**
+ * Stop the given worker (if it is still the active singleton) and clear the
+ * singleton reference. Safe to call multiple times.
+ */
+async function gracefulShutdown(worker: EnsDbWriterWorker, reason: string): Promise<void> {
+  logger.info({
+    msg: `Stopping EnsDbWriterWorker: ${reason}`,
+    module: "EnsDbWriterWorker",
+  });
+  await worker.stop();
+  if (ensDbWriterWorker === worker) {
+    ensDbWriterWorker = undefined;
+  }
+}
+
+/**
  * Start (or restart) the EnsDbWriterWorker.
  *
  * Called from `apps/ensindexer/ponder/src/api/index.ts` on every Ponder
@@ -33,8 +48,7 @@ export async function startEnsDbWriterWorker(): Promise<void> {
   // this is a safety net for cases where the callback didn't run (e.g.
   // unexpected shutdown ordering).
   if (ensDbWriterWorker) {
-    await ensDbWriterWorker.stop();
-    ensDbWriterWorker = undefined;
+    await gracefulShutdown(ensDbWriterWorker, "stale instance from previous API exec");
   }
 
   const worker = new EnsDbWriterWorker(
@@ -49,38 +63,25 @@ export async function startEnsDbWriterWorker(): Promise<void> {
   // replaces this on every dev-mode hot reload, so this read MUST happen
   // inside the function call (not at module scope).
   const apiShutdown = localPonderContext.apiShutdown;
+  const abortSignal = apiShutdown.abortController.signal;
 
-  apiShutdown.add(async () => {
-    logger.info({
-      msg: "Stopping EnsDbWriterWorker due to API shutdown",
-      module: "EnsDbWriterWorker",
-    });
-    await worker.stop();
-    if (ensDbWriterWorker === worker) {
-      ensDbWriterWorker = undefined;
-    }
-  });
+  apiShutdown.add(() => gracefulShutdown(worker, "API shutdown"));
 
   worker
-    .run()
+    .run(abortSignal)
     // Handle any uncaught errors from the worker
     .catch(async (error) => {
       // If Ponder has begun shutting down our API instance (hot reload or
       // graceful shutdown), the abort propagates through in-flight fetches
-      // as an AbortError. Treat that as a clean stop, not a worker failure.
-      if (apiShutdown.abortController.signal.aborted || isAbortError(error)) {
-        logger.info({
-          msg: "EnsDbWriterWorker stopped due to API shutdown",
-          module: "EnsDbWriterWorker",
-        });
+      // (or `signal.throwIfAborted()`) as an AbortError. Treat that as a
+      // clean stop, not a worker failure.
+      if (abortSignal.aborted || isAbortError(error)) {
+        await gracefulShutdown(worker, "API shutdown (run aborted)");
         return;
       }
 
       // Real worker error — clean up and trigger non-zero exit.
-      await worker.stop();
-      if (ensDbWriterWorker === worker) {
-        ensDbWriterWorker = undefined;
-      }
+      await gracefulShutdown(worker, "uncaught error");
 
       logger.error({
         msg: "EnsDbWriterWorker encountered an error",

--- a/apps/ensindexer/src/lib/local-ponder-client.ts
+++ b/apps/ensindexer/src/lib/local-ponder-client.ts
@@ -17,7 +17,6 @@ export const localPonderClient = new LocalPonderClient(
   indexedBlockranges,
   publicClients,
   localPonderContext,
-  // Reload-scoped: read fresh on every fetch via the reactive proxy. See
-  // local-ponder-context.ts for the staleness contract.
+  // See local-ponder-context.ts for the staleness contract.
   () => localPonderContext.apiShutdown.abortController.signal,
 );

--- a/apps/ensindexer/src/lib/local-ponder-client.ts
+++ b/apps/ensindexer/src/lib/local-ponder-client.ts
@@ -17,4 +17,7 @@ export const localPonderClient = new LocalPonderClient(
   indexedBlockranges,
   publicClients,
   localPonderContext,
+  // Reload-scoped: read fresh on every fetch via the reactive proxy. See
+  // local-ponder-context.ts for the staleness contract.
+  () => localPonderContext.apiShutdown.abortController.signal,
 );

--- a/apps/ensindexer/src/lib/local-ponder-client.ts
+++ b/apps/ensindexer/src/lib/local-ponder-client.ts
@@ -7,7 +7,7 @@ import { LocalPonderClient } from "@ensnode/ponder-sdk";
 
 import { getPluginsAllDatasourceNames } from "@/lib/plugin-helpers";
 
-import { localPonderContext } from "./local-ponder-context";
+import { getApiShutdown, localPonderContext } from "./local-ponder-context";
 
 const pluginsAllDatasourceNames = getPluginsAllDatasourceNames(config.plugins);
 const indexedBlockranges = buildIndexedBlockranges(config.namespace, pluginsAllDatasourceNames);
@@ -18,5 +18,5 @@ export const localPonderClient = new LocalPonderClient(
   publicClients,
   localPonderContext,
   // See local-ponder-context.ts for the staleness contract.
-  () => localPonderContext.apiShutdown.abortController.signal,
+  () => getApiShutdown().abortController.signal,
 );

--- a/apps/ensindexer/src/lib/local-ponder-context.ts
+++ b/apps/ensindexer/src/lib/local-ponder-context.ts
@@ -1,4 +1,9 @@
-import { deserializePonderAppContext, type PonderAppContext } from "@ensnode/ponder-sdk";
+import {
+  deserializePonderAppContext,
+  isPonderAppShutdownManager,
+  type PonderAppContext,
+  type PonderAppShutdownManager,
+} from "@ensnode/ponder-sdk";
 
 /**
  * Local Ponder Context — reactive wrapper over Ponder's runtime globals.
@@ -29,28 +34,6 @@ import { deserializePonderAppContext, type PonderAppContext } from "@ensnode/pon
 
 if (!globalThis.PONDER_COMMON) {
   throw new Error("PONDER_COMMON must be defined by Ponder at runtime as a global variable.");
-}
-
-/**
- * Ponder shutdown manager runtime shape.
- *
- * Mirrors `ponder/src/internal/shutdown.ts` — the object Ponder publishes
- * on `globalThis.PONDER_COMMON.{shutdown,apiShutdown}`.
- */
-export interface PonderAppShutdownManager {
-  add: (callback: () => undefined | Promise<unknown>) => void;
-  isKilled: boolean;
-  abortController: AbortController;
-}
-
-function isPonderAppShutdownManager(value: unknown): value is PonderAppShutdownManager {
-  if (typeof value !== "object" || value === null) return false;
-  const obj = value as Record<string, unknown>;
-  return (
-    typeof obj.add === "function" &&
-    typeof obj.isKilled === "boolean" &&
-    obj.abortController instanceof AbortController
-  );
 }
 
 function readShutdownManager(field: "apiShutdown" | "shutdown"): PonderAppShutdownManager {
@@ -94,6 +77,7 @@ export interface LocalPonderContext extends PonderAppContext {
 
 export const localPonderContext: LocalPonderContext = new Proxy({} as LocalPonderContext, {
   get(_target, prop) {
+    if (typeof prop === "symbol") return undefined;
     if (prop === "apiShutdown") return readShutdownManager("apiShutdown");
     if (prop === "shutdown") return readShutdownManager("shutdown");
     return getStableContext()[prop as keyof PonderAppContext];

--- a/apps/ensindexer/src/lib/local-ponder-context.ts
+++ b/apps/ensindexer/src/lib/local-ponder-context.ts
@@ -1,14 +1,101 @@
 import { deserializePonderAppContext, type PonderAppContext } from "@ensnode/ponder-sdk";
 
+/**
+ * Local Ponder Context — reactive wrapper over Ponder's runtime globals.
+ *
+ * Why this is a Proxy and not an eagerly-deserialized object:
+ *
+ * Ponder's dev mode hot-reloads the API entry file by re-executing it via
+ * vite-node. On every indexing-file change, Ponder ALSO kills and replaces
+ * `common.shutdown` and `common.apiShutdown` on `globalThis.PONDER_COMMON`
+ * (see `ponder/src/bin/commands/dev.ts:95-101`). Modules in our API-side
+ * dependency graph (this file included) are NOT re-evaluated when only an
+ * indexing file changes — vite-node only invalidates the changed file's
+ * dep tree. So any value cached in a module-level closure during the
+ * original boot becomes stale on the very next reload.
+ *
+ * Stable fields (`command`, `localPonderAppUrl`, `logger`) are validated
+ * once and memoized — Ponder does not mutate `options` or `logger` on
+ * reload. Reload-scoped fields (`apiShutdown`, `shutdown`) MUST be re-read
+ * from `globalThis.PONDER_COMMON` on every access.
+ *
+ * Contract for callers: NEVER cache reload-scoped fields in a module-level
+ * closure or capture them in a constructor argument. Always reach for them
+ * via `localPonderContext.<field>` from code that runs per-reload (e.g. the
+ * API entry file or per-request handlers). If you need an `AbortSignal`
+ * across calls, store a getter (`() => localPonderContext.apiShutdown
+ * .abortController.signal`), not the signal itself.
+ */
+
 if (!globalThis.PONDER_COMMON) {
   throw new Error("PONDER_COMMON must be defined by Ponder at runtime as a global variable.");
 }
 
 /**
- * Local Ponder app context
+ * Ponder shutdown manager runtime shape.
  *
- * Represents the {@link PonderAppContext} object provided by Ponder runtime to
- * the local Ponder app. Useful for accessing internal Ponder app configuration
- * and utilities such as the logger.
+ * Mirrors `ponder/src/internal/shutdown.ts` — the object Ponder publishes
+ * on `globalThis.PONDER_COMMON.{shutdown,apiShutdown}`.
  */
-export const localPonderContext = deserializePonderAppContext(globalThis.PONDER_COMMON);
+export interface PonderAppShutdownManager {
+  add: (callback: () => undefined | Promise<unknown>) => void;
+  isKilled: boolean;
+  abortController: AbortController;
+}
+
+function isPonderAppShutdownManager(value: unknown): value is PonderAppShutdownManager {
+  if (typeof value !== "object" || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj.add === "function" &&
+    typeof obj.isKilled === "boolean" &&
+    obj.abortController instanceof AbortController
+  );
+}
+
+function readShutdownManager(field: "apiShutdown" | "shutdown"): PonderAppShutdownManager {
+  const raw = (globalThis.PONDER_COMMON as Record<string, unknown> | undefined)?.[field];
+  if (!isPonderAppShutdownManager(raw)) {
+    throw new Error(`globalThis.PONDER_COMMON.${field} is not a valid Ponder shutdown manager.`);
+  }
+  return raw;
+}
+
+let cachedStableContext: PonderAppContext | undefined;
+function getStableContext(): PonderAppContext {
+  if (!cachedStableContext) {
+    if (!globalThis.PONDER_COMMON) {
+      throw new Error("PONDER_COMMON must be defined by Ponder at runtime as a global variable.");
+    }
+    cachedStableContext = deserializePonderAppContext(globalThis.PONDER_COMMON);
+  }
+  return cachedStableContext;
+}
+
+/**
+ * Local Ponder Context.
+ *
+ * Combines stable {@link PonderAppContext} fields with reload-scoped
+ * shutdown managers. See module-level comment for the staleness contract.
+ */
+export interface LocalPonderContext extends PonderAppContext {
+  /**
+   * The current `apiShutdown` manager. RELOAD-SCOPED — identity changes
+   * every API hot-reload. Always read fresh; never cache.
+   */
+  readonly apiShutdown: PonderAppShutdownManager;
+
+  /**
+   * The current `shutdown` manager. RELOAD-SCOPED — identity changes
+   * every indexing hot-reload. Always read fresh; never cache.
+   */
+  readonly shutdown: PonderAppShutdownManager;
+}
+
+export const localPonderContext: LocalPonderContext = new Proxy({} as LocalPonderContext, {
+  get(_target, prop) {
+    if (prop === "apiShutdown") return readShutdownManager("apiShutdown");
+    if (prop === "shutdown") return readShutdownManager("shutdown");
+    return getStableContext()[prop as keyof PonderAppContext];
+  },
+});

--- a/apps/ensindexer/src/lib/local-ponder-context.ts
+++ b/apps/ensindexer/src/lib/local-ponder-context.ts
@@ -1,14 +1,13 @@
 import {
   deserializePonderAppContext,
   isPonderAppShutdownManager,
-  type PonderAppContext,
   type PonderAppShutdownManager,
 } from "@ensnode/ponder-sdk";
 
 /**
- * Local Ponder Context — reactive wrapper over Ponder's runtime globals.
+ * Local Ponder Context — wrappers over Ponder's runtime globals.
  *
- * Why this is a Proxy and not an eagerly-deserialized object:
+ * Stable vs reload-scoped fields:
  *
  * Ponder's dev mode hot-reloads the API entry file by re-executing it via
  * vite-node. On every indexing-file change, Ponder ALSO kills and replaces
@@ -19,22 +18,28 @@ import {
  * dep tree. So any value cached in a module-level closure during the
  * original boot becomes stale on the very next reload.
  *
- * Stable fields (`command`, `localPonderAppUrl`, `logger`) are validated
- * once and memoized — Ponder does not mutate `options` or `logger` on
- * reload. Reload-scoped fields (`apiShutdown`, `shutdown`) MUST be re-read
- * from `globalThis.PONDER_COMMON` on every access.
+ * Stable fields (`command`, `localPonderAppUrl`, `logger`) are eagerly
+ * deserialized once at module load — Ponder does not mutate `options` or
+ * `logger` on reload. Reload-scoped fields are exposed as FUNCTIONS
+ * ({@link getApiShutdown}, {@link getShutdown}) rather than properties on
+ * the context object so that every call site is forced to re-read fresh
+ * from `globalThis.PONDER_COMMON`. The function call form makes the
+ * staleness contract visible at the call site — a captured `const sig =
+ * getApiShutdown().abortController.signal` is obviously caching a
+ * function result, whereas a captured `localPonderContext.apiShutdown`
+ * would have looked like an innocent property access.
  *
- * Contract for callers: NEVER cache reload-scoped fields in a module-level
- * closure or capture them in a constructor argument. Always reach for them
- * via `localPonderContext.<field>` from code that runs per-reload (e.g. the
- * API entry file or per-request handlers). If you need an `AbortSignal`
- * across calls, store a getter (`() => localPonderContext.apiShutdown
- * .abortController.signal`), not the signal itself.
+ * Contract for callers: NEVER cache the return value of `getApiShutdown`
+ * or `getShutdown` (or any field on it) in a module-level closure or a
+ * constructor argument. If you need to attach a listener or read the
+ * signal across calls, store the GETTER function, not its return value.
  */
 
 if (!globalThis.PONDER_COMMON) {
   throw new Error("PONDER_COMMON must be defined by Ponder at runtime as a global variable.");
 }
+
+export const localPonderContext = deserializePonderAppContext(globalThis.PONDER_COMMON);
 
 function readShutdownManager(field: "apiShutdown" | "shutdown"): PonderAppShutdownManager {
   const raw = (globalThis.PONDER_COMMON as Record<string, unknown> | undefined)?.[field];
@@ -44,42 +49,18 @@ function readShutdownManager(field: "apiShutdown" | "shutdown"): PonderAppShutdo
   return raw;
 }
 
-let cachedStableContext: PonderAppContext | undefined;
-function getStableContext(): PonderAppContext {
-  if (!cachedStableContext) {
-    if (!globalThis.PONDER_COMMON) {
-      throw new Error("PONDER_COMMON must be defined by Ponder at runtime as a global variable.");
-    }
-    cachedStableContext = deserializePonderAppContext(globalThis.PONDER_COMMON);
-  }
-  return cachedStableContext;
+/**
+ * Returns the current `apiShutdown` manager. RELOAD-SCOPED — Ponder
+ * replaces this on every API hot reload. Always call fresh; never cache.
+ */
+export function getApiShutdown(): PonderAppShutdownManager {
+  return readShutdownManager("apiShutdown");
 }
 
 /**
- * Local Ponder Context.
- *
- * Combines stable {@link PonderAppContext} fields with reload-scoped
- * shutdown managers. See module-level comment for the staleness contract.
+ * Returns the current `shutdown` manager. RELOAD-SCOPED — Ponder
+ * replaces this on every indexing hot reload. Always call fresh; never cache.
  */
-export interface LocalPonderContext extends PonderAppContext {
-  /**
-   * The current `apiShutdown` manager. RELOAD-SCOPED — identity changes
-   * every API hot-reload. Always read fresh; never cache.
-   */
-  readonly apiShutdown: PonderAppShutdownManager;
-
-  /**
-   * The current `shutdown` manager. RELOAD-SCOPED — identity changes
-   * every indexing hot-reload. Always read fresh; never cache.
-   */
-  readonly shutdown: PonderAppShutdownManager;
+export function getShutdown(): PonderAppShutdownManager {
+  return readShutdownManager("shutdown");
 }
-
-export const localPonderContext: LocalPonderContext = new Proxy({} as LocalPonderContext, {
-  get(_target, prop) {
-    if (typeof prop === "symbol") return undefined;
-    if (prop === "apiShutdown") return readShutdownManager("apiShutdown");
-    if (prop === "shutdown") return readShutdownManager("shutdown");
-    return getStableContext()[prop as keyof PonderAppContext];
-  },
-});

--- a/packages/ponder-sdk/src/client.test.ts
+++ b/packages/ponder-sdk/src/client.test.ts
@@ -322,4 +322,82 @@ describe("Ponder Client", () => {
       });
     });
   });
+
+  describe("getAbortSignal getter", () => {
+    it("invokes getAbortSignal on every fetch and forwards the signal", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(new Response(null, { status: 200 }));
+      const signal = new AbortController().signal;
+      const getAbortSignal = vi.fn(() => signal);
+      const ponderClient = new PonderClient(new URL("http://localhost:3000"), getAbortSignal);
+
+      // Act
+      await ponderClient.health();
+      await ponderClient.health();
+
+      // Assert
+      expect(getAbortSignal).toHaveBeenCalledTimes(2);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch).toHaveBeenNthCalledWith(1, expect.any(URL), { signal });
+      expect(mockFetch).toHaveBeenNthCalledWith(2, expect.any(URL), { signal });
+    });
+
+    it("re-reads the signal between fetches so callers get fresh identity", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(new Response(null, { status: 200 }));
+      const firstSignal = new AbortController().signal;
+      const secondSignal = new AbortController().signal;
+      const getAbortSignal = vi
+        .fn<() => AbortSignal | undefined>()
+        .mockReturnValueOnce(firstSignal)
+        .mockReturnValueOnce(secondSignal);
+      const ponderClient = new PonderClient(new URL("http://localhost:3000"), getAbortSignal);
+
+      // Act
+      await ponderClient.health();
+      await ponderClient.health();
+
+      // Assert
+      expect(mockFetch).toHaveBeenNthCalledWith(1, expect.any(URL), { signal: firstSignal });
+      expect(mockFetch).toHaveBeenNthCalledWith(2, expect.any(URL), { signal: secondSignal });
+    });
+
+    it("aborting the signal cancels in-flight fetches", async () => {
+      // Arrange
+      const abortController = new AbortController();
+      mockFetch.mockImplementation(
+        (_input, init) =>
+          new Promise((_resolve, reject) => {
+            init?.signal?.addEventListener("abort", () => {
+              const error = new Error("aborted");
+              error.name = "AbortError";
+              reject(error);
+            });
+          }),
+      );
+      const ponderClient = new PonderClient(
+        new URL("http://localhost:3000"),
+        () => abortController.signal,
+      );
+
+      // Act
+      const pending = ponderClient.health();
+      abortController.abort();
+
+      // Assert
+      await expect(pending).rejects.toThrowError(/aborted/);
+    });
+
+    it("treats getAbortSignal as optional (undefined signal → no abort)", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce(new Response(null, { status: 200 }));
+      const ponderClient = new PonderClient(new URL("http://localhost:3000"));
+
+      // Act
+      await ponderClient.health();
+
+      // Assert
+      expect(mockFetch).toHaveBeenCalledWith(expect.any(URL), { signal: undefined });
+    });
+  });
 });

--- a/packages/ponder-sdk/src/client.ts
+++ b/packages/ponder-sdk/src/client.ts
@@ -4,19 +4,22 @@ import type { PonderIndexingMetrics } from "./indexing-metrics";
 import type { PonderIndexingStatus } from "./indexing-status";
 
 /**
- * PonderClient for fetching data from Ponder apps.
+ * Returns the current `AbortSignal` to attach to outgoing requests.
  *
- * The optional `getAbortSignal` is invoked at fetch time so each request
- * uses the current `AbortSignal`. Passing a getter (instead of a captured
- * `AbortSignal`) is required for consumers that need to track signals
- * which change identity over the client's lifetime — e.g. signals derived
+ * Consumers must use a getter (not a captured `AbortSignal`) when the
+ * underlying signal can change identity over time — e.g. signals derived
  * from Ponder's `apiShutdown` manager, which Ponder kills and replaces on
  * every dev-mode hot reload.
+ */
+export type AbortSignalGetter = () => AbortSignal | undefined;
+
+/**
+ * PonderClient for fetching data from Ponder apps.
  */
 export class PonderClient {
   constructor(
     private readonly baseUrl: URL,
-    private readonly getAbortSignal?: () => AbortSignal | undefined,
+    private readonly getAbortSignal?: AbortSignalGetter,
   ) {}
 
   /**

--- a/packages/ponder-sdk/src/client.ts
+++ b/packages/ponder-sdk/src/client.ts
@@ -5,9 +5,19 @@ import type { PonderIndexingStatus } from "./indexing-status";
 
 /**
  * PonderClient for fetching data from Ponder apps.
+ *
+ * The optional `getAbortSignal` is invoked at fetch time so each request
+ * uses the current `AbortSignal`. Passing a getter (instead of a captured
+ * `AbortSignal`) is required for consumers that need to track signals
+ * which change identity over the client's lifetime — e.g. signals derived
+ * from Ponder's `apiShutdown` manager, which Ponder kills and replaces on
+ * every dev-mode hot reload.
  */
 export class PonderClient {
-  constructor(private readonly baseUrl: URL) {}
+  constructor(
+    private readonly baseUrl: URL,
+    private readonly getAbortSignal?: () => AbortSignal | undefined,
+  ) {}
 
   /**
    * Check Ponder Health
@@ -18,7 +28,7 @@ export class PonderClient {
    */
   async health(): Promise<void> {
     const requestUrl = new URL("/health", this.baseUrl);
-    const response = await fetch(requestUrl);
+    const response = await fetch(requestUrl, { signal: this.getAbortSignal?.() });
 
     if (!response.ok) {
       throw new Error(
@@ -35,7 +45,7 @@ export class PonderClient {
    */
   async metrics(): Promise<PonderIndexingMetrics> {
     const requestUrl = new URL("/metrics", this.baseUrl);
-    const response = await fetch(requestUrl);
+    const response = await fetch(requestUrl, { signal: this.getAbortSignal?.() });
 
     if (!response.ok) {
       throw new Error(
@@ -56,7 +66,7 @@ export class PonderClient {
    */
   async status(): Promise<PonderIndexingStatus> {
     const requestUrl = new URL("/status", this.baseUrl);
-    const response = await fetch(requestUrl);
+    const response = await fetch(requestUrl, { signal: this.getAbortSignal?.() });
 
     if (!response.ok) {
       throw new Error(

--- a/packages/ponder-sdk/src/local-ponder-client.ts
+++ b/packages/ponder-sdk/src/local-ponder-client.ts
@@ -1,7 +1,7 @@
 import type { BlockNumberRangeWithStartBlock } from "./blockrange";
 import type { CachedPublicClient } from "./cached-public-client";
 import type { ChainId, ChainIdString } from "./chains";
-import { PonderClient } from "./client";
+import { type AbortSignalGetter, PonderClient } from "./client";
 import { deserializeChainId } from "./deserialize/chains";
 import {
   type ChainIndexingMetrics,
@@ -82,14 +82,14 @@ export class LocalPonderClient extends PonderClient {
    * @param ponderPublicClients All cached public clients provided by the local Ponder app
    *                            (may include non-indexed chains).
    * @param ponderAppContext The internal context of the local Ponder app.
-   * @param getAbortSignal Optional getter invoked at fetch time to attach an `AbortSignal` to outgoing HTTP requests. Use a getter (not a captured signal) when the underlying signal can change identity over time — e.g. across Ponder dev-mode hot reloads.
+   * @param getAbortSignal Optional {@link AbortSignalGetter} invoked at fetch time. See its docs for the staleness contract.
    */
   constructor(
     indexedChainIds: Set<ChainId>,
     indexedBlockranges: Map<ChainId, BlockNumberRangeWithStartBlock>,
     ponderPublicClients: Record<ChainIdString, CachedPublicClient>,
     ponderAppContext: PonderAppContext,
-    getAbortSignal?: () => AbortSignal | undefined,
+    getAbortSignal?: AbortSignalGetter,
   ) {
     super(ponderAppContext.localPonderAppUrl, getAbortSignal);
 

--- a/packages/ponder-sdk/src/local-ponder-client.ts
+++ b/packages/ponder-sdk/src/local-ponder-client.ts
@@ -82,14 +82,16 @@ export class LocalPonderClient extends PonderClient {
    * @param ponderPublicClients All cached public clients provided by the local Ponder app
    *                            (may include non-indexed chains).
    * @param ponderAppContext The internal context of the local Ponder app.
+   * @param getAbortSignal Optional getter invoked at fetch time to attach an `AbortSignal` to outgoing HTTP requests. Use a getter (not a captured signal) when the underlying signal can change identity over time — e.g. across Ponder dev-mode hot reloads.
    */
   constructor(
     indexedChainIds: Set<ChainId>,
     indexedBlockranges: Map<ChainId, BlockNumberRangeWithStartBlock>,
     ponderPublicClients: Record<ChainIdString, CachedPublicClient>,
     ponderAppContext: PonderAppContext,
+    getAbortSignal?: () => AbortSignal | undefined,
   ) {
-    super(ponderAppContext.localPonderAppUrl);
+    super(ponderAppContext.localPonderAppUrl, getAbortSignal);
 
     this.indexedChainIds = indexedChainIds;
 

--- a/packages/ponder-sdk/src/ponder-app-context.ts
+++ b/packages/ponder-sdk/src/ponder-app-context.ts
@@ -13,6 +13,31 @@ export const PonderAppCommands = {
 export type PonderAppCommand = (typeof PonderAppCommands)[keyof typeof PonderAppCommands];
 
 /**
+ * Ponder shutdown manager runtime shape.
+ *
+ * Mirrors `ponder/src/internal/shutdown.ts` — the object Ponder publishes
+ * on `globalThis.PONDER_COMMON.{shutdown,apiShutdown}`. Reload-scoped:
+ * Ponder kills and replaces these on every dev-mode hot reload, so
+ * consumers must always read the current instance fresh and never cache
+ * a captured reference.
+ */
+export interface PonderAppShutdownManager {
+  add: (callback: () => undefined | Promise<unknown>) => void;
+  isKilled: boolean;
+  abortController: AbortController;
+}
+
+export function isPonderAppShutdownManager(value: unknown): value is PonderAppShutdownManager {
+  if (typeof value !== "object" || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj.add === "function" &&
+    typeof obj.isKilled === "boolean" &&
+    obj.abortController instanceof AbortController
+  );
+}
+
+/**
  * Ponder app context
  *
  * Represents the internal context of a local Ponder app.

--- a/packages/ponder-sdk/src/ponder-app-context.ts
+++ b/packages/ponder-sdk/src/ponder-app-context.ts
@@ -22,7 +22,11 @@ export type PonderAppCommand = (typeof PonderAppCommands)[keyof typeof PonderApp
  * a captured reference.
  */
 export interface PonderAppShutdownManager {
-  add: (callback: () => undefined | Promise<unknown>) => void;
+  // Ponder awaits the callback's return value internally, so any value
+  // (sync or async) is accepted. Typed as `unknown` to keep callbacks
+  // that return `void` assignable without a Biome `noConfusingVoidType`
+  // violation.
+  add: (callback: () => unknown) => void;
   isKilled: boolean;
   abortController: AbortController;
 }


### PR DESCRIPTION
# fix(ensindexer): hot-reload safe writer worker

## Reviewer Focus

- `apps/ensindexer/src/lib/local-ponder-context.ts` — the `getApiShutdown()` / `getShutdown()` function pattern. The staleness contract (always read fresh, never cache) is enforced ergonomically by making call sites function calls rather than property accesses.
- `apps/ensindexer/src/lib/ensdb-writer-worker/singleton.ts` — the `.run().catch()` clean-stop discrimination: `(abortSignal.aborted || ensDbWriterWorker !== worker) && isAbortError(error)`. Both abort-source paths must be validated to avoid masking real errors AND to avoid misclassifying intentional supersession as a fatal error.
- `apps/ensindexer/src/lib/ensdb-writer-worker/ensdb-writer-worker.ts` — the `stopRequested` guard. `stop()` flips it; `run()` checks via `checkCancellation()` between every async setup step so a stop during startup actually cancels.

## Problem

ponder dev-mode hot reload of indexing handler files crashed ensindexer with `Error: EnsDbWriterWorker has already been initialized` and `process.exit(1)`.

Root cause: ponder kills and replaces `common.shutdown` and `common.apiShutdown` on every indexing reload (`ponder/src/bin/commands/dev.ts:95-101`), then re-execs the api entry file. but vite-node only invalidates the changed file's dep tree — api-side singleton modules stay cached. so module-level state survives across reloads (singleton check throws), and any reference cached during the first boot goes stale.

resolves #1432.

## What Changed

1. **`local-ponder-context.ts`** — stable fields stay as an eager `const`. reload-scoped fields are exposed as functions `getApiShutdown()` / `getShutdown()` that re-read `globalThis.PONDER_COMMON` on every call. the function-call shape makes the fresh-read contract visible at every call site, so accidental caching reads as obviously wrong (`const sig = getApiShutdown().signal` clearly caches a function result; the equivalent property access wouldn't).
2. **`singleton.ts`** — `startEnsDbWriterWorker()` is reset-aware. drops the throw-on-re-init, awaits any prior worker's `stop()`, registers cleanup via `getApiShutdown().add(...)` so ponder properly awaits worker shutdown during its kill sequence. extracted `gracefulShutdown(worker, reason)` helper. `.run().catch()` distinguishes intentional stops (signal aborted OR worker superseded in singleton, AND error is `AbortError`) from real failures, which fail-fast via `process.exit(1)`.
3. **`ensdb-writer-worker.ts`** — `stop()` is async. `inFlightSnapshot` tracks the latest upsert with skip-overlap so `stop()` deterministically awaits one promise. new `stopRequested` flag + `checkCancellation()` helper let `stop()` cancel an in-progress `run()` startup before it arms the recurring interval. `run()` accepts an optional external `AbortSignal` for the same purpose.
4. **`packages/ponder-sdk`** — `PonderClient` accepts an optional `AbortSignalGetter` (typed alias). `LocalPonderClient` forwards it. invoked at fetch time inside `health/metrics/status` so requests use the current signal instead of a captured-at-construct reference. `PonderAppShutdownManager` interface + `isPonderAppShutdownManager` guard exported alongside `PonderAppContext` since they mirror a Ponder runtime type.

## Self-Review

- bugs caught during review iteration: typescript narrowing of `globalThis.PONDER_COMMON` lost when read moved into a function (added explicit check); `isAbortError` originally only checked `instanceof Error` and missed `DOMException` (the actual fetch-abort rejection type); the catch-path discriminator went through `||` → `&&` → `(signal.aborted || superseded) && isAbortError` as the supersession case from the defensive cleanup path was identified.
- logic simplified: replaced an initial reactive `Proxy` over `globalThis.PONDER_COMMON` with explicit getter functions. the proxy was technically correct but hid the staleness contract behind property-access syntax. -19 lines.
- naming: introduced "reload-scoped" vs "stable" field distinction to make the contract teachable.
- dead code removed: the `typeof ensDbWriterWorker !== "undefined"` throw is gone — re-init is the expected path.

## Cross-Codebase Alignment

- audited every api-side singleton (`ensDbClient`, `ensRainbowClient`, `publicConfigBuilder`, `indexingStatusBuilder`, `localPonderClient`) for stale-reference hazards. only `localPonderClient` captured a runtime mutable (the abort signal), addressed via the getter-pattern threading.
- `publicConfigBuilder` and `indexingStatusBuilder` cache `immutablePublicConfig` / `_immutableIndexingConfig` after first build. could mask config changes if you edit `config.ts` and reload — pre-existing pre-fix behavior, not the crash, deferred.

## Downstream & Consumer Impact

- `PonderClient` constructor: optional second arg `getAbortSignal?: AbortSignalGetter`. backwards compatible.
- `LocalPonderClient` constructor: optional 5th arg, same. backwards compatible.
- `EnsDbWriterWorker.stop()` is now `async` and returns `Promise<void>`. existing call sites (production + tests) updated to await.
- new exports from `@ensnode/ponder-sdk`: `AbortSignalGetter`, `PonderAppShutdownManager`, `isPonderAppShutdownManager`.

## Testing

- `pnpm -F ensindexer typecheck` ✓
- `pnpm -F @ensnode/ponder-sdk typecheck` ✓
- `pnpm test --project ensindexer --project @ensnode/ponder-sdk` → 268 passed (4 new `PonderClient` tests for the getAbortSignal getter pattern).
- `pnpm lint` ✓
- manual: `pnpm -F ensindexer dev` against ens-test-env, edited an indexing handler multiple times. confirmed: hot reload completes, no "already been initialized", no `ELIFECYCLE`, indexing resumes, snapshots continue upserting.

no automated hot-reload test infrastructure exists; manual smoke test is the only path.

## Risk Analysis

- the catch path's intentional-stop discrimination has been the most-reviewed area. final shape: `(signal.aborted || ensDbWriterWorker !== worker) && isAbortError(error)` — both an abort-source signal AND the AbortError name are required, ruling out both "real error during shutdown" and "AbortError from a cross-contamination race that didn't actually stop us."
- `stopRequested` + the external `AbortSignal` provide two independent cancellation channels. `checkCancellation()` honors both.
- `process.exit(1)` on real worker errors is explicit and fail-fast. can't rethrow from the fire-and-forget catch (would become an unhandled rejection rather than reaching api/index.ts).
- the function-call getter pattern can still be misused (capture the result), but the misuse reads as obviously wrong, which is the whole improvement over the proxy.
- mitigations / rollback: revert the commit; the previous (broken) behavior is well understood.
- named owner: @shrugs

## Pre-Review Checklist

- [x] I reviewed every line of this diff and understand it end-to-end
- [x] I'm prepared to defend this PR line-by-line in review
- [x] I'm comfortable being the on-call owner for this change
- [x] Relevant changesets are included (or explicitly not required)