### PR TITLE
hotfix: install pg_trgm in ensnode schema + set search_path

### DIFF
--- a/.changeset/eight-plums-accept.md
+++ b/.changeset/eight-plums-accept.md
@@ -1,0 +1,6 @@
+---
+"@ensnode/ensdb-sdk": patch
+"ensindexer": patch
+---
+
+Hotfix: moved the pg_trgm extesion into the ensnode schema to avoid implicit dependency on 'public' schema existing.

--- a/.changeset/eight-plums-accept.md
+++ b/.changeset/eight-plums-accept.md
@@ -3,4 +3,4 @@
 "ensindexer": patch
 ---
 
-Hotfix: moved the pg_trgm extesion into the ensnode schema to avoid implicit dependency on 'public' schema existing.
+Hotfix: moved the pg_trgm extension into the ensnode schema to avoid implicit dependency on 'public' schema existing.

--- a/apps/ensindexer/ponder/src/api/index.ts
+++ b/apps/ensindexer/ponder/src/api/index.ts
@@ -11,22 +11,20 @@ import { logger } from "@/lib/logger";
 
 import ensNodeApi from "./handlers/ensnode-api";
 
-// The entry point for the ENSDb Writer Worker. It must be placed inside
-// the `api` directory of the Ponder app to avoid the following build issue:
-// Error: Invalid dependency graph. Config, schema, and indexing function files
-// cannot import objects from the API function file "src/api/index.ts".
 // Before starting the ENSDb Writer Worker, we need to ensure that
 // the ENSNode Schema in ENSDb is up to date by running any pending migrations.
-migrateEnsNodeSchema()
-  .then(startEnsDbWriterWorker)
-  .catch((error) => {
-    logger.error({
-      msg: "Failed to initialize ENSNode metadata",
-      error,
-      module: "ponder-api",
-    });
-    process.exit(1);
+await migrateEnsNodeSchema().catch((error) => {
+  logger.error({
+    msg: "Failed to initialize ENSNode metadata",
+    error,
+    module: "ponder-api",
   });
+  process.exitCode = 1;
+  throw error;
+});
+
+// The entry point for the ENSDb Writer Worker.
+startEnsDbWriterWorker();
 
 const app = new Hono();
 

--- a/apps/ensindexer/src/ponder/config.ts
+++ b/apps/ensindexer/src/ponder/config.ts
@@ -1,5 +1,7 @@
 import config from "@/config";
 
+import { ENSDB_CONNECTION_OPTIONS } from "@ensnode/ensdb-sdk";
+
 import { mergePonderConfigs } from "@/lib/merge-ponder-configs";
 import { ALL_PLUGINS, type AllPluginsMergedConfig } from "@/plugins";
 
@@ -55,8 +57,9 @@ ponderConfig.ordering = "omnichain";
 // However, we want Ponder to always use the `ENSDB_URL` environment variable instead and so
 // we make explicit use of it here.
 ponderConfig.database = {
-  connectionString: config.ensDbUrl,
   kind: "postgres",
+  connectionString: config.ensDbUrl,
+  poolConfig: { options: ENSDB_CONNECTION_OPTIONS },
 };
 
 export default ponderConfig;

--- a/docs/ensnode.io/ensapi-openapi.json
+++ b/docs/ensnode.io/ensapi-openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "ENSApi APIs",
-    "version": "1.9.0",
+    "version": "1.10.0",
     "description": "APIs for ENS resolution, navigating the ENS nameforest, and metadata about an ENSNode"
   },
   "servers": [

--- a/packages/ensdb-sdk/migrations/0001_enable_ext_pg_trgm.sql
+++ b/packages/ensdb-sdk/migrations/0001_enable_ext_pg_trgm.sql
@@ -1,3 +1,5 @@
--- This migration enables the pg_trgm extension, which is used for trigram-based indexing and
--- searching in PostgreSQL.
-CREATE EXTENSION IF NOT EXISTS pg_trgm;
+-- Enable the pg_trgm extension in the 'ensnode' schema (created by migration 0000).
+-- Installing into 'ensnode' rather than the default creation schema avoids a dependency
+-- on 'public' existing, and lets the connection's search_path put this extension's
+-- operators/opclasses (e.g. gin_trgm_ops) on the lookup path for trigram indexes.
+CREATE EXTENSION IF NOT EXISTS pg_trgm SCHEMA "ensnode";

--- a/packages/ensdb-sdk/src/client/ensdb-config.ts
+++ b/packages/ensdb-sdk/src/client/ensdb-config.ts
@@ -39,3 +39,5 @@ export const ENSDB_SCHEMA_CHECKSUM = getDrizzleSchemaChecksum({
   ...abstractEnsIndexerSchema,
   ...ensNodeSchema,
 });
+
+export { ENSDB_CONNECTION_OPTIONS } from "../lib/drizzle";

--- a/packages/ensdb-sdk/src/lib/drizzle.test.ts
+++ b/packages/ensdb-sdk/src/lib/drizzle.test.ts
@@ -178,7 +178,7 @@ describe("buildEnsDbDrizzleClient", () => {
     buildEnsDbDrizzleClient(connectionString, concreteEnsIndexerSchema);
 
     expect(drizzle).toHaveBeenCalledWith({
-      connection: connectionString,
+      connection: { connectionString, options: expect.stringContaining("search_path=ensnode") },
       schema: expect.objectContaining({
         metadata: expect.anything(),
       }),

--- a/packages/ensdb-sdk/src/lib/drizzle.ts
+++ b/packages/ensdb-sdk/src/lib/drizzle.ts
@@ -15,6 +15,18 @@ import * as ensNodeSchema from "../ensnode";
 import { createChecksum } from "./checksum";
 
 /**
+ * PostgreSQL startup `options` string for ENSDb connections.
+ *
+ * Sets `search_path` so unqualified references (notably the `gin_trgm_ops`
+ * opclass from the pg_trgm extension, installed in the `ensnode` schema by
+ * migration 0001) resolve correctly at query and index-creation time.
+ *
+ * Pass via node-postgres `PoolConfig.options` (e.g. Ponder's
+ * `database.poolConfig.options`) or Drizzle's connection config.
+ */
+export const ENSDB_CONNECTION_OPTIONS = "-c search_path=ensnode,public";
+
+/**
  * Abstract ENSIndexer Schema
  *
  * Represents the "abstract" ENSIndexer Schema definition, where tables do not reference
@@ -164,7 +176,7 @@ export function buildEnsDbDrizzleClient<ConcreteEnsIndexerSchema extends Abstrac
   const ensDbSchema = buildEnsDbSchema<ConcreteEnsIndexerSchema>(concreteEnsIndexerSchema);
 
   return drizzle({
-    connection: connectionString,
+    connection: { connectionString, options: ENSDB_CONNECTION_OPTIONS },
     schema: ensDbSchema,
     casing: "snake_case",
     logger,


### PR DESCRIPTION
## Summary
- Move the `pg_trgm` extension into the `ensnode` schema (migration 0001) so install no longer implicitly depends on `public` existing.
- Export `ENSDB_CONNECTION_OPTIONS` from `@ensnode/ensdb-sdk` and pass `-c search_path=ensnode,public` to both the ensdb-sdk drizzle client and Ponder's pool config (`admin`/`user`/`readonly`/`sync`) so `gin_trgm_ops` resolves when Ponder creates the trigram index on `subgraph_domain.name`.
- the silent 'failure' wasn't actually a failure because the extension is correctly installed into the ENS node schema, because the migrations run in that context, but the search path wasn't updated. Now we explicitly specify the schema and inject the correct search path into all of our database connections. 

## Why
On a production database without a `public` schema, `CREATE EXTENSION IF NOT EXISTS pg_trgm` (no `SCHEMA` clause) fails with "no schema has been selected to create in" — Postgres picks the first writable schema in `search_path` (default `"$user", public`), and if neither resolves, it errors. The error was also effectively silent because of the schema actually being installed into "ensnode" but not in the search path.

## Test plan
- manual