### PR TITLE
Fix type inference

### DIFF
--- a/apps/ensapi/src/handlers/api/explore/registrar-actions-api.routes.ts
+++ b/apps/ensapi/src/handlers/api/explore/registrar-actions-api.routes.ts
@@ -11,7 +11,8 @@ import {
   makeLowercaseAddressSchema,
   makeNodeSchema,
   makePositiveIntegerSchema,
-  makeRegistrarActionsResponseOkSchema,
+  makeRegistrarActionsResponseErrorSchema,
+  makeSerializedRegistrarActionsResponseOkSchema,
   makeUnixTimestampSchema,
   registrarActionsResponseOkExample,
 } from "@ensnode/ensnode-sdk/internal";
@@ -104,7 +105,7 @@ export const getRegistrarActionsRoute = createRoute({
       description: "Successfully retrieved registrar actions",
       content: {
         "application/json": {
-          schema: makeRegistrarActionsResponseOkSchema().openapi({
+          schema: makeSerializedRegistrarActionsResponseOkSchema().openapi({
             example: registrarActionsResponseOkExample,
           }),
         },
@@ -120,13 +121,11 @@ export const getRegistrarActionsRoute = createRoute({
     },
     500: {
       description: "Internal server error",
-      // TODO: fix the problem with typechecking.
-      // Throws error ```Type '{ currency: "ETH"; amount: string; }' is not assignable to type 'null'.```
-      // content: {
-      //   "application/json": {
-      //     schema: makeRegistrarActionsResponseErrorSchema("Registrar Actions Error Response"),
-      //   },
-      // },
+      content: {
+        "application/json": {
+          schema: makeRegistrarActionsResponseErrorSchema("Registrar Actions Error Response"),
+        },
+      },
     },
   },
 });
@@ -152,7 +151,7 @@ export const getRegistrarActionsByParentNodeRoute = createRoute({
       description: "Successfully retrieved registrar actions",
       content: {
         "application/json": {
-          schema: makeRegistrarActionsResponseOkSchema(
+          schema: makeSerializedRegistrarActionsResponseOkSchema(
             "Registrar Actions By ParentNode Response",
           ).openapi({
             example: registrarActionsResponseOkExample,
@@ -170,15 +169,13 @@ export const getRegistrarActionsByParentNodeRoute = createRoute({
     },
     500: {
       description: "Internal server error",
-      // TODO: fix the problem with typechecking.
-      // Throws error ```Type '{ currency: "ETH"; amount: string; }' is not assignable to type 'null'.```
-      // content: {
-      //   "application/json": {
-      //     schema: makeRegistrarActionsResponseErrorSchema(
-      //       "Registrar Actions By ParentNode Error Response",
-      //     ),
-      //   },
-      // },
+      content: {
+        "application/json": {
+          schema: makeRegistrarActionsResponseErrorSchema(
+            "Registrar Actions By ParentNode Error Response",
+          ),
+        },
+      },
     },
   },
 });

--- a/docs/docs.ensnode.io/ensapi-openapi.json
+++ b/docs/docs.ensnode.io/ensapi-openapi.json
@@ -1858,7 +1858,7 @@
                                           "baseCost": {
                                             "type": "object",
                                             "properties": {
-                                              "amount": { "type": "string", "pattern": "^d+$" },
+                                              "amount": { "type": "string", "pattern": "^\\d+$" },
                                               "currency": { "type": "string", "enum": ["ETH"] }
                                             },
                                             "required": ["amount", "currency"],
@@ -1867,7 +1867,7 @@
                                           "premium": {
                                             "type": "object",
                                             "properties": {
-                                              "amount": { "type": "string", "pattern": "^d+$" },
+                                              "amount": { "type": "string", "pattern": "^\\d+$" },
                                               "currency": { "type": "string", "enum": ["ETH"] }
                                             },
                                             "required": ["amount", "currency"],
@@ -1876,7 +1876,7 @@
                                           "total": {
                                             "type": "object",
                                             "properties": {
-                                              "amount": { "type": "string", "pattern": "^d+$" },
+                                              "amount": { "type": "string", "pattern": "^\\d+$" },
                                               "currency": { "type": "string", "enum": ["ETH"] }
                                             },
                                             "required": ["amount", "currency"],
@@ -1987,7 +1987,7 @@
                                           "baseCost": {
                                             "type": "object",
                                             "properties": {
-                                              "amount": { "type": "string", "pattern": "^d+$" },
+                                              "amount": { "type": "string", "pattern": "^\\d+$" },
                                               "currency": { "type": "string", "enum": ["ETH"] }
                                             },
                                             "required": ["amount", "currency"],
@@ -1996,7 +1996,7 @@
                                           "premium": {
                                             "type": "object",
                                             "properties": {
-                                              "amount": { "type": "string", "pattern": "^d+$" },
+                                              "amount": { "type": "string", "pattern": "^\\d+$" },
                                               "currency": { "type": "string", "enum": ["ETH"] }
                                             },
                                             "required": ["amount", "currency"],
@@ -2005,7 +2005,7 @@
                                           "total": {
                                             "type": "object",
                                             "properties": {
-                                              "amount": { "type": "string", "pattern": "^d+$" },
+                                              "amount": { "type": "string", "pattern": "^\\d+$" },
                                               "currency": { "type": "string", "enum": ["ETH"] }
                                             },
                                             "required": ["amount", "currency"],
@@ -2203,7 +2203,26 @@
               }
             }
           },
-          "500": { "description": "Internal server error" }
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "responseCode": { "type": "string", "enum": ["error"] },
+                    "error": {
+                      "type": "object",
+                      "properties": { "message": { "type": "string" }, "details": {} },
+                      "required": ["message"]
+                    }
+                  },
+                  "required": ["responseCode", "error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -2357,7 +2376,7 @@
                                           "baseCost": {
                                             "type": "object",
                                             "properties": {
-                                              "amount": { "type": "string", "pattern": "^d+$" },
+                                              "amount": { "type": "string", "pattern": "^\\d+$" },
                                               "currency": { "type": "string", "enum": ["ETH"] }
                                             },
                                             "required": ["amount", "currency"],
@@ -2366,7 +2385,7 @@
                                           "premium": {
                                             "type": "object",
                                             "properties": {
-                                              "amount": { "type": "string", "pattern": "^d+$" },
+                                              "amount": { "type": "string", "pattern": "^\\d+$" },
                                               "currency": { "type": "string", "enum": ["ETH"] }
                                             },
                                             "required": ["amount", "currency"],
@@ -2375,7 +2394,7 @@
                                           "total": {
                                             "type": "object",
                                             "properties": {
-                                              "amount": { "type": "string", "pattern": "^d+$" },
+                                              "amount": { "type": "string", "pattern": "^\\d+$" },
                                               "currency": { "type": "string", "enum": ["ETH"] }
                                             },
                                             "required": ["amount", "currency"],
@@ -2486,7 +2505,7 @@
                                           "baseCost": {
                                             "type": "object",
                                             "properties": {
-                                              "amount": { "type": "string", "pattern": "^d+$" },
+                                              "amount": { "type": "string", "pattern": "^\\d+$" },
                                               "currency": { "type": "string", "enum": ["ETH"] }
                                             },
                                             "required": ["amount", "currency"],
@@ -2495,7 +2514,7 @@
                                           "premium": {
                                             "type": "object",
                                             "properties": {
-                                              "amount": { "type": "string", "pattern": "^d+$" },
+                                              "amount": { "type": "string", "pattern": "^\\d+$" },
                                               "currency": { "type": "string", "enum": ["ETH"] }
                                             },
                                             "required": ["amount", "currency"],
@@ -2504,7 +2523,7 @@
                                           "total": {
                                             "type": "object",
                                             "properties": {
-                                              "amount": { "type": "string", "pattern": "^d+$" },
+                                              "amount": { "type": "string", "pattern": "^\\d+$" },
                                               "currency": { "type": "string", "enum": ["ETH"] }
                                             },
                                             "required": ["amount", "currency"],
@@ -2702,7 +2721,26 @@
               }
             }
           },
-          "500": { "description": "Internal server error" }
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "responseCode": { "type": "string", "enum": ["error"] },
+                    "error": {
+                      "type": "object",
+                      "properties": { "message": { "type": "string" }, "details": {} },
+                      "required": ["message"]
+                    }
+                  },
+                  "required": ["responseCode", "error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
         }
       }
     },

--- a/packages/ensnode-sdk/src/ensapi/api/registrar-actions/zod-schemas.ts
+++ b/packages/ensnode-sdk/src/ensapi/api/registrar-actions/zod-schemas.ts
@@ -2,11 +2,18 @@ import { namehashInterpretedName } from "enssdk";
 import { z } from "zod/v4";
 import type { ParsePayload } from "zod/v4/core";
 
-import { makeRegistrarActionSchema } from "../../../registrars/zod-schemas";
+import {
+  makeRegistrarActionSchema,
+  makeSerializedRegistrarActionSchema,
+} from "../../../registrars/zod-schemas";
 import { makeReinterpretedNameSchema, makeUnixTimestampSchema } from "../../../shared/zod-schemas";
 import { makeErrorResponseSchema } from "../shared/errors/zod-schemas";
 import { makeResponsePageContextSchema } from "../shared/pagination/zod-schemas";
 import { type NamedRegistrarAction, RegistrarActionsResponseCodes } from "./response";
+import {
+  SerializedNamedRegistrarAction,
+  SerializedRegistrarActionsResponseOk,
+} from "./serialized-response";
 
 function invariant_registrationLifecycleNodeMatchesName(ctx: ParsePayload<NamedRegistrarAction>) {
   const { name, action } = ctx.value;
@@ -32,6 +39,17 @@ export const makeNamedRegistrarActionSchema = (valueLabel: string = "Named Regis
       name: makeReinterpretedNameSchema(valueLabel),
     })
     .check(invariant_registrationLifecycleNodeMatchesName);
+
+/**
+ * Schema for {@link SerializedNamedRegistrarAction}.
+ */
+const makeSerializedNamedRegistrarActionSchema = (
+  valueLabel: string = "Serialized Named Registrar Action",
+) =>
+  z.object({
+    action: makeSerializedRegistrarActionSchema(valueLabel),
+    name: makeReinterpretedNameSchema(valueLabel),
+  });
 
 /**
  * Schema for {@link RegistrarActionsResponseOk}
@@ -67,3 +85,16 @@ export const makeRegistrarActionsResponseSchema = (
     makeRegistrarActionsResponseOkSchema(valueLabel),
     makeRegistrarActionsResponseErrorSchema(valueLabel),
   ]);
+
+/**
+ * Schema for {@link SerializedRegistrarActionsResponseOk}
+ */
+export const makeSerializedRegistrarActionsResponseOkSchema = (
+  valueLabel: string = "Serialized Registrar Actions Response OK",
+) =>
+  z.object({
+    responseCode: z.literal(RegistrarActionsResponseCodes.Ok),
+    registrarActions: z.array(makeSerializedNamedRegistrarActionSchema(valueLabel)),
+    pageContext: makeResponsePageContextSchema(`${valueLabel}.pageContext`),
+    accurateAsOf: makeUnixTimestampSchema(`${valueLabel}.accurateAsOf`),
+  });

--- a/packages/ensnode-sdk/src/registrars/zod-schemas.ts
+++ b/packages/ensnode-sdk/src/registrars/zod-schemas.ts
@@ -184,16 +184,12 @@ const EventIdsSchema = z
   .transform((v) => v as [RegistrarActionEventId, ...RegistrarActionEventId[]]);
 
 // Base schema without refinements - can be extended
-const makeBaseRegistrarActionSchemaWithoutCheck = (
-  valueLabel: string = "Base Registrar Action",
-) =>
+const makeBaseRegistrarActionSchemaWithoutCheck = (valueLabel: string = "Base Registrar Action") =>
   z.object({
     id: EventIdSchema,
     incrementalDuration: makeDurationSchema(`${valueLabel} Incremental Duration`),
     registrant: makeLowercaseAddressSchema(`${valueLabel} Registrant`),
-    registrationLifecycle: makeRegistrationLifecycleSchema(
-      `${valueLabel} Registration Lifecycle`,
-    ),
+    registrationLifecycle: makeRegistrationLifecycleSchema(`${valueLabel} Registration Lifecycle`),
     pricing: makeRegistrarActionPricingSchema(`${valueLabel} Pricing`),
     referral: makeRegistrarActionReferralSchema(`${valueLabel} Referral`),
     block: makeBlockRefSchema(`${valueLabel} Block`),
@@ -251,6 +247,7 @@ const makeSerializedRegistrarActionRenewalSchema = (valueLabel: string = "Serial
 export const makeSerializedRegistrarActionSchema = (
   valueLabel: string = "Serialized Registrar Action",
 ) =>
-  makeSerializedRegistrarActionRegistrationSchema(`${valueLabel} Registration`).or(
+  z.discriminatedUnion("type", [
+    makeSerializedRegistrarActionRegistrationSchema(`${valueLabel} Registration`),
     makeSerializedRegistrarActionRenewalSchema(`${valueLabel} Renewal`),
-  );
+  ]);

--- a/packages/ensnode-sdk/src/registrars/zod-schemas.ts
+++ b/packages/ensnode-sdk/src/registrars/zod-schemas.ts
@@ -11,6 +11,7 @@ import {
   makeLowercaseAddressSchema,
   makeNodeSchema,
   makePriceEthSchema,
+  makeSerializedPriceEthSchema,
   makeTransactionHashSchema,
   makeUnixTimestampSchema,
 } from "../shared/zod-schemas";
@@ -23,6 +24,8 @@ import {
   type RegistrarActionPricingUnknown,
   type RegistrarActionReferralAvailable,
   RegistrarActionTypes,
+  SerializedRegistrarAction,
+  SerializedRegistrarActionPricing,
 } from "./registrar-action";
 import type { RegistrationLifecycle } from "./registration-lifecycle";
 import { Subregistry } from "./subregistry";
@@ -85,6 +88,27 @@ const makeRegistrarActionPricingSchema = (valueLabel: string = "Registrar Action
         total: z.null(),
       })
       .transform((v) => v as RegistrarActionPricingUnknown),
+  ]);
+
+/**
+ * Schema for parsing objects into {@link SerializedRegistrarActionPricing}.
+ */
+export const makeSerializedRegistrarActionPricingSchema = (
+  valueLabel: string = "Serialized Registrar Action Pricing",
+) =>
+  z.union([
+    // pricing available
+    z.object({
+      baseCost: makeSerializedPriceEthSchema(`${valueLabel} Base Cost`),
+      premium: makeSerializedPriceEthSchema(`${valueLabel} Premium`),
+      total: makeSerializedPriceEthSchema(`${valueLabel} Total`),
+    }),
+    // pricing unknown
+    z.object({
+      baseCost: z.null(),
+      premium: z.null(),
+      total: z.null(),
+    }),
   ]);
 
 /** Invariant: decodedReferrer is based on encodedReferrer */
@@ -194,3 +218,32 @@ export const makeRegistrarActionSchema = (valueLabel: string = "Registrar Action
     makeRegistrarActionRegistrationSchema(`${valueLabel} Registration`),
     makeRegistrarActionRenewalSchema(`${valueLabel} Renewal`),
   ]);
+
+const makeSerializedBaseRegistrarActionSchema = (
+  valueLabel: string = "Serialized Base Registrar Action",
+) =>
+  makeBaseRegistrarActionSchema(valueLabel).extend({
+    pricing: makeSerializedRegistrarActionPricingSchema(`${valueLabel} Pricing`),
+  });
+
+const makeSerializedRegistrarActionRegistrationSchema = (
+  valueLabel: string = "Serialized Registration",
+) =>
+  makeSerializedBaseRegistrarActionSchema(valueLabel).extend({
+    type: z.literal(RegistrarActionTypes.Registration),
+  });
+
+const makeSerializedRegistrarActionRenewalSchema = (valueLabel: string = "Serialized Renewal") =>
+  makeSerializedBaseRegistrarActionSchema(valueLabel).extend({
+    type: z.literal(RegistrarActionTypes.Renewal),
+  });
+
+/**
+ * Schema for  {@link SerializedRegistrarAction}
+ */
+export const makeSerializedRegistrarActionSchema = (
+  valueLabel: string = "Serialized Registrar Action",
+) =>
+  makeSerializedRegistrarActionRegistrationSchema(`${valueLabel} Registration`).or(
+    makeSerializedRegistrarActionRenewalSchema(`${valueLabel} Renewal`),
+  );

--- a/packages/ensnode-sdk/src/registrars/zod-schemas.ts
+++ b/packages/ensnode-sdk/src/registrars/zod-schemas.ts
@@ -183,22 +183,29 @@ const EventIdsSchema = z
   .min(1)
   .transform((v) => v as [RegistrarActionEventId, ...RegistrarActionEventId[]]);
 
+// Base schema without refinements - can be extended
+const makeBaseRegistrarActionSchemaWithoutCheck = (
+  valueLabel: string = "Base Registrar Action",
+) =>
+  z.object({
+    id: EventIdSchema,
+    incrementalDuration: makeDurationSchema(`${valueLabel} Incremental Duration`),
+    registrant: makeLowercaseAddressSchema(`${valueLabel} Registrant`),
+    registrationLifecycle: makeRegistrationLifecycleSchema(
+      `${valueLabel} Registration Lifecycle`,
+    ),
+    pricing: makeRegistrarActionPricingSchema(`${valueLabel} Pricing`),
+    referral: makeRegistrarActionReferralSchema(`${valueLabel} Referral`),
+    block: makeBlockRefSchema(`${valueLabel} Block`),
+    transactionHash: makeTransactionHashSchema(`${valueLabel} Transaction Hash`),
+    eventIds: EventIdsSchema,
+  });
+
+// Base schema with refinements - used for parsing/validation
 export const makeBaseRegistrarActionSchema = (valueLabel: string = "Base Registrar Action") =>
-  z
-    .object({
-      id: EventIdSchema,
-      incrementalDuration: makeDurationSchema(`${valueLabel} Incremental Duration`),
-      registrant: makeLowercaseAddressSchema(`${valueLabel} Registrant`),
-      registrationLifecycle: makeRegistrationLifecycleSchema(
-        `${valueLabel} Registration Lifecycle`,
-      ),
-      pricing: makeRegistrarActionPricingSchema(`${valueLabel} Pricing`),
-      referral: makeRegistrarActionReferralSchema(`${valueLabel} Referral`),
-      block: makeBlockRefSchema(`${valueLabel} Block`),
-      transactionHash: makeTransactionHashSchema(`${valueLabel} Transaction Hash`),
-      eventIds: EventIdsSchema,
-    })
-    .check(invariant_eventIdsInitialElementIsTheActionId);
+  makeBaseRegistrarActionSchemaWithoutCheck(valueLabel).check(
+    invariant_eventIdsInitialElementIsTheActionId,
+  );
 
 export const makeRegistrarActionRegistrationSchema = (valueLabel: string = "Registration ") =>
   makeBaseRegistrarActionSchema(valueLabel).extend({
@@ -222,7 +229,7 @@ export const makeRegistrarActionSchema = (valueLabel: string = "Registrar Action
 const makeSerializedBaseRegistrarActionSchema = (
   valueLabel: string = "Serialized Base Registrar Action",
 ) =>
-  makeBaseRegistrarActionSchema(valueLabel).extend({
+  makeBaseRegistrarActionSchemaWithoutCheck(valueLabel).extend({
     pricing: makeSerializedRegistrarActionPricingSchema(`${valueLabel} Pricing`),
   });
 

--- a/packages/ensnode-sdk/src/shared/zod-schemas.ts
+++ b/packages/ensnode-sdk/src/shared/zod-schemas.ts
@@ -242,7 +242,9 @@ const makePriceAmountSchema = (valueLabel: string = "Amount") =>
     });
 
 const makeSerializedCurrencyAmountSchema = (valueLabel: string = "Serialized Currency Amount") =>
-  z.string({ error: `${valueLabel} must be a string.` });
+  z.string({ error: `${valueLabel} must be a string.` }).regex(/^\d+$/, {
+    error: `${valueLabel} can only contain digits (0-9) and must represent a non-negative integer.`,
+  });
 
 export const makePriceCurrencySchema = (
   currency: CurrencyId,

--- a/packages/ensnode-sdk/src/shared/zod-schemas.ts
+++ b/packages/ensnode-sdk/src/shared/zod-schemas.ts
@@ -29,6 +29,7 @@ import {
   type PriceDai,
   type PriceEth,
   type PriceUsdc,
+  type SerializedPriceEth,
 } from "./currencies";
 import type { BlockRef, Datetime, Duration, UnixTimestamp } from "./types";
 
@@ -240,12 +241,27 @@ const makePriceAmountSchema = (valueLabel: string = "Amount") =>
       error: `${valueLabel} must not be negative.`,
     });
 
+const makeSerializedCurrencyAmountSchema = (valueLabel: string = "Serialized Currency Amount") =>
+  z.string({ error: `${valueLabel} must be a string.` });
+
 export const makePriceCurrencySchema = (
   currency: CurrencyId,
   valueLabel: string = "Price Currency",
 ) =>
   z.strictObject({
     amount: makePriceAmountSchema(`${valueLabel} amount`),
+
+    currency: z.literal(currency, {
+      error: `${valueLabel} currency must be set to '${currency}'.`,
+    }),
+  });
+
+export const makeSerializedPriceCurrencySchema = (
+  currency: CurrencyId,
+  valueLabel: string = "Price Currency",
+) =>
+  z.strictObject({
+    amount: makeSerializedCurrencyAmountSchema(`${valueLabel} amount`),
 
     currency: z.literal(currency, {
       error: `${valueLabel} currency must be set to '${currency}'.`,
@@ -271,6 +287,11 @@ export const makePriceSchema = (valueLabel: string = "Price") =>
  */
 export const makePriceEthSchema = (valueLabel: string = "Price ETH") =>
   makePriceCurrencySchema(CurrencyIds.ETH, valueLabel).transform((v) => v as PriceEth);
+
+export const makeSerializedPriceEthSchema = (valueLabel: string = "Serialized Price ETH") =>
+  makeSerializedPriceCurrencySchema(CurrencyIds.ETH, valueLabel).transform(
+    (v) => v as SerializedPriceEth,
+  );
 
 /**
  * Schema for {@link PriceUsdc} type.


### PR DESCRIPTION
For OpenAPI Spec, we use the Zod schemas that describe "serialized" data model that is in fact returned in HTTP responses

# Lite PR

[Tip: Review docs on the ENSNode PR process](https://ensnode.io/docs/contributing/prs)

## Summary

- Applied the fix to use `makeSerializedRegistrarActionsResponseOkSchema` to describe the "serialized" data model returned from the Registrar Actions API handlers.

---

## Why

The type error exists in registrar-actions-api.ts (the handler), not in the routes file. The handler returns SerializedRegistrarActionsResponseOk (with string amounts), but the route schema expects domain types (bigint amounts).

When the 500 response was commented out, the route definition was incomplete, which likely caused TypeScript to skip full type validation between the handler return type and the route's expected response type. The `createRoute` function from `@hono/zod-openapi` uses the response schemas to infer what handlers should return - an incomplete route definition may not trigger this inference properly.

The real issue is the mismatch between:
- Registrar Actions API Handler returns: `SerializedRegistrarActionsResponseOk` (string amounts)
- Registrar Actions API Route Schema expects: Domain types from `makeRegistrarActionsResponseOkSchema` (bigint amounts)

---

## Testing

- Ran testing suite, typechecks.

---

## Notes for Reviewer (Optional)

- Anything non-obvious or worth a heads-up.
- Resolves #1954 

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)
