### PR TITLE
Fix ENSNode Schema migrations execution

### DIFF
--- a/.changeset/tough-clubs-eat.md
+++ b/.changeset/tough-clubs-eat.md
@@ -1,5 +1,5 @@
 ---
-"@ensnode/ensdb-sdk": minor
+"@ensnode/ensdb-sdk": patch
 ---
 
 Made `EnsDbWriter.migrateEnsNodeSchema` race-condition safe.

--- a/.changeset/tough-clubs-eat.md
+++ b/.changeset/tough-clubs-eat.md
@@ -1,0 +1,5 @@
+---
+"@ensnode/ensdb-sdk": minor
+---
+
+Made `EnsDbWriter.migrateEnsNodeSchema` race-condition safe.

--- a/packages/ensdb-sdk/src/client/ensdb-writer.test.ts
+++ b/packages/ensdb-sdk/src/client/ensdb-writer.test.ts
@@ -11,10 +11,19 @@ import * as ensDbClientMock from "./ensdb-client.mock";
 import { EnsDbWriter } from "./ensdb-writer";
 import { EnsNodeMetadataKeys } from "./ensnode-metadata";
 
+const executeMock = vi.fn(async () => undefined);
 const onConflictDoUpdateMock = vi.fn(async () => undefined);
 const valuesMock = vi.fn(() => ({ onConflictDoUpdate: onConflictDoUpdateMock }));
 const insertMock = vi.fn(() => ({ values: valuesMock }));
-const drizzleClientMock = { insert: insertMock } as any;
+const transactionMock = vi.fn(async (callback: (tx: any) => Promise<void>) => {
+  const tx = { execute: executeMock, insert: insertMock };
+  return callback(tx);
+});
+const drizzleClientMock = {
+  insert: insertMock,
+  transaction: transactionMock,
+  execute: executeMock,
+} as any;
 
 vi.mock("drizzle-orm/node-postgres", () => ({
   drizzle: vi.fn(() => drizzleClientMock),
@@ -26,9 +35,11 @@ describe("EnsDbWriter", () => {
     new EnsDbWriter(ensDbClientMock.ensDbUrl, ensDbClientMock.ensIndexerSchemaName);
 
   beforeEach(() => {
+    executeMock.mockClear();
     onConflictDoUpdateMock.mockClear();
     valuesMock.mockClear();
     insertMock.mockClear();
+    transactionMock.mockClear();
     vi.mocked(migrate).mockClear();
   });
 
@@ -84,18 +95,22 @@ describe("EnsDbWriter", () => {
   });
 
   describe("migrateEnsNodeSchema", () => {
-    it("calls drizzle-orm migrateEnsNodeSchema with the correct parameters", async () => {
+    it("calls drizzle-orm migrate with the correct parameters inside a transaction", async () => {
       const migrationsDirPath = "/path/to/migrations";
 
       await createEnsDbWriter().migrateEnsNodeSchema(migrationsDirPath);
 
-      expect(vi.mocked(migrate)).toHaveBeenCalledWith(drizzleClientMock, {
-        migrationsFolder: migrationsDirPath,
-        migrationsSchema: "ensnode",
-      });
+      expect(transactionMock).toHaveBeenCalled();
+      expect(vi.mocked(migrate)).toHaveBeenCalledWith(
+        expect.objectContaining({ execute: executeMock }),
+        {
+          migrationsFolder: migrationsDirPath,
+          migrationsSchema: "ensnode",
+        },
+      );
     });
 
-    it("propagates errors from the migrateEnsNodeSchema function", async () => {
+    it("propagates errors from the migrate function", async () => {
       const migrationsDirPath = "/path/to/migrations";
       vi.mocked(migrate).mockRejectedValueOnce(new Error("Migration failed"));
 

--- a/packages/ensdb-sdk/src/client/ensdb-writer.test.ts
+++ b/packages/ensdb-sdk/src/client/ensdb-writer.test.ts
@@ -101,6 +101,15 @@ describe("EnsDbWriter", () => {
       await createEnsDbWriter().migrateEnsNodeSchema(migrationsDirPath);
 
       expect(transactionMock).toHaveBeenCalled();
+      expect(executeMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queryChunks: expect.arrayContaining([
+            expect.objectContaining({ value: ["SELECT pg_advisory_xact_lock("] }),
+            expect.any(BigInt),
+            expect.objectContaining({ value: [")"] }),
+          ]),
+        }),
+      );
       expect(vi.mocked(migrate)).toHaveBeenCalledWith(
         expect.objectContaining({ execute: executeMock }),
         {

--- a/packages/ensdb-sdk/src/client/ensdb-writer.ts
+++ b/packages/ensdb-sdk/src/client/ensdb-writer.ts
@@ -41,31 +41,19 @@ export class EnsDbWriter extends EnsDbReader {
    * @throws error when migration execution fails.
    */
   async migrateEnsNodeSchema(migrationsDirPath: string): Promise<void> {
-    // Acquire advisory lock to only allow one ENSIndexer instance to execute
-    // migrations at a time across all ENSIndexer instances that share
-    // the same ENSDb instance.
-    await this.drizzleClient.execute(sql`SELECT pg_advisory_lock(${this.MIGRATION_LOCK_ID})`);
-
-    try {
-      // Run any pending migrations for ENSNode Schema.
-      // If there were any pending migrations that have not been run before,
-      // they will be executed by the ENSIndexer instance that acquired the lock,
-      // while other instances will wait for the lock to be released before
-      // they can run migrations, but since the function is idempotent,
-      // they will simply skip running any migrations that have already been run
-      // by the first ENSIndexer instance.
-      await migrate(this.drizzleClient, {
+    // `pg_advisory_xact_lock` is transaction-scoped, and is automatically released
+    // when the transaction ends, with no explicit unlock needed. Running it inside
+    // a Drizzle transaction also guarantees that the lock acquisition, all
+    // migration queries, and the lock release all run on the same physical
+    // connection — which is required for advisory locks to work correctly with a
+    // connection pool.
+    await this.drizzleClient.transaction(async (tx) => {
+      await tx.execute(sql`SELECT pg_advisory_xact_lock(${this.MIGRATION_LOCK_ID})`);
+      await migrate(tx, {
         migrationsFolder: migrationsDirPath,
         migrationsSchema: "ensnode",
       });
-    } finally {
-      // Release advisory lock after migrations execution is completed,
-      // regardless of success or failure, to prevent deadlocks.
-      // Note: this is optional since Postgres automatically releases
-      // all advisory locks held by a session when it ends, but it's
-      // a good practice to release locks as soon as they're no longer needed.
-      await this.drizzleClient.execute(sql`SELECT pg_advisory_unlock(${this.MIGRATION_LOCK_ID})`);
-    }
+    });
   }
 
   /**

--- a/packages/ensdb-sdk/src/client/ensdb-writer.ts
+++ b/packages/ensdb-sdk/src/client/ensdb-writer.ts
@@ -25,7 +25,9 @@ export class EnsDbWriter extends EnsDbReader {
    * Stable arbitrary lock ID for ENSNode Schema migrations to
    * prevent concurrent migration execution across multiple ENSIndexer instances.
    */
-  private readonly MIGRATION_LOCK_ID: bigint = advisoryLockId("ensnode-schema-migration-lock");
+  private static readonly MIGRATION_LOCK_ID: bigint = advisoryLockId(
+    "ensnode-schema-migration-lock",
+  );
 
   /**
    * Execute pending database migrations for ENSNode Schema in ENSDb.
@@ -48,7 +50,7 @@ export class EnsDbWriter extends EnsDbReader {
     // connection — which is required for advisory locks to work correctly with a
     // connection pool.
     await this.drizzleClient.transaction(async (tx) => {
-      await tx.execute(sql`SELECT pg_advisory_xact_lock(${this.MIGRATION_LOCK_ID})`);
+      await tx.execute(sql`SELECT pg_advisory_xact_lock(${EnsDbWriter.MIGRATION_LOCK_ID})`);
       await migrate(tx, {
         migrationsFolder: migrationsDirPath,
         migrationsSchema: "ensnode",

--- a/packages/ensdb-sdk/src/client/ensdb-writer.ts
+++ b/packages/ensdb-sdk/src/client/ensdb-writer.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import { migrate } from "drizzle-orm/node-postgres/migrator";
 
 import {
@@ -7,6 +8,7 @@ import {
   serializeEnsIndexerPublicConfig,
 } from "@ensnode/ensnode-sdk";
 
+import { advisoryLockId } from "../lib/advisory-lock-id";
 import { EnsDbReader } from "./ensdb-reader";
 import { EnsNodeMetadataKeys } from "./ensnode-metadata";
 import type { SerializedEnsNodeMetadata } from "./serialize/ensnode-metadata";
@@ -20,17 +22,50 @@ import type { SerializedEnsNodeMetadata } from "./serialize/ensnode-metadata";
  */
 export class EnsDbWriter extends EnsDbReader {
   /**
+   * Stable arbitrary lock ID for ENSNode Schema migrations to
+   * prevent concurrent migration execution across multiple ENSIndexer instances.
+   */
+  private readonly MIGRATION_LOCK_ID: bigint = advisoryLockId("ensnode-schema-migration-lock");
+
+  /**
    * Execute pending database migrations for ENSNode Schema in ENSDb.
+   *
+   * This function is:
+   * - idempotent and can be safely executed multiple times,
+   * - safe to execute concurrently across multiple ENSIndexer instances,
+   *   as it uses a stable arbitrary advisory lock to prevent concurrent
+   *   execution of migrations.
    *
    * @param migrationsDirPath - The file path to the directory containing
    *                            database migration files for ENSNode Schema.
    * @throws error when migration execution fails.
    */
   async migrateEnsNodeSchema(migrationsDirPath: string): Promise<void> {
-    return migrate(this.drizzleClient, {
-      migrationsFolder: migrationsDirPath,
-      migrationsSchema: "ensnode",
-    });
+    // Acquire advisory lock to only allow one ENSIndexer instance to execute
+    // migrations at a time across all ENSIndexer instances that share
+    // the same ENSDb instance.
+    await this.drizzleClient.execute(sql`SELECT pg_advisory_lock(${this.MIGRATION_LOCK_ID})`);
+
+    try {
+      // Run any pending migrations for ENSNode Schema.
+      // If there were any pending migrations that have not been run before,
+      // they will be executed by the ENSIndexer instance that acquired the lock,
+      // while other instances will wait for the lock to be released before
+      // they can run migrations, but since the function is idempotent,
+      // they will simply skip running any migrations that have already been run
+      // by the first ENSIndexer instance.
+      await migrate(this.drizzleClient, {
+        migrationsFolder: migrationsDirPath,
+        migrationsSchema: "ensnode",
+      });
+    } finally {
+      // Release advisory lock after migrations execution is completed,
+      // regardless of success or failure, to prevent deadlocks.
+      // Note: this is optional since Postgres automatically releases
+      // all advisory locks held by a session when it ends, but it's
+      // a good practice to release locks as soon as they're no longer needed.
+      await this.drizzleClient.execute(sql`SELECT pg_advisory_unlock(${this.MIGRATION_LOCK_ID})`);
+    }
   }
 
   /**

--- a/packages/ensdb-sdk/src/lib/advisory-lock-id.test.ts
+++ b/packages/ensdb-sdk/src/lib/advisory-lock-id.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { advisoryLockId } from "./advisory-lock-id";
+
+describe("advisoryLockId", () => {
+  it("returns a bigint for any string input", () => {
+    expect(advisoryLockId("test-name")).toBeTypeOf("bigint");
+    expect(advisoryLockId("")).toBeTypeOf("bigint");
+    expect(advisoryLockId("schema-migrations")).toBeTypeOf("bigint");
+  });
+
+  it("returns consistent (deterministic) results for the same input", () => {
+    expect(advisoryLockId("name")).toBe(advisoryLockId("name"));
+    expect(advisoryLockId("")).toBe(advisoryLockId(""));
+  });
+
+  it("returns different results for different inputs", () => {
+    expect(advisoryLockId("name-one")).not.toBe(advisoryLockId("name-two"));
+  });
+
+  it("produces expected lock ID for known input", () => {
+    // SHA-256 of "hello" -> first 8 bytes as signed 64-bit big-endian
+    expect(advisoryLockId("hello")).toBe(3238736544897475342n);
+  });
+
+  it("produces values within PostgreSQL bigint range", () => {
+    // PostgreSQL bigint is signed 64-bit
+    const result = advisoryLockId("any-name");
+
+    expect(result).toBeGreaterThanOrEqual(-9223372036854775808n);
+    expect(result).toBeLessThanOrEqual(9223372036854775807n);
+  });
+});

--- a/packages/ensdb-sdk/src/lib/advisory-lock-id.ts
+++ b/packages/ensdb-sdk/src/lib/advisory-lock-id.ts
@@ -1,0 +1,15 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Generate a stable arbitrary advisory lock ID for the given name.
+ *
+ * @param name - The name to derive the advisory lock ID from. This should be
+ *               a fixed string that uniquely identifies the critical section of code that
+ *               requires synchronization, such as "schema-migrations".
+ * @returns A bigint representing the advisory lock ID to be used with PostgreSQL advisory locks.
+ */
+export function advisoryLockId(name: string): bigint {
+  const hash = createHash("sha256").update(name).digest();
+  // Read the first 8 bytes as a signed 64-bit integer (Postgres bigint range)
+  return hash.readBigInt64BE(0);
+}


### PR DESCRIPTION
Use advisory locks mechanism provided by ENSDb to ensure that any pending ENSNode Schema migrations are executed exactly once, even if multiple ENSIndexer instances attempt running migrations conurrently.

# Lite PR

[Tip: Review docs on the ENSNode PR process](https://ensnode.io/docs/contributing/prs)

## Summary

- The `migrateEnsNodeSchema` method in `EnsDbWriter` class is now race-condition-safe.
  - The standard fix is a Postgres advisory lock — cheap, session-scoped, and automatically released on disconnect

---

## Why

I noticed that the ENSDb instance in one of hosted ENSNode environments has five records in `ensnode.__drizzle_migrations` table with the same `hash` column value. It means that each of the five ENSIndexer instances in this ENSNode environment has executed the same pending migration file on the same ENSNode Schema.
<img width="704" height="331" alt="image" src="https://github.com/user-attachments/assets/90b65c43-3c26-47b8-80f9-0ea27024a05b" />

To prevent any issues with running ENSNode Schema migrations by multiple ENSIndexer instances, we need to apply a locking mechanism so that only one ENSIndexer instance can attempt executing the pending migrations for the ENSNode Schema at a time.

---

## Testing

- I ran multiple ENSIndexer instances locally at the same time and noticed only one record was added into the `ensnode.__drizzle_migrations` table for one pending migration file. The lock works 👍 

---

## Notes for Reviewer (Optional)

- Anything non-obvious or worth a heads-up.

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)
