### PR TITLE
feat(ensrainbow): enhance entrypoint command with eager public config and mismatch handling

### DIFF
--- a/.changeset/ensrainbow-eager-public-config.md
+++ b/.changeset/ensrainbow-eager-public-config.md
@@ -1,0 +1,11 @@
+---
+"ensrainbow": minor
+---
+
+ENSRainbow's `GET /v1/config` is now available immediately at startup, removing the cold-start gap that previously forced downstream services (e.g. ENSIndexer) to wait for the entire database download/validation before they could read public config (issue #2020).
+
+- The entrypoint command now builds the `EnsRainbowPublicConfig` in-memory from its CLI/env arguments (`LABEL_SET_ID`, `LABEL_SET_VERSION`) before the HTTP server starts accepting requests, so `/v1/config` returns `200` from the first request.
+- After the background bootstrap finishes, ENSRainbow verifies that the on-disk database's stored label set (`labelSetId` and `highestLabelSetVersion`) matches the configured one. On mismatch it logs a helpful error naming both the expected and actual label sets, refuses to serve, and terminates with exit code `1`.
+- `/ready` continues to gate on full database readiness (`200` only after the database has been attached and the env-vs-DB validation has passed).
+- `/v1/heal/{labelhash}` and `/v1/labels/count` continue to return `503 Service Unavailable` while the database is still bootstrapping.
+- `/health` is unchanged and still returns `200` as soon as the HTTP server is listening.

--- a/apps/ensindexer/src/lib/public-config-builder/public-config-builder.test.ts
+++ b/apps/ensindexer/src/lib/public-config-builder/public-config-builder.test.ts
@@ -230,49 +230,9 @@ describe("PublicConfigBuilder", () => {
       expect(result).toBe(customConfig);
       expect(result.isSubgraphCompatible).toBe(false);
     });
-
-    it("awaits readiness before fetching ENSRainbow config", async () => {
-      const callOrder: string[] = [];
-      const ensRainbowClientMock = {
-        config: vi.fn().mockImplementation(async () => {
-          callOrder.push("config");
-          return mockEnsRainbowConfig;
-        }),
-      } as unknown as EnsRainbow.ApiClient;
-      const waitForReady = vi.fn().mockImplementation(async () => {
-        callOrder.push("wait");
-      });
-
-      setupStandardMocks();
-      const mockPublicConfig = createMockPublicConfig();
-      vi.mocked(validateEnsIndexerPublicConfig).mockReturnValue(mockPublicConfig);
-
-      const builder = new PublicConfigBuilder(ensRainbowClientMock, waitForReady);
-      const result = await builder.getPublicConfig();
-
-      expect(waitForReady).toHaveBeenCalledTimes(1);
-      expect(ensRainbowClientMock.config).toHaveBeenCalledTimes(1);
-      expect(callOrder).toEqual(["wait", "config"]);
-      expect(result).toBe(mockPublicConfig);
-    });
   });
 
   describe("getPublicConfig() - error handling", () => {
-    it("throws when readiness check fails and does not call config()", async () => {
-      const readinessError = new Error("ENSRainbow not ready");
-      const ensRainbowClientMock = {
-        config: vi.fn(),
-      } as unknown as EnsRainbow.ApiClient;
-      const waitForReady = vi.fn().mockRejectedValue(readinessError);
-
-      const builder = new PublicConfigBuilder(ensRainbowClientMock, waitForReady);
-
-      await expect(builder.getPublicConfig()).rejects.toThrow(readinessError);
-      expect(waitForReady).toHaveBeenCalledTimes(1);
-      expect(ensRainbowClientMock.config).not.toHaveBeenCalled();
-      expect(validateEnsIndexerPublicConfig).not.toHaveBeenCalled();
-    });
-
     it("throws when ENSRainbow client config() fails", async () => {
       // Arrange
       const ensRainbowError = new Error("ENSRainbow service unavailable");

--- a/apps/ensindexer/src/lib/public-config-builder/public-config-builder.ts
+++ b/apps/ensindexer/src/lib/public-config-builder/public-config-builder.ts
@@ -20,15 +20,6 @@ export class PublicConfigBuilder {
   private ensRainbowClient: EnsRainbow.ApiClient;
 
   /**
-   * One-time async readiness hook awaited before the first
-   * `ensRainbowClient.config()` invocation, so callers don't race ENSRainbow's
-   * background bootstrap. Defaults to a no-op for callers that don't need to
-   * gate on readiness (e.g. tests or environments where ENSRainbow is already
-   * known to be ready).
-   */
-  private waitForEnsRainbowReady: () => Promise<void>;
-
-  /**
    * Immutable ENSIndexer Public Config
    *
    * The cached ENSIndexer Public Config object, which is built and validated
@@ -38,15 +29,9 @@ export class PublicConfigBuilder {
 
   /**
    * @param ensRainbowClient ENSRainbow Client instance used to fetch ENSRainbow Public Config
-   * @param waitForEnsRainbowReady One-time async readiness hook awaited before the first
-   *        `ensRainbowClient.config()` invocation. Defaults to a no-op.
    */
-  constructor(
-    ensRainbowClient: EnsRainbow.ApiClient,
-    waitForEnsRainbowReady: () => Promise<void> = async () => {},
-  ) {
+  constructor(ensRainbowClient: EnsRainbow.ApiClient) {
     this.ensRainbowClient = ensRainbowClient;
-    this.waitForEnsRainbowReady = waitForEnsRainbowReady;
   }
 
   /**
@@ -62,8 +47,6 @@ export class PublicConfigBuilder {
    */
   async getPublicConfig(): Promise<EnsIndexerPublicConfig> {
     if (typeof this.immutablePublicConfig === "undefined") {
-      await this.waitForEnsRainbowReady();
-
       const [versionInfo, ensRainbowPublicConfig] = await Promise.all([
         this.getEnsIndexerVersionInfo(),
         // TODO: remove dependency on ENSRainbow by dropping `ensRainbowPublicConfig` from `EnsIndexerPublicConfig`.

--- a/apps/ensindexer/src/lib/public-config-builder/singleton.ts
+++ b/apps/ensindexer/src/lib/public-config-builder/singleton.ts
@@ -1,7 +1,4 @@
-import { ensRainbowClient, waitForEnsRainbowToBeReady } from "@/lib/ensrainbow/singleton";
+import { ensRainbowClient } from "@/lib/ensrainbow/singleton";
 import { PublicConfigBuilder } from "@/lib/public-config-builder/public-config-builder";
 
-export const publicConfigBuilder = new PublicConfigBuilder(
-  ensRainbowClient,
-  waitForEnsRainbowToBeReady,
-);
+export const publicConfigBuilder = new PublicConfigBuilder(ensRainbowClient);

--- a/apps/ensrainbow/src/commands/entrypoint-command.test.ts
+++ b/apps/ensrainbow/src/commands/entrypoint-command.test.ts
@@ -109,6 +109,15 @@ describe("entrypointCommand (existing DB on disk)", () => {
     expect(healthRes.status).toBe(200);
     const healthData = (await healthRes.json()) as EnsRainbow.HealthResponse;
     expect(healthData).toEqual({ status: "ok" });
+
+    // /v1/config must serve the eagerly-built public config from CLI/env args before the DB
+    // attach completes (issue #2020). Note we have NOT awaited bootstrapComplete yet.
+    const earlyConfigRes = await fetch(`${endpoint}/v1/config`);
+    expect(earlyConfigRes.status).toBe(200);
+    const earlyConfigData = (await earlyConfigRes.json()) as EnsRainbow.ENSRainbowPublicConfig;
+    expect(earlyConfigData.serverLabelSet.labelSetId).toBe(labelSetId);
+    expect(earlyConfigData.serverLabelSet.highestLabelSetVersion).toBe(labelSetVersion);
+
     await handle.bootstrapComplete;
 
     const readyRes = await fetch(`${endpoint}/ready`);
@@ -127,6 +136,75 @@ describe("entrypointCommand (existing DB on disk)", () => {
 
     // Marker should still be present after a successful idempotent attach.
     expect(existsSync(markerFile)).toBe(true);
+  });
+});
+
+describe("entrypointCommand (env-vs-DB label-set mismatch)", () => {
+  // The directory name is keyed off the *configured* label set. By seeding a database whose
+  // internal `labelSetId` / `highestLabelSetVersion` differ from those values, we trigger the
+  // post-bootstrap mismatch check.
+  const configuredLabelSetId = buildLabelSetId("entrypoint-mismatch-test");
+  const configuredLabelSetVersion = buildLabelSetVersion(0);
+  const dbLabelSetId = buildLabelSetId("different-labelset");
+  const dbLabelSetVersion = buildLabelSetVersion(1);
+  const port = 3228;
+  const endpoint = `http://localhost:${port}`;
+
+  let testDataDir: string;
+  let handle: EntrypointCommandHandle | undefined;
+
+  beforeEach(async () => {
+    testDataDir = await mkdtemp(join(tmpdir(), "ensrainbow-test-entrypoint-mismatch-"));
+    const dbSubdir = join(testDataDir, `data-${configuredLabelSetId}_${configuredLabelSetVersion}`);
+    const markerFile = join(testDataDir, DB_READY_MARKER_FILENAME);
+
+    const db = await ENSRainbowDB.create(dbSubdir);
+    await db.setPrecalculatedRainbowRecordCount(0);
+    await db.markIngestionFinished();
+    await db.setLabelSetId(dbLabelSetId);
+    await db.setHighestLabelSetVersion(dbLabelSetVersion);
+    await db.close();
+
+    await writeFile(markerFile, "");
+  });
+
+  afterEach(async () => {
+    if (handle) {
+      await handle.close().catch(() => {});
+      handle = undefined;
+    }
+    await rm(testDataDir, { recursive: true, force: true });
+  });
+
+  it("invokes the exit hook with code 1 and does not flip /ready to 200", async () => {
+    const exit = vi.fn<(code: number) => never>(() => undefined as never);
+
+    handle = await entrypointCommand({
+      port,
+      dataDir: testDataDir as AbsolutePath,
+      dbSchemaVersion: DB_SCHEMA_VERSION as DbSchemaVersion,
+      labelSetId: configuredLabelSetId,
+      labelSetVersion: configuredLabelSetVersion,
+      registerSignalHandlers: false,
+      exit,
+    });
+
+    // /v1/config still serves the *configured* (in-memory) public config during the
+    // mismatch window: the DB-derived one is never published.
+    const configRes = await fetch(`${endpoint}/v1/config`);
+    expect(configRes.status).toBe(200);
+    const configData = (await configRes.json()) as EnsRainbow.ENSRainbowPublicConfig;
+    expect(configData.serverLabelSet.labelSetId).toBe(configuredLabelSetId);
+    expect(configData.serverLabelSet.highestLabelSetVersion).toBe(configuredLabelSetVersion);
+
+    await handle.bootstrapComplete;
+
+    expect(exit).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledWith(1);
+
+    // /ready must NOT flip to 200 on mismatch - the cachedDbConfig is never set.
+    const readyRes = await fetch(`${endpoint}/ready`);
+    expect(readyRes.status).toBe(503);
   });
 });
 

--- a/apps/ensrainbow/src/commands/entrypoint-command.test.ts
+++ b/apps/ensrainbow/src/commands/entrypoint-command.test.ts
@@ -110,8 +110,7 @@ describe("entrypointCommand (existing DB on disk)", () => {
     const healthData = (await healthRes.json()) as EnsRainbow.HealthResponse;
     expect(healthData).toEqual({ status: "ok" });
 
-    // /v1/config must serve the eagerly-built public config from CLI/env args before the DB
-    // attach completes (issue #2020). Note we have NOT awaited bootstrapComplete yet.
+    // /v1/config from CLI/env before bootstrap completes.
     const earlyConfigRes = await fetch(`${endpoint}/v1/config`);
     expect(earlyConfigRes.status).toBe(200);
     const earlyConfigData = (await earlyConfigRes.json()) as EnsRainbow.ENSRainbowPublicConfig;
@@ -140,9 +139,7 @@ describe("entrypointCommand (existing DB on disk)", () => {
 });
 
 describe("entrypointCommand (env-vs-DB label-set mismatch)", () => {
-  // The directory name is keyed off the *configured* label set. By seeding a database whose
-  // internal `labelSetId` / `highestLabelSetVersion` differ from those values, we trigger the
-  // post-bootstrap mismatch check.
+  // DB path uses configured id/version; contents claim a different label set -> mismatch after attach.
   const configuredLabelSetId = buildLabelSetId("entrypoint-mismatch-test");
   const configuredLabelSetVersion = buildLabelSetVersion(0);
   const dbLabelSetId = buildLabelSetId("different-labelset");
@@ -189,8 +186,7 @@ describe("entrypointCommand (env-vs-DB label-set mismatch)", () => {
       exit,
     });
 
-    // /v1/config still serves the *configured* (in-memory) public config during the
-    // mismatch window: the DB-derived one is never published.
+    // Still CLI/env public config; bootstrap fails before publishing db-backed state.
     const configRes = await fetch(`${endpoint}/v1/config`);
     expect(configRes.status).toBe(200);
     const configData = (await configRes.json()) as EnsRainbow.ENSRainbowPublicConfig;

--- a/apps/ensrainbow/src/commands/entrypoint-command.test.ts
+++ b/apps/ensrainbow/src/commands/entrypoint-command.test.ts
@@ -174,7 +174,9 @@ describe("entrypointCommand (env-vs-DB label-set mismatch)", () => {
   });
 
   it("invokes the exit hook with code 1 and does not flip /ready to 200", async () => {
-    const exit = vi.fn<(code: number) => never>(() => undefined as never);
+    const exit = vi.fn((code: number): never => {
+      throw new Error(`test exit hook (${code})`);
+    });
 
     handle = await entrypointCommand({
       port,

--- a/apps/ensrainbow/src/commands/entrypoint-command.ts
+++ b/apps/ensrainbow/src/commands/entrypoint-command.ts
@@ -93,13 +93,7 @@ export async function entrypointCommand(
 
   const ensRainbowServer = ENSRainbowServer.createPending();
 
-  // Eagerly build an in-memory `EnsRainbowPublicConfig` from CLI/env args so that `/v1/config`
-  // can serve a non-503 response from the moment the HTTP server starts accepting requests.
-  // This removes the cold-start gap for downstream services (e.g. ENSIndexer) that need to
-  // read ENSRainbow's public config to decide how to behave.
-  // The value is `EnsRainbowServerLabelSet.highestLabelSetVersion` because the entrypoint is
-  // committing to download and serve exactly this version; the post-bootstrap validation below
-  // confirms the on-disk database matches.
+  // Public config from CLI/env so `/v1/config` works before attach; validated against DB after bootstrap.
   const argsServerLabelSet: EnsRainbowServerLabelSet = {
     labelSetId: options.labelSetId,
     highestLabelSetVersion: options.labelSetVersion,
@@ -193,11 +187,6 @@ export async function entrypointCommand(
     setTimeout(() => {
       runDbBootstrap(options, ensRainbowServer, bootstrapAborter.signal)
         .then((dbConfig) => {
-          // Validate that the on-disk database actually matches the label set the entrypoint
-          // was configured to serve. The eagerly-built `inMemoryPublicConfig` (as exposed via
-          // `/v1/config` from startup) must agree with the canonical state stored in the DB;
-          // otherwise downstream consumers would have been told a misleading config during the
-          // cold-start window.
           if (
             dbConfig.serverLabelSet.labelSetId !== argsServerLabelSet.labelSetId ||
             dbConfig.serverLabelSet.highestLabelSetVersion !==

--- a/apps/ensrainbow/src/commands/entrypoint-command.ts
+++ b/apps/ensrainbow/src/commands/entrypoint-command.ts
@@ -6,10 +6,10 @@ import { fileURLToPath } from "node:url";
 
 import { serve } from "@hono/node-server";
 
+import type { EnsRainbowServerLabelSet } from "@ensnode/ensnode-sdk";
 import { stringifyConfig } from "@ensnode/ensnode-sdk/internal";
-import type { EnsRainbow } from "@ensnode/ensrainbow-sdk";
 
-import { buildEnsRainbowPublicConfig } from "@/config/public";
+import { buildEnsRainbowPublicConfigFromLabelSet } from "@/config/public";
 import type { AbsolutePath, DbConfig, DbSchemaVersion } from "@/config/types";
 import { createApi } from "@/lib/api";
 import { ENSRainbowDB } from "@/lib/database";
@@ -50,6 +50,12 @@ export interface EntrypointCommandOptions {
    * Tests should pass `false` to avoid leaking handlers across cases.
    */
   registerSignalHandlers?: boolean;
+  /**
+   * Hook used to terminate the process on fatal bootstrap errors (download failure or
+   * env-vs-DB label-set mismatch). Defaults to `process.exit`. Tests can override this
+   * to assert termination without actually killing the test runner.
+   */
+  exit?: (code: number) => never;
 }
 
 /**
@@ -87,13 +93,21 @@ export async function entrypointCommand(
 
   const ensRainbowServer = ENSRainbowServer.createPending();
 
-  let cachedPublicConfig: EnsRainbow.ENSRainbowPublicConfig | null = null;
+  // Eagerly build an in-memory `EnsRainbowPublicConfig` from CLI/env args so that `/v1/config`
+  // can serve a non-503 response from the moment the HTTP server starts accepting requests.
+  // This removes the cold-start gap for downstream services (e.g. ENSIndexer) that need to
+  // read ENSRainbow's public config to decide how to behave.
+  // The value is `EnsRainbowServerLabelSet.highestLabelSetVersion` because the entrypoint is
+  // committing to download and serve exactly this version; the post-bootstrap validation below
+  // confirms the on-disk database matches.
+  const argsServerLabelSet: EnsRainbowServerLabelSet = {
+    labelSetId: options.labelSetId,
+    highestLabelSetVersion: options.labelSetVersion,
+  };
+  const inMemoryPublicConfig = buildEnsRainbowPublicConfigFromLabelSet(argsServerLabelSet);
+
   let cachedDbConfig: DbConfig | null = null;
-  const app = createApi(
-    ensRainbowServer,
-    () => cachedPublicConfig,
-    () => cachedDbConfig,
-  );
+  const app = createApi(ensRainbowServer, inMemoryPublicConfig, () => cachedDbConfig);
 
   const httpServer = serve({
     fetch: app.fetch,
@@ -172,13 +186,38 @@ export async function entrypointCommand(
     process.once("SIGINT", signalHandler);
   }
 
+  const exit = options.exit ?? ((code: number) => process.exit(code));
+
   const bootstrapComplete = new Promise<void>((resolvePromise) => {
     // Defer bootstrap so the HTTP server starts accepting requests first.
     setTimeout(() => {
       runDbBootstrap(options, ensRainbowServer, bootstrapAborter.signal)
-        .then(({ publicConfig, dbConfig }) => {
+        .then((dbConfig) => {
+          // Validate that the on-disk database actually matches the label set the entrypoint
+          // was configured to serve. The eagerly-built `inMemoryPublicConfig` (as exposed via
+          // `/v1/config` from startup) must agree with the canonical state stored in the DB;
+          // otherwise downstream consumers would have been told a misleading config during the
+          // cold-start window.
+          if (
+            dbConfig.serverLabelSet.labelSetId !== argsServerLabelSet.labelSetId ||
+            dbConfig.serverLabelSet.highestLabelSetVersion !==
+              argsServerLabelSet.highestLabelSetVersion
+          ) {
+            logger.error(
+              `ENSRainbow database label set ` +
+                `${dbConfig.serverLabelSet.labelSetId}@${dbConfig.serverLabelSet.highestLabelSetVersion} ` +
+                `does not match the configured ` +
+                `LABEL_SET_ID=${argsServerLabelSet.labelSetId} / ` +
+                `LABEL_SET_VERSION=${argsServerLabelSet.highestLabelSetVersion}. ` +
+                `Refusing to serve a misconfigured database; please reconcile the env/CLI ` +
+                `arguments with the database in the data directory and restart.`,
+            );
+            resolvePromise();
+            exit(1);
+            return;
+          }
+
           cachedDbConfig = dbConfig;
-          cachedPublicConfig = publicConfig;
           logger.info(
             "ENSRainbow database bootstrap complete. Service is ready to serve heal requests.",
           );
@@ -191,7 +230,8 @@ export async function entrypointCommand(
             return;
           }
           logger.error(error, "ENSRainbow database bootstrap failed - exiting");
-          process.exit(1);
+          resolvePromise();
+          exit(1);
         })
         .finally(() => {
           signalBootstrapSettled();
@@ -206,13 +246,13 @@ export async function entrypointCommand(
  * Idempotent DB bootstrap pipeline.
  *
  * If marker + DB are present, reuse them; otherwise download + extract.
- * Returns the public config and DB config for the attached DB.
+ * Returns the {@link DbConfig} read from the attached DB.
  */
 async function runDbBootstrap(
   options: EntrypointCommandOptions,
   ensRainbowServer: ENSRainbowServer,
   signal: AbortSignal,
-): Promise<{ publicConfig: EnsRainbow.ENSRainbowPublicConfig; dbConfig: DbConfig }> {
+): Promise<DbConfig> {
   const { dataDir, dbSchemaVersion, labelSetId, labelSetVersion } = options;
   const downloadTempDir = options.downloadTempDir ?? join(dataDir, ".download-temp");
   const markerFile = join(dataDir, DB_READY_MARKER_FILENAME);
@@ -233,8 +273,7 @@ async function runDbBootstrap(
       throwIfAborted(signal);
       await ensRainbowServer.attachDb(existingDb);
       existingDbAttached = true;
-      const dbConfig = await buildDbConfig(ensRainbowServer);
-      return { publicConfig: buildEnsRainbowPublicConfig(dbConfig), dbConfig };
+      return await buildDbConfig(ensRainbowServer);
     } catch (error) {
       // Always release any opened DB handle/lock first, even when aborting. This prevents
       // a leaked LevelDB lock when SIGTERM races a non-abort failure (e.g. attachDb throws
@@ -296,8 +335,7 @@ async function runDbBootstrap(
     // Write marker only after a successful attach.
     await writeFile(markerFile, "");
 
-    const dbConfig = await buildDbConfig(ensRainbowServer);
-    return { publicConfig: buildEnsRainbowPublicConfig(dbConfig), dbConfig };
+    return await buildDbConfig(ensRainbowServer);
   } catch (error) {
     if (!dbAttached) {
       await safeClose(db);

--- a/apps/ensrainbow/src/commands/entrypoint-command.ts
+++ b/apps/ensrainbow/src/commands/entrypoint-command.ts
@@ -55,7 +55,7 @@ export interface EntrypointCommandOptions {
    * env-vs-DB label-set mismatch). Defaults to `process.exit`. Tests can override this
    * to assert termination without actually killing the test runner.
    */
-  exit?: (code: number) => never;
+  exit?: (code: number) => void;
 }
 
 /**
@@ -64,7 +64,8 @@ export interface EntrypointCommandOptions {
 export interface EntrypointCommandHandle {
   /**
    * Resolves when bootstrap finishes or is aborted by shutdown.
-   * Never rejects: non-abort failures terminate the process via `process.exit(1)`.
+   * Never rejects: non-abort failures terminate the process via `options.exit(1)`
+   * (defaults to `process.exit(1)`).
    */
   readonly bootstrapComplete: Promise<void>;
   close(): Promise<void>;
@@ -181,6 +182,16 @@ export async function entrypointCommand(
   }
 
   const exit = options.exit ?? ((code: number) => process.exit(code));
+  let exitRequested = false;
+  const requestExit = (code: number) => {
+    exitRequested = true;
+    try {
+      exit(code);
+    } catch (_error) {
+      // Tests may throw from a custom exit hook to short-circuit control flow.
+      // Swallow to avoid this surfacing as a bootstrap failure.
+    }
+  };
 
   const bootstrapComplete = new Promise<void>((resolvePromise) => {
     // Defer bootstrap so the HTTP server starts accepting requests first.
@@ -202,7 +213,7 @@ export async function entrypointCommand(
                 `arguments with the database in the data directory and restart.`,
             );
             resolvePromise();
-            exit(1);
+            requestExit(1);
             return;
           }
 
@@ -218,9 +229,13 @@ export async function entrypointCommand(
             resolvePromise();
             return;
           }
+          if (exitRequested) {
+            resolvePromise();
+            return;
+          }
           logger.error(error, "ENSRainbow database bootstrap failed - exiting");
           resolvePromise();
-          exit(1);
+          requestExit(1);
         })
         .finally(() => {
           signalBootstrapSettled();

--- a/apps/ensrainbow/src/commands/entrypoint-command.ts
+++ b/apps/ensrainbow/src/commands/entrypoint-command.ts
@@ -52,10 +52,12 @@ export interface EntrypointCommandOptions {
   registerSignalHandlers?: boolean;
   /**
    * Hook used to terminate the process on fatal bootstrap errors (download failure or
-   * env-vs-DB label-set mismatch). Defaults to `process.exit`. Tests can override this
-   * to assert termination without actually killing the test runner.
+   * env-vs-DB label-set mismatch). Defaults to `process.exit`. Implementations must not
+   * return normally (same contract as `process.exit`); otherwise the server keeps running
+   * in a failed bootstrap state. Tests may override with a mock that throws to avoid
+   * exiting the runner.
    */
-  exit?: (code: number) => void;
+  exit?: (code: number) => never;
 }
 
 /**

--- a/apps/ensrainbow/src/commands/entrypoint-command.ts
+++ b/apps/ensrainbow/src/commands/entrypoint-command.ts
@@ -53,9 +53,11 @@ export interface EntrypointCommandOptions {
   /**
    * Hook used to terminate the process on fatal bootstrap errors (download failure or
    * env-vs-DB label-set mismatch). Defaults to `process.exit`. Implementations must not
-   * return normally (same contract as `process.exit`); otherwise the server keeps running
-   * in a failed bootstrap state. Tests may override with a mock that throws to avoid
-   * exiting the runner.
+   * return normally (same contract as `process.exit`). If a custom hook returns anyway,
+   * {@link entrypointCommand} calls `process.exit(code)` as a fallback so the process
+   * cannot keep serving after a fatal bootstrap error. Tests should throw from the hook
+   * (caught internally) instead of returning, so the test runner is not killed by that
+   * fallback.
    */
   exit?: (code: number) => never;
 }
@@ -187,11 +189,22 @@ export async function entrypointCommand(
   let exitRequested = false;
   const requestExit = (code: number) => {
     exitRequested = true;
+    let exitHookThrew = false;
     try {
       exit(code);
     } catch (_error) {
+      exitHookThrew = true;
       // Tests may throw from a custom exit hook to short-circuit control flow.
       // Swallow to avoid this surfacing as a bootstrap failure.
+    }
+    if (!exitHookThrew) {
+      // TypeScript cannot enforce `never` at runtime; a buggy hook could return and leave
+      // HTTP up after resolvePromise() + fatal bootstrap — force termination.
+      logger.error(
+        new Error("ENSRainbow exit hook returned without terminating the process"),
+        "Exit hook violated non-returning contract; calling process.exit as fallback",
+      );
+      process.exit(code);
     }
   };
 

--- a/apps/ensrainbow/src/commands/server-command.test.ts
+++ b/apps/ensrainbow/src/commands/server-command.test.ts
@@ -38,11 +38,7 @@ describe("Server Command Tests", () => {
       const ensRainbowServer = await ENSRainbowServer.init(db);
       const dbConfig = await buildDbConfig(ensRainbowServer);
       const publicConfig = buildEnsRainbowPublicConfig(dbConfig);
-      app = createApi(
-        ensRainbowServer,
-        () => publicConfig,
-        () => dbConfig,
-      );
+      app = createApi(ensRainbowServer, publicConfig, () => dbConfig);
 
       // Start the server on a different port than what ENSRainbow defaults to
       server = serve({
@@ -192,23 +188,29 @@ describe("Server Command Tests", () => {
     });
   });
 
-  describe("Pending server (no DB attached yet)", () => {
+  describe("Pending server (eagerly built public config, no DB attached yet)", () => {
     const pendingPort = 3225;
+    const pendingLabelSetId = "pending-test";
+    const pendingLabelSetVersion = 7;
     let pendingApp: Hono;
     let pendingServer: ReturnType<typeof serve>;
     let pendingEnsRainbowServer: ENSRainbowServer;
-    let pendingPublicConfig: EnsRainbow.ENSRainbowPublicConfig | null;
     let pendingDbConfig: Awaited<ReturnType<typeof buildDbConfig>> | null;
 
     beforeAll(async () => {
       pendingEnsRainbowServer = ENSRainbowServer.createPending();
-      pendingPublicConfig = null;
       pendingDbConfig = null;
-      pendingApp = createApi(
-        pendingEnsRainbowServer,
-        () => pendingPublicConfig,
-        () => pendingDbConfig,
-      );
+      // The entrypoint command builds this in-memory public config eagerly from CLI/env args
+      // before the DB is attached; mirror that here using a label set that does not yet exist
+      // in any database.
+      const eagerPublicConfig = buildEnsRainbowPublicConfig({
+        serverLabelSet: {
+          labelSetId: pendingLabelSetId,
+          highestLabelSetVersion: pendingLabelSetVersion,
+        },
+        recordsCount: 0,
+      });
+      pendingApp = createApi(pendingEnsRainbowServer, eagerPublicConfig, () => pendingDbConfig);
       pendingServer = serve({
         fetch: pendingApp.fetch,
         port: pendingPort,
@@ -247,13 +249,19 @@ describe("Server Command Tests", () => {
       expect(data.errorCode).toBe(ErrorCode.ServiceUnavailable);
     });
 
-    it("GET /v1/labels/count and /v1/config return 503 while the DB is not attached", async () => {
-      const [countRes, configRes] = await Promise.all([
-        fetch(`http://localhost:${pendingPort}/v1/labels/count`),
-        fetch(`http://localhost:${pendingPort}/v1/config`),
-      ]);
+    it("GET /v1/labels/count returns 503 while the DB is not attached", async () => {
+      const countRes = await fetch(`http://localhost:${pendingPort}/v1/labels/count`);
       expect(countRes.status).toBe(503);
-      expect(configRes.status).toBe(503);
+    });
+
+    it("GET /v1/config returns 200 with the eagerly-built public config while the DB is not attached", async () => {
+      const configRes = await fetch(`http://localhost:${pendingPort}/v1/config`);
+      expect(configRes.status).toBe(200);
+      const configData = (await configRes.json()) as EnsRainbow.ENSRainbowPublicConfig;
+      expect(configData.serverLabelSet.labelSetId).toBe(pendingLabelSetId);
+      expect(configData.serverLabelSet.highestLabelSetVersion).toBe(pendingLabelSetVersion);
+      expect(typeof configData.versionInfo.ensRainbow).toBe("string");
+      expect(configData.versionInfo.ensRainbow.length).toBeGreaterThan(0);
     });
 
     it("After attachDb, /ready returns 200 and /v1/heal serves labels", async () => {
@@ -265,13 +273,12 @@ describe("Server Command Tests", () => {
       try {
         await attachDb.setPrecalculatedRainbowRecordCount(1);
         await attachDb.markIngestionFinished();
-        await attachDb.setLabelSetId("pending-test");
-        await attachDb.setHighestLabelSetVersion(0);
+        await attachDb.setLabelSetId(pendingLabelSetId);
+        await attachDb.setHighestLabelSetVersion(pendingLabelSetVersion);
         await attachDb.addRainbowRecord("pending-label", 0);
 
         await pendingEnsRainbowServer.attachDb(attachDb);
         pendingDbConfig = await buildDbConfig(pendingEnsRainbowServer);
-        pendingPublicConfig = buildEnsRainbowPublicConfig(pendingDbConfig);
 
         const readyRes = await fetch(`http://localhost:${pendingPort}/ready`);
         expect(readyRes.status).toBe(200);
@@ -288,8 +295,8 @@ describe("Server Command Tests", () => {
         const configRes = await fetch(`http://localhost:${pendingPort}/v1/config`);
         expect(configRes.status).toBe(200);
         const configData = (await configRes.json()) as EnsRainbow.ENSRainbowPublicConfig;
-        expect(configData.serverLabelSet.labelSetId).toBe("pending-test");
-        expect(configData.serverLabelSet.highestLabelSetVersion).toBe(0);
+        expect(configData.serverLabelSet.labelSetId).toBe(pendingLabelSetId);
+        expect(configData.serverLabelSet.highestLabelSetVersion).toBe(pendingLabelSetVersion);
 
         const countRes = await fetch(`http://localhost:${pendingPort}/v1/labels/count`);
         expect(countRes.status).toBe(200);

--- a/apps/ensrainbow/src/commands/server-command.test.ts
+++ b/apps/ensrainbow/src/commands/server-command.test.ts
@@ -200,9 +200,7 @@ describe("Server Command Tests", () => {
     beforeAll(async () => {
       pendingEnsRainbowServer = ENSRainbowServer.createPending();
       pendingDbConfig = null;
-      // The entrypoint command builds this in-memory public config eagerly from CLI/env args
-      // before the DB is attached; mirror that here using a label set that does not yet exist
-      // in any database.
+      // Mirror entrypoint: public config from declared label set before DB attach.
       const eagerPublicConfig = buildEnsRainbowPublicConfig({
         serverLabelSet: {
           labelSetId: pendingLabelSetId,

--- a/apps/ensrainbow/src/commands/server-command.test.ts
+++ b/apps/ensrainbow/src/commands/server-command.test.ts
@@ -9,7 +9,10 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 import { type EnsRainbow, ErrorCode, StatusCode } from "@ensnode/ensrainbow-sdk";
 
-import { buildEnsRainbowPublicConfig } from "@/config/public";
+import {
+  buildEnsRainbowPublicConfig,
+  buildEnsRainbowPublicConfigFromLabelSet,
+} from "@/config/public";
 import { createApi } from "@/lib/api";
 import { ENSRainbowDB } from "@/lib/database";
 import { buildDbConfig, ENSRainbowServer } from "@/lib/server";
@@ -201,12 +204,9 @@ describe("Server Command Tests", () => {
       pendingEnsRainbowServer = ENSRainbowServer.createPending();
       pendingDbConfig = null;
       // Mirror entrypoint: public config from declared label set before DB attach.
-      const eagerPublicConfig = buildEnsRainbowPublicConfig({
-        serverLabelSet: {
-          labelSetId: pendingLabelSetId,
-          highestLabelSetVersion: pendingLabelSetVersion,
-        },
-        recordsCount: 0,
+      const eagerPublicConfig = buildEnsRainbowPublicConfigFromLabelSet({
+        labelSetId: pendingLabelSetId,
+        highestLabelSetVersion: pendingLabelSetVersion,
       });
       pendingApp = createApi(pendingEnsRainbowServer, eagerPublicConfig, () => pendingDbConfig);
       pendingServer = serve({

--- a/apps/ensrainbow/src/commands/server-command.ts
+++ b/apps/ensrainbow/src/commands/server-command.ts
@@ -31,11 +31,7 @@ export async function serverCommand(options: ServerCommandOptions): Promise<void
     console.log("ENSRainbow public config:");
     console.log(stringifyConfig(publicConfig, { pretty: true }));
 
-    const app = createApi(
-      ensRainbowServer,
-      () => publicConfig,
-      () => dbConfig,
-    );
+    const app = createApi(ensRainbowServer, publicConfig, () => dbConfig);
 
     const httpServer = serve({
       fetch: app.fetch,

--- a/apps/ensrainbow/src/config/public.ts
+++ b/apps/ensrainbow/src/config/public.ts
@@ -5,14 +5,7 @@ import type { EnsRainbow } from "@ensnode/ensrainbow-sdk";
 
 import type { DbConfig } from "./types";
 
-/**
- * Build an `EnsRainbowPublicConfig` from a known `EnsRainbowServerLabelSet`.
- *
- * Used by both:
- * - the eager startup path (entrypoint command), where the label set comes from CLI/env args
- *   and the database has not yet been opened, and
- * - the post-bootstrap path, where the label set comes from the opened database.
- */
+/** Builds public config from a label set (CLI/env before DB open, or from DB after open). */
 export function buildEnsRainbowPublicConfigFromLabelSet(
   serverLabelSet: EnsRainbowServerLabelSet,
 ): EnsRainbow.ENSRainbowPublicConfig {

--- a/apps/ensrainbow/src/config/public.ts
+++ b/apps/ensrainbow/src/config/public.ts
@@ -1,17 +1,31 @@
 import packageJson from "@/../package.json" with { type: "json" };
 
-import type { EnsRainbowVersionInfo } from "@ensnode/ensnode-sdk";
+import type { EnsRainbowServerLabelSet, EnsRainbowVersionInfo } from "@ensnode/ensnode-sdk";
 import type { EnsRainbow } from "@ensnode/ensrainbow-sdk";
 
 import type { DbConfig } from "./types";
 
-export function buildEnsRainbowPublicConfig(dbConfig: DbConfig): EnsRainbow.ENSRainbowPublicConfig {
+/**
+ * Build an `EnsRainbowPublicConfig` from a known `EnsRainbowServerLabelSet`.
+ *
+ * Used by both:
+ * - the eager startup path (entrypoint command), where the label set comes from CLI/env args
+ *   and the database has not yet been opened, and
+ * - the post-bootstrap path, where the label set comes from the opened database.
+ */
+export function buildEnsRainbowPublicConfigFromLabelSet(
+  serverLabelSet: EnsRainbowServerLabelSet,
+): EnsRainbow.ENSRainbowPublicConfig {
   const versionInfo = {
     ensRainbow: packageJson.version,
   } satisfies EnsRainbowVersionInfo;
 
   return {
-    serverLabelSet: dbConfig.serverLabelSet,
+    serverLabelSet,
     versionInfo,
   };
+}
+
+export function buildEnsRainbowPublicConfig(dbConfig: DbConfig): EnsRainbow.ENSRainbowPublicConfig {
+  return buildEnsRainbowPublicConfigFromLabelSet(dbConfig.serverLabelSet);
 }

--- a/apps/ensrainbow/src/lib/api.ts
+++ b/apps/ensrainbow/src/lib/api.ts
@@ -18,15 +18,10 @@ import { getErrorMessage } from "@/utils/error-utils";
 import { logger } from "@/utils/logger";
 
 /**
- * Supplier of the current public config for the API.
+ * Supplier of the current {@link DbConfig} snapshot.
  *
  * Returns `null` while the server is still bootstrapping its database. Once the database is
- * attached, the supplier returns the final `ENSRainbowPublicConfig` (cached by the caller).
- */
-export type PublicConfigSupplier = () => EnsRainbow.ENSRainbowPublicConfig | null;
-
-/**
- * Like {@link PublicConfigSupplier}, but yields the {@link DbConfig} snapshot.
+ * attached, the supplier returns the final `DbConfig` (cached by the caller).
  */
 export type DbConfigSupplier = () => DbConfig | null;
 
@@ -48,13 +43,15 @@ function buildServiceUnavailableBody(
 /**
  * Creates and configures the ENS Rainbow API routes.
  *
- * When `publicConfigSupplier` (or `dbConfigSupplier`) returns `null`, routes that depend on the
- * database respond with HTTP 503 so that clients polling `/ready` can wait for the bootstrap to
- * complete.
+ * `publicConfig` is always available - the entrypoint command builds it eagerly from CLI/env
+ * arguments before the database has finished bootstrapping, so `/v1/config` can serve it
+ * immediately. When `dbConfigSupplier` returns `null`, routes that depend on the database
+ * (e.g. `/v1/labels/count`, `/v1/heal/:labelhash`, `/ready`) respond with HTTP 503 so that
+ * clients polling `/ready` can wait for the bootstrap to complete.
  */
 export function createApi(
   server: ENSRainbowServer,
-  publicConfigSupplier: PublicConfigSupplier,
+  publicConfig: EnsRainbow.ENSRainbowPublicConfig,
   dbConfigSupplier: DbConfigSupplier,
 ): Hono {
   const api = new Hono();
@@ -133,8 +130,10 @@ export function createApi(
   });
 
   api.get("/ready", (c: HonoContext) => {
-    // Require both DB attach and config publication to avoid a transient false-ready state.
-    if (!server.isReady() || publicConfigSupplier() === null) {
+    // `/ready` indicates the database has fully bootstrapped (downloaded, attached, validated).
+    // Require both `server.isReady()` (DB attached) and `dbConfigSupplier() !== null`
+    // (DB-derived config published) to avoid a transient false-ready state.
+    if (!server.isReady() || dbConfigSupplier() === null) {
       return c.json(buildServiceUnavailableBody(), 503);
     }
     const result: EnsRainbow.ReadyResponse = { status: "ok" };
@@ -156,10 +155,6 @@ export function createApi(
   });
 
   api.get("/v1/config", (c: HonoContext) => {
-    const publicConfig = publicConfigSupplier();
-    if (publicConfig === null) {
-      return c.json(buildServiceUnavailableBody(), 503);
-    }
     return c.json(publicConfig);
   });
 

--- a/apps/ensrainbow/src/lib/api.ts
+++ b/apps/ensrainbow/src/lib/api.ts
@@ -41,13 +41,10 @@ function buildServiceUnavailableBody(
 }
 
 /**
- * Creates and configures the ENS Rainbow API routes.
+ * Creates and configures ENSRainbow HTTP routes.
  *
- * `publicConfig` is always available - the entrypoint command builds it eagerly from CLI/env
- * arguments before the database has finished bootstrapping, so `/v1/config` can serve it
- * immediately. When `dbConfigSupplier` returns `null`, routes that depend on the database
- * (e.g. `/v1/labels/count`, `/v1/heal/:labelhash`, `/ready`) respond with HTTP 503 so that
- * clients polling `/ready` can wait for the bootstrap to complete.
+ * `publicConfig` may be built before the DB exists (entrypoint). `dbConfigSupplier` stays `null`
+ * until bootstrap finishes; database-backed routes and `/ready` return 503 until then.
  */
 export function createApi(
   server: ENSRainbowServer,
@@ -68,7 +65,7 @@ export function createApi(
   );
 
   api.get("/v1/heal/:labelhash", async (c: HonoContext) => {
-    if (!server.isReady()) {
+    if (!server.isReady() || dbConfigSupplier() === null) {
       return c.json(buildServiceUnavailableBody(), 503);
     }
 
@@ -130,9 +127,6 @@ export function createApi(
   });
 
   api.get("/ready", (c: HonoContext) => {
-    // `/ready` indicates the database has fully bootstrapped (downloaded, attached, validated).
-    // Require both `server.isReady()` (DB attached) and `dbConfigSupplier() !== null`
-    // (DB-derived config published) to avoid a transient false-ready state.
     if (!server.isReady() || dbConfigSupplier() === null) {
       return c.json(buildServiceUnavailableBody(), 503);
     }

--- a/docs/ensnode.io/src/content/docs/ensrainbow/usage/api.mdx
+++ b/docs/ensnode.io/src/content/docs/ensrainbow/usage/api.mdx
@@ -14,7 +14,7 @@ sidebar:
 | `GET /ready` | Readiness probe — succeeds once the database has been downloaded, validated, and opened | `ReadyResponse`, `ServiceUnavailableError` |
 | `GET /v1/heal/{labelhash}` | Heal a single labelhash | `HealSuccess`, `HealError` |
 | `GET /v1/labels/count` | Current healable label count | `CountSuccess`, `CountServerError`, `ServiceUnavailableError` |
-| `GET /v1/config` | Public configuration of the running instance | `ENSRainbowPublicConfig`, `ServiceUnavailableError` |
+| `GET /v1/config` | Public configuration of the running instance — available immediately at startup | `ENSRainbowPublicConfig` |
 
 :::tip[Deterministic Results]
 Pin `labelSetVersion` in your client if you need **deterministic results** across time. See the [Label Sets & Versioning guide](/ensrainbow/concepts/label-sets-and-versioning/) for details.
@@ -26,6 +26,7 @@ ENSRainbow's container starts its HTTP server immediately so that orchestrators 
 
 - **`GET /health`** — pure **liveness** probe. Returns `200 { status: "ok" }` as soon as the HTTP server is bound. It does **not** guarantee the database is loaded.
 - **`GET /ready`** — **readiness** probe. Returns `200 { status: "ok" }` only after the database has been downloaded, lite-validated, and opened by the process. While the server is still bootstrapping, it returns `503 Service Unavailable` with a structured error body so clients can poll with backoff.
+- **`GET /v1/config`** — **available immediately** at startup. ENSRainbow builds the public config in-memory from its CLI/env arguments (`LABEL_SET_ID`, `LABEL_SET_VERSION`) before the database has finished bootstrapping, so downstream services (e.g. ENSIndexer) can read the public config without waiting on a cold start. When bootstrap finishes, ENSRainbow verifies the database's stored label set matches the configured one and refuses to serve (terminating with a non-zero exit code) on mismatch.
 
 While the database is not yet ready, the following routes return `503` with the body:
 
@@ -39,7 +40,6 @@ While the database is not yet ready, the following routes return `503` with the 
 
 - `GET /v1/heal/{labelhash}`
 - `GET /v1/labels/count`
-- `GET /v1/config`
 
 Clients (including ENSIndexer) should poll `/ready` rather than `/health` before issuing heal requests. The official `ensrainbow-sdk` exposes `client.ready()` exactly for this purpose.
 

--- a/docs/ensnode.io/src/content/docs/ensrainbow/usage/api.mdx
+++ b/docs/ensnode.io/src/content/docs/ensrainbow/usage/api.mdx
@@ -200,18 +200,18 @@ Success Response:
 
 ```json
 {
-  "version": "0.1.0",
-  "labelSet": {
+  "serverLabelSet": {
     "labelSetId": "subgraph",
     "highestLabelSetVersion": 0
   },
-  "recordsCount": 133856894
+  "versionInfo": {
+    "ensRainbow": "0.1.0"
+  }
 }
 ```
 
 The response contains:
-- `version`: The current version of ENSRainbow
-- `labelSet`: The label set of the loaded database
-  - `labelSetId`: The label set ID of the loaded database
-  - `highestLabelSetVersion`: The highest label set version available in the database
-- `recordsCount`: The total count of labels that can be healed by the ENSRainbow instance
+- `serverLabelSet`: The label set managed by the ENSRainbow instance
+  - `serverLabelSet.labelSetId`: The label set ID of the loaded database
+  - `serverLabelSet.highestLabelSetVersion`: The highest label set version available in the database
+- `versionInfo.ensRainbow`: The current ENSRainbow service version

--- a/docs/ensnode.io/src/content/docs/ensrainbow/usage/api.mdx
+++ b/docs/ensnode.io/src/content/docs/ensrainbow/usage/api.mdx
@@ -211,7 +211,7 @@ Success Response:
 ```
 
 The response contains:
-- `serverLabelSet`: The label set managed by the ENSRainbow instance
-  - `serverLabelSet.labelSetId`: The label set ID of the loaded database
-  - `serverLabelSet.highestLabelSetVersion`: The highest label set version available in the database
+- `serverLabelSet`: The configured label set (from `LABEL_SET_ID` / `LABEL_SET_VERSION`) used at startup
+  - `serverLabelSet.labelSetId`: Configured label set ID (validated against the database during bootstrap)
+  - `serverLabelSet.highestLabelSetVersion`: Configured label set version (validated against the database during bootstrap)
 - `versionInfo.ensRainbow`: The current ENSRainbow service version


### PR DESCRIPTION
# Lite PR

[Tip: Review docs on the ENSNode PR process](https://ensnode.io/docs/contributing/prs)

## Summary

- ENSRainbow now serves `GET /v1/config` **immediately on startup** (entrypoint mode), using CLI/env label-set values.
- After DB bootstrap completes, ENSRainbow **validates the DB-stored label set matches** the configured one and terminates with a helpful error on mismatch.
- `GET /ready` and `GET /v1/heal/:labelhash` are now aligned to only succeed once bootstrap has completed and DB-backed config is published; docs + tests updated.

---

## Why

- Prevent ENSRainbow cold starts from cascading across dependent services by allowing clients to fetch `EnsRainbowPublicConfig` as soon as possible.
- Related: [Issue #2020](https://github.com/namehash/ensnode/issues/2020)

---

## Testing



---

## Notes for Reviewer (Optional)

- `entrypointCommand` builds `/v1/config` from `LABEL_SET_ID`/`LABEL_SET_VERSION` immediately, then validates those values against DB metadata after bootstrap; on mismatch it exits (testable via an injected `exit` hook).

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)