### PR TITLE
Add `REFERRAL_PROGRAM_EDITIONS` to the ENSApi Alpha instance config

### DIFF
--- a/.github/workflows/deploy_ensnode_yellow.yml
+++ b/.github/workflows/deploy_ensnode_yellow.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v4
         with:
-          terraform_version: 1.6.0
+          terraform_version: 1.6.6
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6

--- a/.github/workflows/plan_terraform_ensnode_yellow.yml
+++ b/.github/workflows/plan_terraform_ensnode_yellow.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v4
         with:
-          terraform_version: 1.6.0
+          terraform_version: 1.6.6
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -93,7 +93,7 @@ locals {
       ensnode_indexer_type         = "alpha-sepolia"
       ensnode_environment_name     = var.render_environment
       ensindexer_schema_name       = "alphaSepoliaSchema-${var.ensnode_version}"
-      plugins                      = "subgraph,basenames,lineanames,registrars,ensv2,protocol-acceleration,"
+      plugins                      = "subgraph,basenames,lineanames,registrars,ensv2,protocol-acceleration"
       namespace                    = "sepolia"
       render_instance_plan         = "starter"
       subgraph_compat              = false

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -93,7 +93,7 @@ locals {
       ensnode_indexer_type         = "alpha-sepolia"
       ensnode_environment_name     = var.render_environment
       ensindexer_schema_name       = "alphaSepoliaSchema-${var.ensnode_version}"
-      plugins                      = "subgraph,basenames,lineanames,registrars"
+      plugins                      = "subgraph,basenames,lineanames,registrars,ensv2,protocol-acceleration,"
       namespace                    = "sepolia"
       render_instance_plan         = "starter"
       subgraph_compat              = false
@@ -165,7 +165,7 @@ module "ensindexer" {
   ensindexer_schema_name    = each.value.ensindexer_schema_name
   plugins                   = each.value.plugins
   namespace                 = each.value.namespace
-  referral_program_editions = each.value.referral_program_editions
+  referral_program_editions = try(each.value.referral_program_editions, "")
   subgraph_compat           = each.value.subgraph_compat
 
   # Common configuration (spread operator merges the map)

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -58,7 +58,7 @@ locals {
       ensnode_indexer_type         = "v2-sepolia"
       ensnode_environment_name     = var.render_environment
       ensindexer_schema_name       = "v2SepoliaSchema-${var.ensnode_version}"
-      plugins                      = "ensv2,protocol-acceleration"
+      plugins                      = "subgraph,ensv2,protocol-acceleration"
       namespace                    = "sepolia"
       render_instance_plan         = "starter"
       subgraph_compat              = false

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -165,7 +165,7 @@ module "ensindexer" {
   ensindexer_schema_name    = each.value.ensindexer_schema_name
   plugins                   = each.value.plugins
   namespace                 = each.value.namespace
-  referral_program_editions = try(each.value.referral_program_editions, "")
+  referral_program_editions = try(each.value.referral_program_editions, null)
   subgraph_compat           = each.value.subgraph_compat
 
   # Common configuration (spread operator merges the map)

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -82,7 +82,7 @@ locals {
       ensindexer_schema_name       = "alphaSchema-${var.ensnode_version}"
       plugins                      = "subgraph,basenames,lineanames,threedns,protocol-acceleration,registrars,tokenscope"
       namespace                    = "mainnet"
-      referral_program_editions    = "https://ensawards.org/production-editions-v1.10.0.json"
+      referral_program_editions    = "https://ensawards.org/production-editions.json"
       render_instance_plan         = "standard"
       subgraph_compat              = false
       ensindexer_label_set_id      = "searchlight"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -82,6 +82,7 @@ locals {
       ensindexer_schema_name       = "alphaSchema-${var.ensnode_version}"
       plugins                      = "subgraph,basenames,lineanames,threedns,protocol-acceleration,registrars,tokenscope"
       namespace                    = "mainnet"
+      referral_program_editions    = "https://ensawards.org/production-editions-v1.10.0.json"
       render_instance_plan         = "standard"
       subgraph_compat              = false
       ensindexer_label_set_id      = "searchlight"
@@ -158,13 +159,14 @@ module "ensindexer" {
   for_each = local.ensindexer_instances
 
   # Instance-specific configuration
-  ensnode_indexer_type     = each.value.ensnode_indexer_type
-  render_instance_plan     = each.value.render_instance_plan
-  ensnode_environment_name = each.value.ensnode_environment_name
-  ensindexer_schema_name   = each.value.ensindexer_schema_name
-  plugins                  = each.value.plugins
-  namespace                = each.value.namespace
-  subgraph_compat          = each.value.subgraph_compat
+  ensnode_indexer_type      = each.value.ensnode_indexer_type
+  render_instance_plan      = each.value.render_instance_plan
+  ensnode_environment_name  = each.value.ensnode_environment_name
+  ensindexer_schema_name    = each.value.ensindexer_schema_name
+  plugins                   = each.value.plugins
+  namespace                 = each.value.namespace
+  referral_program_editions = each.value.referral_program_editions
+  subgraph_compat           = each.value.subgraph_compat
 
   # Common configuration (spread operator merges the map)
   hosted_zone_name = local.hosted_zone_name

--- a/terraform/modules/ensindexer/main.tf
+++ b/terraform/modules/ensindexer/main.tf
@@ -59,7 +59,9 @@ resource "render_web_service" "ensapi" {
     }
   }
 
-  env_vars = local.common_variables
+  env_vars = merge(local.common_variables, {
+    "REFERRAL_PROGRAM_EDITIONS" = { value = var.referral_program_editions },
+  })
 
   # See https://render.com/docs/custom-domains
   custom_domains = [

--- a/terraform/modules/ensindexer/main.tf
+++ b/terraform/modules/ensindexer/main.tf
@@ -59,9 +59,12 @@ resource "render_web_service" "ensapi" {
     }
   }
 
-  env_vars = merge(local.common_variables, {
-    "REFERRAL_PROGRAM_EDITIONS" = { value = var.referral_program_editions },
-  })
+  env_vars = merge(
+    local.common_variables,
+    var.referral_program_editions != null ? {
+      "REFERRAL_PROGRAM_EDITIONS" = { value = var.referral_program_editions }
+    } : {},
+  )
 
   # See https://render.com/docs/custom-domains
   custom_domains = [

--- a/terraform/modules/ensindexer/variables.tf
+++ b/terraform/modules/ensindexer/variables.tf
@@ -74,7 +74,7 @@ variable "namespace" {
 
 variable "referral_program_editions" {
   type    = string
-  default = ""
+  default = null
 }
 
 variable "subgraph_compat" {

--- a/terraform/modules/ensindexer/variables.tf
+++ b/terraform/modules/ensindexer/variables.tf
@@ -73,7 +73,8 @@ variable "namespace" {
 }
 
 variable "referral_program_editions" {
-  type = string
+  type    = string
+  default = ""
 }
 
 variable "subgraph_compat" {

--- a/terraform/modules/ensindexer/variables.tf
+++ b/terraform/modules/ensindexer/variables.tf
@@ -72,6 +72,10 @@ variable "namespace" {
   type = string
 }
 
+variable "referral_program_editions" {
+  type = string
+}
+
 variable "subgraph_compat" {
   type = bool
 }


### PR DESCRIPTION
# Lite PR

[Tip: Review docs on the ENSNode PR process](https://ensnode.io/docs/contributing/prs)

## Summary

- Added `REFERRAL_PROGRAM_EDITIONS` to the ENSApi Alpha instance config
- Activated `ensv2` and `protocol-acceleration` plugins for the ENSIndexer Alpha Sepolia instance.
- Activated `subgraph` plugin for the ENSIndexer V2 Sepolia instance.

---

## Why

- The Yellow env must have its ENSApi Alpha instance configured to use `REFERRAL_PROGRAM_EDITIONS` env var.
- All ENSIndexer instances must have the following plugins active: `subgraph,ensv2,protocol-acceleration`. Exceptions are: the Subgraph-compatible instances (ENSIndexer Mainnet, ENSIndexer Sepolia), and (only for the v1.10 releases) the ENSIndexer Alpha instance.

---

## Testing

- Relying on the CI step that executes TF plan command.

---

## Notes for Reviewer (Optional)

- Hide whitespaces while reviewing the PR.

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)
