### PR TITLE
refactor(api): remove deprecated version endpoint and update documentation to reflect changes in public config endpoint

### DIFF
--- a/.changeset/odd-seahorses-sleep.md
+++ b/.changeset/odd-seahorses-sleep.md
@@ -1,0 +1,6 @@
+---
+"@ensnode/ensrainbow-sdk": minor
+---
+
+Remove deprecated ENSRainbow `version()` client method and `Version*` types (the `/v1/version` endpoint has been removed in favor of `/v1/config`).
+

--- a/apps/ensrainbow/src/commands/server-command.test.ts
+++ b/apps/ensrainbow/src/commands/server-command.test.ts
@@ -157,20 +157,6 @@ describe("Server Command Tests", () => {
     });
   });
 
-  describe("GET /v1/version", () => {
-    it("should return version information", async () => {
-      const response = await fetch(`http://localhost:${nonDefaultPort}/v1/version`);
-      expect(response.status).toBe(200);
-      const data = await response.json();
-
-      expect(data.status).toEqual(StatusCode.Success);
-      expect(typeof data.versionInfo.version).toBe("string");
-      expect(typeof data.versionInfo.dbSchemaVersion).toBe("number");
-      expect(typeof data.versionInfo.labelSet.labelSetId).toBe("string");
-      expect(typeof data.versionInfo.labelSet.highestLabelSetVersion).toBe("number");
-    });
-  });
-
   describe("GET /v1/config", () => {
     it("should return config snapshot from startup", async () => {
       // The config is built once on startup with count = 0 (set in beforeAll)
@@ -227,9 +213,6 @@ describe("Server Command Tests", () => {
           method: "OPTIONS",
         }),
         fetch(`http://localhost:${nonDefaultPort}/v1/config`, {
-          method: "OPTIONS",
-        }),
-        fetch(`http://localhost:${nonDefaultPort}/v1/version`, {
           method: "OPTIONS",
         }),
       ]);

--- a/apps/ensrainbow/src/lib/api.ts
+++ b/apps/ensrainbow/src/lib/api.ts
@@ -1,5 +1,3 @@
-import packageJson from "@/../package.json" with { type: "json" };
-
 import type { Context as HonoContext } from "hono";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
@@ -14,7 +12,6 @@ import {
 } from "@ensnode/ensnode-sdk";
 import { type EnsRainbow, ErrorCode, StatusCode } from "@ensnode/ensrainbow-sdk";
 
-import { DB_SCHEMA_VERSION } from "@/lib/database";
 import type { ENSRainbowServer } from "@/lib/server";
 import { getErrorMessage } from "@/utils/error-utils";
 import { logger } from "@/utils/logger";
@@ -100,21 +97,6 @@ export function createApi(
 
   api.get("/v1/config", (c: HonoContext) => {
     return c.json(publicConfig);
-  });
-
-  /**
-   * @deprecated Use GET /v1/config instead. This endpoint will be removed in a future version.
-   */
-  api.get("/v1/version", (c: HonoContext) => {
-    const result: EnsRainbow.VersionResponse = {
-      status: StatusCode.Success,
-      versionInfo: {
-        version: packageJson.version,
-        dbSchemaVersion: DB_SCHEMA_VERSION,
-        labelSet: server.serverLabelSet,
-      },
-    };
-    return c.json(result);
   });
 
   return api;

--- a/docs/ensnode.io/src/content/docs/ensrainbow/concepts/versioning.mdx
+++ b/docs/ensnode.io/src/content/docs/ensrainbow/concepts/versioning.mdx
@@ -9,7 +9,7 @@ sidebar:
 ENSRainbow uses **three distinct version numbers**—each serving a different purpose.
 
 ## 1. ENSRainbow Software Version
-The semantic version of the Node.js application itself (e.g. `v0.4.2`).
+The semantic version of the Node.js application itself (e.g. `0.4.2`).
 - Bumped when new features, fixes, or breaking changes are released.
 - Shown in `/v1/config` under the `version` field.
 

--- a/docs/ensnode.io/src/content/docs/ensrainbow/concepts/versioning.mdx
+++ b/docs/ensnode.io/src/content/docs/ensrainbow/concepts/versioning.mdx
@@ -11,7 +11,7 @@ ENSRainbow uses **three distinct version numbers**—each serving a different pu
 ## 1. ENSRainbow Software Version
 The semantic version of the Node.js application itself (e.g. `v0.4.2`).
 - Bumped when new features, fixes, or breaking changes are released.
-- Shown in `/v1/version` under the `version` field.
+- Shown in `/v1/config` under the `version` field.
 
 ## 2. Database Schema Version (`DB_SCHEMA_VERSION`)
 Specifies the expected on-disk structure of the LevelDB database as well as the expected format of the downloadable pre-built LevelDB databases.

--- a/docs/ensnode.io/src/content/docs/ensrainbow/contributing/index.mdx
+++ b/docs/ensnode.io/src/content/docs/ensrainbow/contributing/index.mdx
@@ -36,7 +36,7 @@ For focused guidance on specific topics, check out these dedicated pages:
 
 Follow these steps to start contributing to ENSRainbow:
 
-1. **Follow ENSNode's [contribution guide](/docs/contributing/)** to prepare your workspace environment & install dependencies
+1. **Follow ENSNode's [contribution guide](/docs/contributing)** to prepare your workspace environment & install dependencies
 2. **Choose your development path** using the focused guides above
 3. **Start with [Local Development](/ensrainbow/contributing/local-development/)** for the quickest way to get ENSRainbow running locally
 

--- a/docs/ensnode.io/src/content/docs/ensrainbow/usage/api.mdx
+++ b/docs/ensnode.io/src/content/docs/ensrainbow/usage/api.mdx
@@ -13,7 +13,7 @@ sidebar:
 | `GET /health` | Liveness probe for orchestration | `{ status: "ok" }` |
 | `GET /v1/heal/{labelhash}` | Heal a single labelhash | `HealSuccess`, `HealError` |
 | `GET /v1/labels/count` | Current healable label count | `CountSuccess`, `CountServerError` |
-| `GET /v1/version` | Server & database schema info plus label set details | `VersionInfo` |
+| `GET /v1/config` | Public service config (version, label set, records count) | `ENSRainbowPublicConfig` |
 
 :::tip[Deterministic Results]
 Pin `labelSetVersion` in your client if you need **deterministic results** across time. See the [Label Sets & Versioning guide](/ensrainbow/concepts/label-sets-and-versioning/) for details.
@@ -148,29 +148,28 @@ Success Response:
 }
 ```
 
-## Get Version Information
+## Get Public Config
 
 ```bash
-curl https://api.ensrainbow.io/v1/version
+curl https://api.ensrainbow.io/v1/config
 ```
 
 Success Response:
 
 ```json
 {
-  "status": "success",
   "version": "0.1.0",
-  "dbSchemaVersion": 3,
   "labelSet": {
     "labelSetId": "subgraph",
     "highestLabelSetVersion": 0
-  }
+  },
+  "recordsCount": 133856894
 }
 ```
 
 The response contains:
 - `version`: The current version of ENSRainbow
-- `dbSchemaVersion`: The current schema version of the database
 - `labelSet`: The label set of the loaded database
   - `labelSetId`: The label set ID of the loaded database
   - `highestLabelSetVersion`: The highest label set version available in the database
+- `recordsCount`: The total count of labels that can be healed by the ENSRainbow instance

--- a/docs/ensnode.io/src/content/docs/ensrainbow/usage/api.mdx
+++ b/docs/ensnode.io/src/content/docs/ensrainbow/usage/api.mdx
@@ -13,7 +13,7 @@ sidebar:
 | `GET /health` | Liveness probe for orchestration | `{ status: "ok" }` |
 | `GET /v1/heal/{labelhash}` | Heal a single labelhash | `HealSuccess`, `HealError` |
 | `GET /v1/labels/count` | Current healable label count | `CountSuccess`, `CountServerError` |
-| `GET /v1/config` | Public service config (version, label set, records count) | `ENSRainbowPublicConfig` |
+| `GET /v1/config` | Public service config (version, label set, records count) | `EnsRainbowPublicConfig` |
 
 :::tip[Deterministic Results]
 Pin `labelSetVersion` in your client if you need **deterministic results** across time. See the [Label Sets & Versioning guide](/ensrainbow/concepts/label-sets-and-versioning/) for details.

--- a/packages/ensrainbow-sdk/src/client.test.ts
+++ b/packages/ensrainbow-sdk/src/client.test.ts
@@ -271,30 +271,6 @@ describe("EnsRainbowApiClient", () => {
     } satisfies EnsRainbow.HealthResponse);
   });
 
-  it("should return version information", async () => {
-    mockFetch.mockResolvedValueOnce({
-      json: () =>
-        Promise.resolve({
-          status: StatusCode.Success,
-          versionInfo: {
-            version: "1.0.0",
-            dbSchemaVersion: 1,
-            labelSet: {
-              labelSetId: "test-label-set-id",
-              highestLabelSetVersion: 123,
-            },
-          },
-        } satisfies EnsRainbow.VersionResponse),
-    });
-
-    const response = await client.version();
-
-    expect(response satisfies EnsRainbow.VersionResponse).toBeTruthy();
-    expect(response.status).toEqual(StatusCode.Success);
-    expect(typeof response.versionInfo.version === "string").toBeTruthy();
-    expect(typeof response.versionInfo.dbSchemaVersion === "number").toBeTruthy();
-  });
-
   describe("config", () => {
     it("should request /v1/config and return public config on success", async () => {
       const configData: EnsRainbow.ENSRainbowPublicConfig = {

--- a/packages/ensrainbow-sdk/src/client.ts
+++ b/packages/ensrainbow-sdk/src/client.ts
@@ -6,7 +6,6 @@ import {
   type Cache,
   type EnsRainbowClientLabelSet,
   type EnsRainbowPublicConfig,
-  type EnsRainbowServerLabelSet,
   LruCache,
 } from "@ensnode/ensnode-sdk";
 
@@ -32,13 +31,6 @@ export namespace EnsRainbow {
     heal(labelHash: LabelHash | EncodedLabelHash | string): Promise<HealResponse>;
 
     health(): Promise<HealthResponse>;
-
-    /**
-     * Get the version information of the ENSRainbow service
-     *
-     * @deprecated Use {@link ApiClient.config} instead. This method will be removed in a future version.
-     */
-    version(): Promise<VersionResponse>;
 
     getOptions(): Readonly<EnsRainbowApiClientOptions>;
   }
@@ -129,38 +121,6 @@ export namespace EnsRainbow {
   }
 
   export type CountResponse = CountSuccess | CountServerError;
-
-  /**
-   * ENSRainbow version information.
-   *
-   * @deprecated Use {@link ENSRainbowPublicConfig} instead. This type will be removed in a future version.
-   */
-  export interface VersionInfo {
-    /**
-     * ENSRainbow version.
-     */
-    version: string;
-
-    /**
-     * ENSRainbow database schema version.
-     */
-    dbSchemaVersion: number;
-
-    /**
-     * The EnsRainbowServerLabelSet managed by the ENSRainbow server.
-     */
-    labelSet: EnsRainbowServerLabelSet;
-  }
-
-  /**
-   * Interface for the version endpoint response
-   *
-   * @deprecated Use {@link ENSRainbowPublicConfig} instead. This type will be removed in a future version.
-   */
-  export interface VersionResponse {
-    status: typeof StatusCode.Success;
-    versionInfo: VersionInfo;
-  }
 
   /**
    * Complete public configuration object for ENSRainbow.
@@ -403,38 +363,6 @@ export class EnsRainbowApiClient implements EnsRainbow.ApiClient {
     }
 
     return response.json() as Promise<EnsRainbow.ENSRainbowPublicConfig>;
-  }
-
-  /**
-   * Get the version information of the ENSRainbow service
-   *
-   * @deprecated Use {@link EnsRainbowApiClient.config} instead. This method will be removed in a future version.
-   * @returns the version information of the ENSRainbow service
-   * @throws if the request fails due to network failures, DNS lookup failures, request
-   * timeouts, CORS violations, or invalid URLs
-   * @example
-   * ```typescript
-   * const response = await client.version();
-   *
-   * console.log(response);
-   *
-   * // {
-   * //   "status": "success",
-   * //   "versionInfo": {
-   * //     "version": "0.1.0",
-   * //     "dbSchemaVersion": 2,
-   * //     "labelSet": {
-   * //       "labelSetId": "subgraph",
-   * //       "labelSetVersion": 0
-   * //     }
-   * //   }
-   * // }
-   * ```
-   */
-  async version(): Promise<EnsRainbow.VersionResponse> {
-    const response = await fetch(new URL("/v1/version", this.options.endpointUrl));
-
-    return response.json() as Promise<EnsRainbow.VersionResponse>;
   }
 
   /**


### PR DESCRIPTION
# Lite PR

[Tip: Review docs on the ENSNode PR process](https://ensnode.io/docs/contributing/prs)

## Summary

- Removed ENSRainbow `GET /v1/version` endpoint (deprecated in favor of `GET /v1/config`).
- Removed the deprecated ENSRainbow SDK `version()` client method and associated types/tests.
- Updated ENSRainbow docs to reference `GET /v1/config` instead of `GET /v1/version`.

---

## Why

- `/v1/version` was already deprecated and duplicated the newer `/v1/config` discovery surface; removing it reduces maintenance and avoids clients relying on a legacy endpoint.

---

## Testing



---

## Notes for Reviewer (Optional)

- In-repo usage of `/v1/version` was limited to ENSRainbow’s own integration test and the deprecated `@ensnode/ensrainbow-sdk` `version()` method; ENSIndexer already uses `ensRainbowClient.config()`.

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)