### PR TITLE
chore: add astro-xss vuln to ignore

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,3 +1,7 @@
 [[IgnoredVulns]]
 id = "GHSA-gpj5-g38j-94v9"
 reason = "drizzle-orm SQL injection via dynamic identifiers (CVE-2026-39356). Not exploitable in ENSNode: we use only static Ponder schema objects, never pass user input to sql.identifier() or .as(). Avoids a fragile drizzle version bump that breaks ponder-subgraph DTS generation."
+
+[[IgnoredVulns]]
+id = "GHSA-j687-52p2-xcff"
+reason = "Astro XSS via define:vars on <script> tags. Not exploitable in ENSNode: docs sites are statically generated and do not pass user-controlled input to define:vars. Upgrading to the fixed version (astro 6.x) requires a major version bump that needs broader testing."


### PR DESCRIPTION
## Summary

Added `GHSA-j687-52p2-xcff` to ignore list of vuln for OSV-Scanner

---

## Why

CICD currently fails: [gh action run](https://github.com/namehash/ensnode/actions/runs/24747876975/job/72403982138)

---

## Testing

```bash
brew install osv-scanner
osv-scanner --config osv-scanner.toml -r ./
```

dont forget to uninstall!! 52 Mb!!!

```
> brew uninstall osv-scanner  
Uninstalling /opt/homebrew/Cellar/osv-scanner/2.3.5... (7 files, 52.3MB)
```

---


## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)
