### PR TITLE
fix: hotfix parse reverse name types

### DIFF
--- a/packages/enssdk/src/lib/parse-reverse-name.test.ts
+++ b/packages/enssdk/src/lib/parse-reverse-name.test.ts
@@ -14,10 +14,8 @@ import {
 import { describe, expect, it } from "vitest";
 
 import { DEFAULT_EVM_CHAIN_ID, evmChainIdToCoinType } from "./coin-type";
-import { asInterpretedName } from "./interpreted-names-and-labels";
 import { parseReverseName } from "./parse-reverse-name";
 import { reverseName } from "./reverse-name";
-import type { InterpretedName } from "./types";
 
 const EXAMPLE_ADDRESS = "0x51050ec063d393217b436747617ad1c2285aeeee";
 const CHAIN_IDS = [
@@ -134,14 +132,13 @@ const negativeCases: string[] = [
 describe("parseReverseName", () => {
   positiveCases.forEach(([input, expected]) => {
     it(`parses "${input}"`, () => {
-      expect(parseReverseName(asInterpretedName(input))).toEqual(expected);
+      expect(parseReverseName(input)).toEqual(expected);
     });
   });
 
   negativeCases.forEach((input) => {
     it(`does not parse "${input}"`, () => {
-      // NOTE: directly cast to avoid running asInterpretedName validation
-      expect(parseReverseName(input as InterpretedName)).toBeNull();
+      expect(parseReverseName(input)).toBeNull();
     });
   });
 

--- a/packages/enssdk/src/lib/parse-reverse-name.ts
+++ b/packages/enssdk/src/lib/parse-reverse-name.ts
@@ -3,7 +3,7 @@ import { hexToBigInt } from "viem";
 import { toNormalizedAddress } from "./address";
 import { bigintToCoinType, DEFAULT_EVM_COIN_TYPE, ETH_COIN_TYPE } from "./coin-type";
 import { asLiteralLabel } from "./interpreted-names-and-labels";
-import type { CoinType, InterpretedName, LiteralLabel, NormalizedAddress } from "./types";
+import type { CoinType, LiteralLabel, NormalizedAddress } from "./types";
 
 /**
  * Matches an ENSIP-19 Reverse Name
@@ -37,11 +37,8 @@ const parseCoinTypeLabel = (coinTypeLabel: LiteralLabel): CoinType => {
 
 /**
  * Parse the address and coinType out of an ENSIP-19 reverse name.
- *
- * @dev accepts InterpretedName because all Reverse Names are Interpreted Names and we use this
- *   function in the context of the Resolution module in which all names are InterpretedNames.
  */
-export function parseReverseName(name: InterpretedName): {
+export function parseReverseName(name: string): {
   address: NormalizedAddress;
   coinType: CoinType;
 } | null {

--- a/packages/enssdk/src/lib/reverse-name.ts
+++ b/packages/enssdk/src/lib/reverse-name.ts
@@ -1,29 +1,26 @@
 import { DEFAULT_EVM_COIN_TYPE, ETH_COIN_TYPE } from "./coin-type";
-import {
-  asInterpretedLabel,
-  interpretedLabelsToInterpretedName,
-} from "./interpreted-names-and-labels";
-import type { CoinType, InterpretedLabel, InterpretedName, NormalizedAddress } from "./types";
+import { asLiteralLabel, literalLabelsToLiteralName } from "./interpreted-names-and-labels";
+import type { CoinType, LiteralLabel, LiteralName, NormalizedAddress } from "./types";
 
-const ADDR_LABEL = asInterpretedLabel("addr");
-const DEFAULT_LABEL = asInterpretedLabel("default");
-const REVERSE_LABEL = asInterpretedLabel("reverse");
+const ADDR_LABEL = asLiteralLabel("addr");
+const DEFAULT_LABEL = asLiteralLabel("default");
+const REVERSE_LABEL = asLiteralLabel("reverse");
 
 /**
  * Gets the Label used for the reverse names of subnames as per ENSIP-11 & ENSIP-19.
  *
  * @see https://docs.ens.domains/ensip/19/#reverse-resolution
  */
-export const addrReverseLabel = (address: NormalizedAddress): InterpretedLabel =>
-  address.slice(2) as InterpretedLabel;
+export const addrReverseLabel = (address: NormalizedAddress): LiteralLabel =>
+  address.slice(2) as LiteralLabel;
 
 /**
  * Converts `coinType` to prefix-free hex string.
  *
  * @see https://docs.ens.domains/ensip/19
  */
-export const coinTypeReverseLabel = (coinType: CoinType): InterpretedLabel =>
-  coinType.toString(16) as InterpretedLabel;
+export const coinTypeReverseLabel = (coinType: CoinType): LiteralLabel =>
+  coinType.toString(16) as LiteralLabel;
 
 /**
  * Gets the reverse name for an address according to ENSIP-11 & ENSIP-19.
@@ -42,10 +39,10 @@ export const coinTypeReverseLabel = (coinType: CoinType): InterpretedLabel =>
  * reverseName("0x1234", BigInt(0x5678)) // "1234.5678.reverse"
  * ```
  */
-export function reverseName(address: NormalizedAddress, coinType: CoinType): InterpretedName {
+export function reverseName(address: NormalizedAddress, coinType: CoinType): LiteralName {
   const label = addrReverseLabel(address);
 
-  const middle = ((): InterpretedLabel => {
+  const middle = ((): LiteralLabel => {
     switch (coinType) {
       case ETH_COIN_TYPE:
         return ADDR_LABEL;
@@ -56,5 +53,5 @@ export function reverseName(address: NormalizedAddress, coinType: CoinType): Int
     }
   })();
 
-  return interpretedLabelsToInterpretedName([label, middle, REVERSE_LABEL]);
+  return literalLabelsToLiteralName([label, middle, REVERSE_LABEL]);
 }


### PR DESCRIPTION
- more correct to accept string for parsing
- more correct to provide literal label given dependencies on this function