### PR TITLE
chore: fix integration-test-env version to monorepo version

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -20,6 +20,7 @@
       "@ensnode/ensdb-sdk",
       "@ensnode/ensnode-react",
       "@ensnode/ensnode-sdk",
+      "@ensnode/integration-test-env",
       "@ensnode/ponder-sdk",
       "@ensnode/ponder-subgraph",
       "@ensnode/shared-configs",

--- a/packages/integration-test-env/package.json
+++ b/packages/integration-test-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ensnode/integration-test-env",
-  "version": "0.0.3",
+  "version": "1.9.0",
   "private": true,
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

- add `@ensnode/integration-test-env` to the changesets `fixed` group
- bump `@ensnode/integration-test-env` from `0.0.3` to `1.9.0` to match the rest of the monorepo

## Why

- keeps the integration test env versioned in lockstep with the packages it orchestrates, same as every other ensnode package

## Testing

- config-only change; verified the diff and that no other package references the old `0.0.3` version

## Notes for Reviewer (Optional)

- no new changeset added since this is tooling config and the next release will naturally bump the package along with the rest of the fixed group

## Checklist

- [x] This PR does **not** change runtime behavior or semantics
- [x] This PR is low-risk and safe to review quickly

🤖 Generated with [Claude Code](https://claude.com/claude-code)