### PR TITLE
Integrate ENSDb health check and readiness check into ENSApi probe endpoints

### DIFF
--- a/.changeset/ready-hands-worry.md
+++ b/.changeset/ready-hands-worry.md
@@ -1,0 +1,5 @@
+---
+"ensapi": minor
+---
+
+Integrated ENSDb health check and readiness check into relevant ENSApi probe endpoints.

--- a/.changeset/ready-hands-worry.md
+++ b/.changeset/ready-hands-worry.md
@@ -2,4 +2,4 @@
 "ensapi": minor
 ---
 
-Integrated ENSDb health check and readiness check into relevant ENSApi probe endpoints.
+Integrated ENSDb health check and readiness check into ENSApi `/health` and `/ready` endpoints.

--- a/apps/ensapi/src/app.ts
+++ b/apps/ensapi/src/app.ts
@@ -4,7 +4,6 @@ import { otel } from "@hono/otel";
 import { cors } from "hono/cors";
 import { html } from "hono/html";
 
-import { ensDbClient } from "@/lib/ensdb/singleton";
 import { errorResponse } from "@/lib/handlers/error-response";
 import { createApp } from "@/lib/hono-factory";
 import logger from "@/lib/logger";
@@ -13,6 +12,7 @@ import { generateOpenApi31Document } from "@/openapi-document";
 import realtimeApi from "./handlers/api/meta/realtime-api";
 import apiRouter from "./handlers/api/router";
 import ensanalyticsApi from "./handlers/ensanalytics/ensanalytics-api";
+import ensApiProbesApi from "./handlers/ensapi-probes/ensapi-probes-api";
 import subgraphApi from "./handlers/subgraph/subgraph-api";
 
 const app = createApp();
@@ -60,41 +60,12 @@ app.route("/v1/ensanalytics", ensanalyticsApi);
 // NOTE: this is legacy endpoint and will be deleted in future. one should use /api/realtime instead
 app.route("/amirealtime", realtimeApi);
 
+// Health check and readiness check endpoints for monitoring and load balancer probes
+app.route("/", ensApiProbesApi);
+
 // generate and return OpenAPI 3.1 document
 app.get("/openapi.json", (c) => {
   return c.json(generateOpenApi31Document(app));
-});
-
-app.get("/health", async (c) => {
-  try {
-    const isEnsDbHealthy = await ensDbClient.isHealthy();
-
-    if (!isEnsDbHealthy) {
-      throw new Error(`ENSDb instance is unhealthy`);
-    }
-
-    return c.json({ responseCode: "ok" });
-  } catch (error) {
-    logger.debug(error, "Health check failed");
-    return c.json({ responseCode: "error", message: "Service Unavailable" }, 503);
-  }
-});
-
-app.get("/ready", async (c) => {
-  try {
-    const isEnsDbReady = await ensDbClient.isReady();
-
-    if (!isEnsDbReady) {
-      throw new Error(
-        `ENSDb instance is not ready. This may indicate that ENSNode Schema migrations were not completed successfully or that the ENSNode Metadata record for ${ensDbClient.ensIndexerSchemaName} ENSIndexer Schema has not been created yet.`,
-      );
-    }
-
-    return c.json({ responseCode: "ok" });
-  } catch (error) {
-    logger.debug(error, "Readiness check failed");
-    return c.json({ responseCode: "error", message: "Service Unavailable" }, 503);
-  }
 });
 
 // log hono errors to console

--- a/apps/ensapi/src/app.ts
+++ b/apps/ensapi/src/app.ts
@@ -4,6 +4,7 @@ import { otel } from "@hono/otel";
 import { cors } from "hono/cors";
 import { html } from "hono/html";
 
+import { ensDbClient } from "@/lib/ensdb/singleton";
 import { errorResponse } from "@/lib/handlers/error-response";
 import { createApp } from "@/lib/hono-factory";
 import logger from "@/lib/logger";
@@ -65,7 +66,35 @@ app.get("/openapi.json", (c) => {
 });
 
 app.get("/health", async (c) => {
-  return c.json({ message: "fallback ok" });
+  try {
+    const isEnsDbHealthy = await ensDbClient.isHealthy();
+
+    if (!isEnsDbHealthy) {
+      throw new Error(`ENSDb instance is unhealthy`);
+    }
+
+    return c.json({ responseCode: "ok" });
+  } catch (error) {
+    logger.error(error, "Health check failed");
+    return c.json({ responseCode: "error", message: "Service Unavailable" }, 503);
+  }
+});
+
+app.get("/ready", async (c) => {
+  try {
+    const isEnsDbReady = await ensDbClient.isReady();
+
+    if (!isEnsDbReady) {
+      throw new Error(
+        `ENSDb instance is not ready. This may indicate that ENSNode Schema migrations were not completed successfully or that the ENSNode Metadata record for ${ensDbClient.ensIndexerSchemaName} ENSIndexer Schema has not been created yet.`,
+      );
+    }
+
+    return c.json({ responseCode: "ok" });
+  } catch (error) {
+    logger.error(error, "Readiness check failed");
+    return c.json({ responseCode: "error", message: "Service Unavailable" }, 503);
+  }
 });
 
 // log hono errors to console

--- a/apps/ensapi/src/app.ts
+++ b/apps/ensapi/src/app.ts
@@ -75,7 +75,7 @@ app.get("/health", async (c) => {
 
     return c.json({ responseCode: "ok" });
   } catch (error) {
-    logger.error(error, "Health check failed");
+    logger.debug(error, "Health check failed");
     return c.json({ responseCode: "error", message: "Service Unavailable" }, 503);
   }
 });
@@ -92,7 +92,7 @@ app.get("/ready", async (c) => {
 
     return c.json({ responseCode: "ok" });
   } catch (error) {
-    logger.error(error, "Readiness check failed");
+    logger.debug(error, "Readiness check failed");
     return c.json({ responseCode: "error", message: "Service Unavailable" }, 503);
   }
 });

--- a/apps/ensapi/src/handlers/ensapi-probes/ensapi-probes-api.routes.ts
+++ b/apps/ensapi/src/handlers/ensapi-probes/ensapi-probes-api.routes.ts
@@ -1,0 +1,66 @@
+import { createRoute, z } from "@hono/zod-openapi";
+
+const makeProbeRouteResponseSchemaOk = () =>
+  z.object({
+    responseCode: z.literal("ok"),
+  });
+
+const makeProbeRouteResponseSchemaError = () =>
+  z.object({
+    responseCode: z.literal("error"),
+    message: z.string(),
+  });
+
+export const healthCheckRoute = createRoute({
+  method: "get",
+  path: "/health",
+  operationId: "getHealthCheck",
+  tags: ["Probes"],
+  summary: "Health Check Endpoint",
+  description: "Checks the health status of the ENSApi service",
+  responses: {
+    200: {
+      description: "Service is healthy",
+      content: {
+        "application/json": {
+          schema: makeProbeRouteResponseSchemaOk(),
+        },
+      },
+    },
+    503: {
+      description: "Service unavailable",
+      content: {
+        "application/json": {
+          schema: makeProbeRouteResponseSchemaError(),
+        },
+      },
+    },
+  },
+});
+
+export const readinessCheckRoute = createRoute({
+  method: "get",
+  path: "/ready",
+  operationId: "getReadinessCheck",
+  tags: ["Probes"],
+  summary: "Readiness Check Endpoint",
+  description: "Checks the readiness status of the ENSApi service",
+  responses: {
+    200: {
+      description: "Service is ready",
+      content: {
+        "application/json": {
+          schema: makeProbeRouteResponseSchemaOk(),
+        },
+      },
+    },
+    503: {
+      description: "Service unavailable",
+      content: {
+        "application/json": {
+          schema: makeProbeRouteResponseSchemaError(),
+        },
+      },
+    },
+  },
+});

--- a/apps/ensapi/src/handlers/ensapi-probes/ensapi-probes-api.ts
+++ b/apps/ensapi/src/handlers/ensapi-probes/ensapi-probes-api.ts
@@ -1,0 +1,43 @@
+import {
+  healthCheckRoute,
+  readinessCheckRoute,
+} from "@/handlers/ensapi-probes/ensapi-probes-api.routes";
+import { ensDbClient } from "@/lib/ensdb/singleton";
+import { createApp } from "@/lib/hono-factory";
+import logger from "@/lib/logger";
+
+const app = createApp();
+
+app.openapi(healthCheckRoute, async (c) => {
+  try {
+    const isEnsDbHealthy = await ensDbClient.isHealthy();
+
+    if (!isEnsDbHealthy) {
+      throw new Error(`ENSDb instance is unhealthy`);
+    }
+
+    return c.json({ responseCode: "ok" }, 200);
+  } catch (error) {
+    logger.debug(error, "Health check failed");
+    return c.json({ responseCode: "error", message: "Service Unavailable" }, 503);
+  }
+});
+
+app.openapi(readinessCheckRoute, async (c) => {
+  try {
+    const isEnsDbReady = await ensDbClient.isReady();
+
+    if (!isEnsDbReady) {
+      throw new Error(
+        `ENSDb instance is not ready. This may indicate that ENSNode Schema migrations were not completed successfully or that the ENSNode Metadata record for ${ensDbClient.ensIndexerSchemaName} ENSIndexer Schema has not been created yet.`,
+      );
+    }
+
+    return c.json({ responseCode: "ok" }, 200);
+  } catch (error) {
+    logger.debug(error, "Readiness check failed");
+    return c.json({ responseCode: "error", message: "Service Unavailable" }, 503);
+  }
+});
+
+export default app;

--- a/docs/ensnode.io/ensapi-openapi.json
+++ b/docs/ensnode.io/ensapi-openapi.json
@@ -2972,6 +2972,80 @@
           "503": { "description": "Service unavailable" }
         }
       }
+    },
+    "/health": {
+      "get": {
+        "operationId": "getHealthCheck",
+        "tags": ["Probes"],
+        "summary": "Health Check Endpoint",
+        "description": "Checks the health status of the ENSApi service",
+        "responses": {
+          "200": {
+            "description": "Service is healthy",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": { "responseCode": { "type": "string", "enum": ["ok"] } },
+                  "required": ["responseCode"]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "responseCode": { "type": "string", "enum": ["error"] },
+                    "message": { "type": "string" }
+                  },
+                  "required": ["responseCode", "message"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ready": {
+      "get": {
+        "operationId": "getReadinessCheck",
+        "tags": ["Probes"],
+        "summary": "Readiness Check Endpoint",
+        "description": "Checks the readiness status of the ENSApi service",
+        "responses": {
+          "200": {
+            "description": "Service is ready",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": { "responseCode": { "type": "string", "enum": ["ok"] } },
+                  "required": ["responseCode"]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "responseCode": { "type": "string", "enum": ["error"] },
+                    "message": { "type": "string" }
+                  },
+                  "required": ["responseCode", "message"]
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "webhooks": {}

--- a/packages/ensdb-sdk/src/client/ensdb-reader.test.ts
+++ b/packages/ensdb-sdk/src/client/ensdb-reader.test.ts
@@ -125,9 +125,7 @@ describe("EnsDbReader", () => {
   });
 
   describe("isReady", () => {
-    it("returns true when healthy and indexing metadata context is initialized", async () => {
-      executeMock.mockResolvedValueOnce({ rows: [] });
-
+    it("returns true indexing metadata context is initialized", async () => {
       const indexingStatus = deserializeCrossChainIndexingStatusSnapshot(
         ensDbClientMock.serializedSnapshot,
       );
@@ -152,18 +150,7 @@ describe("EnsDbReader", () => {
       expect(result).toBe(true);
     });
 
-    it("returns false when healthy but indexing metadata context is uninitialized", async () => {
-      executeMock.mockResolvedValueOnce({ rows: [] });
-      selectResult.current = [];
-
-      const result = await createEnsDbReader().isReady();
-
-      expect(result).toBe(false);
-    });
-
-    it("returns false when not healthy", async () => {
-      executeMock.mockRejectedValueOnce(new Error("Connection refused"));
-
+    it("returns false when indexing metadata context is uninitialized", async () => {
       const result = await createEnsDbReader().isReady();
 
       expect(result).toBe(false);

--- a/packages/ensdb-sdk/src/client/ensdb-reader.test.ts
+++ b/packages/ensdb-sdk/src/client/ensdb-reader.test.ts
@@ -125,7 +125,7 @@ describe("EnsDbReader", () => {
   });
 
   describe("isReady", () => {
-    it("returns true indexing metadata context is initialized", async () => {
+    it("returns true when indexing metadata context is initialized", async () => {
       const indexingStatus = deserializeCrossChainIndexingStatusSnapshot(
         ensDbClientMock.serializedSnapshot,
       );

--- a/packages/ensdb-sdk/src/client/ensdb-reader.ts
+++ b/packages/ensdb-sdk/src/client/ensdb-reader.ts
@@ -148,20 +148,17 @@ export class EnsDbReader<
   }
 
   /**
-   * Check if the ENSDb instance is ready by verifying that it is
-   * healthy and the {@link IndexingMetadataContext} has been initialized for
+   * Check if the ENSDb instance is ready by verifying that
+   * the {@link IndexingMetadataContext} has been initialized for
    * the ENSIndexer Schema used by this ENSDbReader instance.
    */
   async isReady(): Promise<boolean> {
-    const isHealthy = await this.isHealthy();
-
-    if (!isHealthy) {
+    try {
+      const indexingMetadataContext = await this.getIndexingMetadataContext();
+      return indexingMetadataContext.statusCode === IndexingMetadataContextStatusCodes.Initialized;
+    } catch {
       return false;
     }
-
-    const indexingMetadataContext = await this.getIndexingMetadataContext();
-
-    return indexingMetadataContext.statusCode === IndexingMetadataContextStatusCodes.Initialized;
   }
 
   /**


### PR DESCRIPTION
# Lite PR

[Tip: Review docs on the ENSNode PR process](https://ensnode.io/docs/contributing/prs)

## Summary

- The following ENSApi probe endpoints were updated:
  - The `/health` endpoint returns the response based on the ENSDb instance health check.
  - The `/ready` endpoint returns the response based on the ENSDb instance readiness check.
- OpenAPI spec now includes both ENSApi probe endpoints
- ENSDb SDK
  - The readiness check has been simplified to just running a target query against ENSDb instance. If that query is successful.

---

## Why

- Changes were requested in issue #1227 

---

## Testing

- I ran ENSIndexer instance and ENSApi instance locally
- I observed that the Indexing Metadata Context record appeared in ENSDb.
- I tested ENSApi endpoints, both `/health` and `/ready` returned `200 OK`
- I deleted the Indexing Metadata Context record from ENSDb.
- I tested ENSApi endpoints again, `/health` returned `200 OK`, and `/ready` returned `503 Service Unavailable`.

---

## Notes for Reviewer (Optional)

- Anything non-obvious or worth a heads-up.

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)

Resolves #1227 