### PR TITLE
fix: populate sepolia-v2 example query variables with real names + accounts

### DIFF
--- a/packages/ensnode-sdk/src/omnigraph-api/example-queries.ts
+++ b/packages/ensnode-sdk/src/omnigraph-api/example-queries.ts
@@ -32,7 +32,12 @@ const ENS_TEST_ENV_V2_ETH_REGISTRAR = maybeGetDatasourceContract(
 
 const VITALIK_ADDRESS = toNormalizedAddress("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
 
+// owns tryingagain.eth + debuggincrap.eth on sepolia-v2 and has resolver permissions on each
+const SEPOLIA_V2_USER_ADDRESS = toNormalizedAddress("0x205d2686da3bf33f64c17f21462c51b5ead462cf");
+
 const DEVNET_NAME_WITH_OWNED_RESOLVER = asInterpretedName("example.eth");
+
+const SEPOLIA_V2_NAME_WITH_OWNED_RESOLVER = asInterpretedName("tryingagain.eth");
 
 export const GRAPHQL_API_EXAMPLE_QUERIES: Array<{
   query: string;
@@ -85,6 +90,7 @@ query FindDomains(
     variables: {
       default: { name: "vitalik", order: { by: "NAME", dir: "DESC" } },
       [ENSNamespaceIds.EnsTestEnv]: { name: "c", order: { by: "NAME", dir: "DESC" } },
+      [ENSNamespaceIds.SepoliaV2]: { name: "trying", order: { by: "NAME", dir: "DESC" } },
     },
   },
 
@@ -112,7 +118,10 @@ query DomainByName($name: InterpretedName!) {
     }
   }
 }`,
-    variables: { default: { name: "eth" } },
+    variables: {
+      default: { name: "eth" },
+      [ENSNamespaceIds.SepoliaV2]: { name: "tryingagain.eth" },
+    },
   },
 
   //////////////////////
@@ -157,7 +166,10 @@ query DomainEvents($name: InterpretedName!) {
     }
   }
 }`,
-    variables: { default: { name: "newowner.eth" } },
+    variables: {
+      default: { name: "newowner.eth" },
+      [ENSNamespaceIds.SepoliaV2]: { name: "tryingagain.eth" },
+    },
   },
 
   ////////////////////
@@ -182,6 +194,7 @@ query AccountDomains(
     variables: {
       default: { address: VITALIK_ADDRESS },
       [ENSNamespaceIds.EnsTestEnv]: { address: DevnetAccounts.owner.address },
+      [ENSNamespaceIds.SepoliaV2]: { address: SEPOLIA_V2_USER_ADDRESS },
     },
   },
 
@@ -200,6 +213,7 @@ query AccountEvents(
     variables: {
       default: { address: VITALIK_ADDRESS },
       [ENSNamespaceIds.EnsTestEnv]: { address: DevnetAccounts.deployer.address },
+      [ENSNamespaceIds.SepoliaV2]: { address: SEPOLIA_V2_USER_ADDRESS },
     },
   },
 
@@ -283,8 +297,7 @@ query PermissionsByUser($address: Address!) {
 }`,
     variables: {
       default: { address: DevnetAccounts.deployer.address },
-      // TODO: figure out a good sepolia-v2 user address
-      // [ENSNamespaceIds.SepoliaV2]: { address: "" },
+      [ENSNamespaceIds.SepoliaV2]: { address: SEPOLIA_V2_USER_ADDRESS },
     },
   },
 
@@ -310,8 +323,7 @@ query AccountResolverPermissions($address: Address!) {
 }`,
     variables: {
       default: { address: DevnetAccounts.deployer.address },
-      // TODO: figure out a good sepolia-v2 user address
-      // [ENSNamespaceIds.SepoliaV2]: { address: "" },
+      [ENSNamespaceIds.SepoliaV2]: { address: SEPOLIA_V2_USER_ADDRESS },
     },
   },
 
@@ -332,6 +344,7 @@ query DomainResolver($name: InterpretedName!) {
     variables: {
       default: { name: "vitalik.eth" },
       [ENSNamespaceIds.EnsTestEnv]: { name: DEVNET_NAME_WITH_OWNED_RESOLVER },
+      [ENSNamespaceIds.SepoliaV2]: { name: SEPOLIA_V2_NAME_WITH_OWNED_RESOLVER },
     },
   },
 


### PR DESCRIPTION
## Summary

- replace placeholder/empty sepolia-v2 variables in `packages/ensnode-sdk/src/omnigraph-api/example-queries.ts` with real on-chain values pulled from the tenderly virtual rpc
- add sepolia-v2 entries for `FindDomains`, `DomainByName`, `DomainEvents`, `AccountDomains`, `AccountEvents`, `PermissionsByUser`, `AccountResolverPermissions`, `DomainResolver`
- removes the two `TODO: figure out a good sepolia-v2 user address` placeholders

## Why

example queries were returning empty results when run against sepolia-v2 because the variables defaulted to mainnet/devnet values. swapped in a real label owner (`0x205d...62cf` — owns `tryingagain.eth` + `debuggincrap.eth` and has resolver permissions on each name's dedicated resolver) and a real registered name (`tryingagain.eth`).

## Testing

- `pnpm -F @ensnode/ensnode-sdk typecheck` ✅
- `pnpm -F @ensnode/ensnode-sdk lint` ✅
- @shrugs will manually test against the live sepolia-v2 index once it catches up

## Notes for Reviewer

- values were sourced by reading `LabelRegistered` / `EACRolesChanged` / `ResolverUpdated` events directly off the tenderly virtual rpc (block range 3702720–10744892), since the local index hadn't caught up yet
- only 4 .eth labels exist on sepolia-v2 today: `sfmohnjyjvmig`, `sfmohnjyjvv2ok`, `tryingagain`, `debuggincrap` — picked `tryingagain.eth` as the canonical "name with owned resolver" since it has a dedicated resolver + EAC permissions

## Checklist

- [x] This PR does **not** change runtime behavior or semantics
- [x] This PR is low-risk and safe to review quickly