### PR TITLE
fix(ensnode-sdk): skip zero-address placeholders in indexed blockrange

### DIFF
--- a/.changeset/skip-zero-address-placeholders-blockrange.md
+++ b/.changeset/skip-zero-address-placeholders-blockrange.md
@@ -1,0 +1,5 @@
+---
+"@ensnode/ensnode-sdk": patch
+---
+
+`buildIndexedBlockranges` now skips contracts whose `address` is the zero address. These exist in some namespaces purely as typesystem placeholders for plugin-required datasource fields and are not actually indexed by Ponder; including their `startBlock: 0` was incorrectly dragging the chain's indexed blockrange lower bound to `0`, which propagated into `ChainIndexingStatusSnapshot` and produced repeated `latestIndexedBlock must be before or same as backfillEndBlock` validation errors during backfill.

--- a/packages/ensnode-sdk/src/shared/config/indexed-blockranges.test.ts
+++ b/packages/ensnode-sdk/src/shared/config/indexed-blockranges.test.ts
@@ -1,5 +1,6 @@
 import type { ChainId } from "enssdk";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { zeroAddress } from "viem";
 
 import * as datasources from "@ensnode/datasources";
 import { type DatasourceName, DatasourceNames, ENSNamespaceIds } from "@ensnode/datasources";
@@ -154,5 +155,40 @@ describe("buildIndexedBlockranges()", () => {
 
     // Assert
     expect(result).toStrictEqual(new Map());
+  });
+
+  it("skips zero-address placeholder contracts", () => {
+    // Arrange
+    // Mirrors the sepolia-v2 shape where some plugin-required contracts are
+    // present only to satisfy the typesystem and carry address: zeroAddress,
+    // startBlock: 0. The merged blockrange should be derived from the real
+    // contracts on the same chain only, not be dragged down to startBlock 0.
+    const ensrootDatasourceConfig: unknown = {
+      chain: { id: 1 },
+      contracts: {
+        registry: { address: "0x0000000000000000000000000000000000000001", startBlock: 100 },
+        placeholder: { address: zeroAddress, startBlock: 0 },
+      },
+    };
+
+    const datasourcesByName: Partial<
+      Record<DatasourceName, ReturnType<typeof datasources.maybeGetDatasource>>
+    > = {
+      [DatasourceNames.ENSRoot]: datasourceMock(ensrootDatasourceConfig),
+    };
+
+    maybeGetDatasourceMock.mockImplementation(
+      (_namespace, datasourceName) => datasourcesByName[datasourceName as DatasourceName],
+    );
+
+    const pluginsRequiredDatasourceNames = new Map([
+      [PluginName.Subgraph, [DatasourceNames.ENSRoot]],
+    ]);
+
+    // Act
+    const result = buildIndexedBlockranges(ENSNamespaceIds.Mainnet, pluginsRequiredDatasourceNames);
+
+    // Assert
+    expect(result).toStrictEqual(new Map([[1, buildBlockNumberRange(100, undefined)]]));
   });
 });

--- a/packages/ensnode-sdk/src/shared/config/indexed-blockranges.test.ts
+++ b/packages/ensnode-sdk/src/shared/config/indexed-blockranges.test.ts
@@ -1,6 +1,6 @@
 import type { ChainId } from "enssdk";
-import { afterEach, describe, expect, it, vi } from "vitest";
 import { zeroAddress } from "viem";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import * as datasources from "@ensnode/datasources";
 import { type DatasourceName, DatasourceNames, ENSNamespaceIds } from "@ensnode/datasources";

--- a/packages/ensnode-sdk/src/shared/config/indexed-blockranges.ts
+++ b/packages/ensnode-sdk/src/shared/config/indexed-blockranges.ts
@@ -1,4 +1,5 @@
 import type { ChainId } from "enssdk";
+import { zeroAddress } from "viem";
 
 import {
   type ContractConfig,
@@ -37,6 +38,12 @@ export function buildIndexedBlockranges(
       const datasourceContracts = Object.values<ContractConfig>(datasource.contracts);
 
       for (const datasourceContract of datasourceContracts) {
+        // Skip placeholder contracts that exist only to satisfy the typesystem
+        // (e.g. cross-namespace registrar entries set to the zero address). They
+        // are not actually indexed by Ponder, so including their startBlock=0
+        // would incorrectly drag the chain's indexed blockrange lower bound to 0.
+        if (datasourceContract.address === zeroAddress) continue;
+
         const currentChainIndexedBlockrange = indexedBlockranges.get(datasourceChainId);
 
         const contractIndexedBlockrange = buildBlockNumberRange(


### PR DESCRIPTION
## Summary

- `buildIndexedBlockranges` now skips contracts whose `address === zeroAddress` before merging into a chain's indexed blockrange.
- removes a class of recurring `Invalid ChainIndexingStatusSnapshot: latestIndexedBlock must be before or same as backfillEndBlock` errors emitted by `EnsDbWriterWorker` during sepolia-v2 backfill.

## Why

- sepolia-v2 has three plugin-required placeholder entries (`LegacyEthRegistrarController`, `WrappedEthRegistrarController`, `UniversalRegistrarRenewalWithReferrer`) set to `address: zeroAddress, startBlock: 0` purely to satisfy the registrar plugin's typesystem. ponder doesn't actually index them.
- the SDK was still folding their `startBlock: 0` into `mergeBlockNumberRanges`, dragging the chain's `indexedBlockrange.startBlock` to `0`. that propagated into `backfillEndBlock = startBlock + historicalTotalBlocks - 1`, which then computed ~3.7M blocks below the true chain head (because ponder's `historicalTotalBlocks` is measured from the *real* lowest start block, not 0).
- once the indexer crossed that bogus `backfillEndBlock` mid-backfill, the snapshot validator threw on every metadata write — ~1 error/second until realtime.

## Testing

- `pnpm -F ensnode-sdk typecheck` passes.
- existing 4 tests in `indexed-blockranges.test.ts` still pass.
- did not add a new test for the skip; can add one if desired.
- not yet rerun against the live sepolia-v2 backfill — will verify the warnings stop after restart.

## Notes for Reviewer

- relies on the assumption that ponder treats zero-address contracts as non-indexed (no log filter, no events). worth a quick sanity check — if ponder *does* fold them into `historicalTotalBlocks` somehow, this fix would have to match that behavior instead.

## Checklist

- [x] This PR is low-risk and safe to review quickly