### PR TITLE
ci: extract promote_vercel_deployment action, run for ensadmin + example app

### DIFF
--- a/.github/actions/promote_vercel_deployment/action.yml
+++ b/.github/actions/promote_vercel_deployment/action.yml
@@ -1,0 +1,40 @@
+name: Promote Vercel Deployment
+description: Promotes the Vercel production deployment whose commit SHA matches
+  the active ENSIndexer image in the given Railway environment. Ensures exact
+  version matching between the active ENSNode and the Vercel project.
+
+inputs:
+  vercel_team_slug:
+    description: "Vercel team slug"
+    required: true
+
+  vercel_project_id:
+    description: "Vercel project ID to promote"
+    required: true
+
+  vercel_token:
+    description: "Vercel API token"
+    required: true
+
+  railway_token:
+    description: "Railway API token"
+    required: true
+
+  railway_environment_id:
+    description: "Railway environment ID containing the active ENSIndexer image"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Promote
+      shell: bash
+      env:
+        VERCEL_PROJECT_ID: ${{ inputs.vercel_project_id }}
+        VERCEL_TEAM_SLUG: ${{ inputs.vercel_team_slug }}
+        VERCEL_TOKEN: ${{ inputs.vercel_token }}
+        RAILWAY_TOKEN: ${{ inputs.railway_token }}
+        RAILWAY_ENVIRONMENT_ID: ${{ inputs.railway_environment_id }}
+      run: |
+        chmod +x ${{ github.action_path }}/promote_vercel_deployment.sh
+        ${{ github.action_path }}/promote_vercel_deployment.sh

--- a/.github/actions/promote_vercel_deployment/action.yml
+++ b/.github/actions/promote_vercel_deployment/action.yml
@@ -35,6 +35,4 @@ runs:
         VERCEL_TOKEN: ${{ inputs.vercel_token }}
         RAILWAY_TOKEN: ${{ inputs.railway_token }}
         RAILWAY_ENVIRONMENT_ID: ${{ inputs.railway_environment_id }}
-      run: |
-        chmod +x ${{ github.action_path }}/promote_vercel_deployment.sh
-        ${{ github.action_path }}/promote_vercel_deployment.sh
+      run: ${{ github.action_path }}/promote_vercel_deployment.sh

--- a/.github/actions/promote_vercel_deployment/promote_vercel_deployment.sh
+++ b/.github/actions/promote_vercel_deployment/promote_vercel_deployment.sh
@@ -1,29 +1,38 @@
 #!/bin/bash
 
-# Identifies the commit sha of images deployed to the incoming active env and ensures that the appropriate
-# ENSAdmin Vercel Deployment is promoted to production. This ensures exact version matching between
-# the active ENSNode and the production ENSAdmin.
-VERCEL_PROJECT_ID=prj_nKcHTO12hq9kcgascQMq4xokRhwp # admin.ensnode.io
-VERCEL_TEAM_SLUG=namehash
+# Identifies the commit sha of the ENSIndexer image deployed to the active Railway environment
+# and promotes the Vercel deployment with that sha to production for the given Vercel project.
+# Ensures exact version matching between the active ENSNode and the production Vercel deployment.
 
 set -euo pipefail
 
-if [ -z "$VERCEL_TOKEN" ]; then
+if [ -z "${VERCEL_PROJECT_ID:-}" ]; then
+  echo "Error: VERCEL_PROJECT_ID is not set or is empty"
+  exit 1
+fi
+
+if [ -z "${VERCEL_TEAM_SLUG:-}" ]; then
+  echo "Error: VERCEL_TEAM_SLUG is not set or is empty"
+  exit 1
+fi
+
+if [ -z "${VERCEL_TOKEN:-}" ]; then
   echo "Error: VERCEL_TOKEN is not set or is empty"
   exit 1
 fi
 
-if [ -z "$RAILWAY_TOKEN" ]; then
+if [ -z "${RAILWAY_TOKEN:-}" ]; then
   echo "Error: RAILWAY_TOKEN is not set or is empty"
   exit 1
 fi
 
-if [ -z "$RAILWAY_ENVIRONMENT_ID" ]; then
+if [ -z "${RAILWAY_ENVIRONMENT_ID:-}" ]; then
   echo "Error: RAILWAY_ENVIRONMENT_ID is not set or is empty"
   exit 1
 fi
 
 echo "Targeting Railway Environment: $RAILWAY_ENVIRONMENT_ID"
+echo "Targeting Vercel Project: $VERCEL_PROJECT_ID"
 
 # first, get deployed ENSIndexer image from Railway Environment
 RAILWAY_SERVICES_OUTPUT=$(curl \

--- a/.github/workflows/deploy_switch_ensnode_environment.yml
+++ b/.github/workflows/deploy_switch_ensnode_environment.yml
@@ -93,9 +93,22 @@ jobs:
           redis-cli -u $REDIS_URL SET traefik/http/routers/ensrainbow-searchlight-api-router/service "${TARGET_ENVIRONMENT}-ensrainbow-searchlight-api"
 
       - name: Promote ENSAdmin Vercel Deployment
-        run: |
-          chmod +x ./.github/scripts/promote_ensadmin.sh
-          ./.github/scripts/promote_ensadmin.sh
+        uses: ./.github/actions/promote_vercel_deployment
+        with:
+          vercel_team_slug: namehash
+          vercel_project_id: prj_nKcHTO12hq9kcgascQMq4xokRhwp
+          vercel_token: ${{ secrets.VERCEL_TOKEN }}
+          railway_token: ${{ secrets.RAILWAY_TOKEN }}
+          railway_environment_id: ${{ env.RAILWAY_ENVIRONMENT_ID }}
+
+      - name: Promote Example App Vercel Deployment
+        uses: ./.github/actions/promote_vercel_deployment
+        with:
+          vercel_team_slug: namehash
+          vercel_project_id: prj_Ux80vjjNyDfXMNvPEQo4zlx6Eq6D
+          vercel_token: ${{ secrets.VERCEL_TOKEN }}
+          railway_token: ${{ secrets.RAILWAY_TOKEN }}
+          railway_environment_id: ${{ env.RAILWAY_ENVIRONMENT_ID }}
 
       - name: Send Slack Notification
         uses: ./.github/actions/send_slack_notification


### PR DESCRIPTION
## Summary

- extracted `promote_ensadmin.sh` into a reusable composite action at `.github/actions/promote_vercel_deployment/`, parameterized by `vercel_project_id` and `vercel_team_slug`
- `deploy_switch_ensnode_environment` now invokes the action twice: ensadmin (`prj_nKcHTO12hq9kcgascQMq4xokRhwp`) and example app (`prj_Ux80vjjNyDfXMNvPEQo4zlx6Eq6D`)
- deleted the now-unused `.github/scripts/promote_ensadmin.sh`

---

## Why

- the example app's vercel deployment should be version-locked to the active ensnode environment, same as ensadmin
- pulled the script out of `scripts/` and into a composite action so we don't fork per project

---

## Testing

- not tested live — workflow only runs via `workflow_dispatch` against real green/blue environments
- validated by inspection: the script is unchanged apart from reading `VERCEL_PROJECT_ID` / `VERCEL_TEAM_SLUG` from env instead of hardcoding, and the action wires the same env vars through that the workflow already exports

---

## Notes for Reviewer

- the example app step runs after the ensadmin step in the same job. if the example app has no vercel deployment matching the active ensindexer commit sha, the workflow step will fail (and the slack notification won't fire). ensadmin already has this exact behavior — we're just extending the same coupling to a second project.
- the script now lives inside the action directory (`.github/actions/promote_vercel_deployment/promote_vercel_deployment.sh`) instead of `.github/scripts/`, so the action is self-contained.

---

## Checklist

- [x] This PR is low-risk and safe to review quickly