### PR TITLE
feat(enskit-example): add account browser, refresh sepolia-v2 examples

### DIFF
--- a/.changeset/enskit-account-key-by-address.md
+++ b/.changeset/enskit-account-key-by-address.md
@@ -1,0 +1,6 @@
+---
+"enskit": patch
+"@ensnode/ensnode-sdk": patch
+---
+
+allow `Account` entities to be normalized by `address` when `id` is not selected, eliminating urql graphcache warnings on queries like `owner { address }`. updated sepolia-v2 example query variables to point at names/addresses present in the current deployment.

--- a/.changeset/enskit-account-key-by-address.md
+++ b/.changeset/enskit-account-key-by-address.md
@@ -1,6 +1,0 @@
----
-"enskit": patch
-"@ensnode/ensnode-sdk": patch
----
-
-allow `Account` entities to be normalized by `address` when `id` is not selected, eliminating urql graphcache warnings on queries like `owner { address }`. updated sepolia-v2 example query variables to point at names/addresses present in the current deployment.

--- a/examples/enskit-react-example/src/AccountView.tsx
+++ b/examples/enskit-react-example/src/AccountView.tsx
@@ -1,0 +1,99 @@
+import { graphql, useOmnigraphQuery } from "enskit/react/omnigraph";
+import { isNormalizedAddress, type NormalizedAddress, toNormalizedAddress } from "enssdk";
+import { useState } from "react";
+import { Link, Navigate, useParams } from "react-router";
+
+const AccountDomainsQuery = graphql(`
+  query AccountDomains($address: Address!, $first: Int!, $after: String) {
+    account(by: { address: $address }) {
+      address
+      domains(first: $first, after: $after) {
+        totalCount
+        edges {
+          node { __typename id name owner { address } }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+`);
+
+const PAGE_SIZE = 20;
+
+function RenderAccount({ address }: { address: NormalizedAddress }) {
+  const [after, setAfter] = useState<string | null>(null);
+
+  const [result] = useOmnigraphQuery({
+    query: AccountDomainsQuery,
+    variables: { address, first: PAGE_SIZE, after },
+  });
+
+  const { data, fetching, error } = result;
+
+  if (!data && fetching) return <p>Loading...</p>;
+  if (error) return <p>Error: {error.message}</p>;
+  if (!data?.account) return <p>No account found for '{address}'.</p>;
+
+  const { domains } = data.account;
+  if (!domains) return <p>No domains.</p>;
+
+  return (
+    <div>
+      <h2>Account</h2>
+      <p>
+        Address: <code>{data.account.address}</code>
+      </p>
+
+      <h3>Owned Domains ({domains.totalCount})</h3>
+      {domains.edges.length === 0 ? (
+        <p>This account doesn't own any domains.</p>
+      ) : (
+        <>
+          <p>
+            Showcases cursor-based pagination over <code>Account.domains</code>.
+          </p>
+          <ul>
+            {domains.edges.map((edge) => (
+              <li key={edge.node.id}>
+                <Link to={`/domain/${edge.node.name}`}>{edge.node.name}</Link> (
+                {edge.node.__typename})
+              </li>
+            ))}
+          </ul>
+
+          {domains.pageInfo.hasNextPage && (
+            <button
+              type="button"
+              disabled={fetching}
+              onClick={() => setAfter(domains.pageInfo.endCursor)}
+            >
+              {fetching ? "Loading..." : "Next page"}
+            </button>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+export function AccountView() {
+  const params = useParams();
+  const raw = params.address ?? "";
+
+  if (!isNormalizedAddress(raw)) {
+    // try to coerce mixed-case / checksummed input to a NormalizedAddress and redirect
+    try {
+      const normalized = toNormalizedAddress(raw);
+      return <Navigate to={`/account/${normalized}`} replace />;
+    } catch {
+      return (
+        <div>
+          <h2>Invalid address: '{raw}'</h2>
+          <Link to="/">Home</Link>
+        </div>
+      );
+    }
+  }
+
+  return <RenderAccount key={raw} address={raw} />;
+}

--- a/examples/enskit-react-example/src/AccountView.tsx
+++ b/examples/enskit-react-example/src/AccountView.tsx
@@ -53,15 +53,17 @@ function RenderAccount({ address }: { address: NormalizedAddress }) {
             Showcases cursor-based pagination over <code>Account.domains</code>.
           </p>
           <ul>
-            {domains.edges.map((edge) => (
-              <li key={edge.node.id}>
-                <Link to={`/domain/${edge.node.name}`}>{edge.node.name}</Link> (
-                {edge.node.__typename})
-              </li>
-            ))}
+            {domains.edges.map((edge) => {
+              const display = edge.node.name ?? "Unknown Name";
+              return (
+                <li key={edge.node.id}>
+                  <Link to={`/domain/${display}`}>{display}</Link> ({edge.node.__typename})
+                </li>
+              );
+            })}
           </ul>
 
-          {domains.pageInfo.hasNextPage && (
+          {domains.pageInfo.hasNextPage && domains.pageInfo.endCursor !== null && (
             <button
               type="button"
               disabled={fetching}

--- a/examples/enskit-react-example/src/AccountView.tsx
+++ b/examples/enskit-react-example/src/AccountView.tsx
@@ -53,14 +53,16 @@ function RenderAccount({ address }: { address: NormalizedAddress }) {
             Showcases cursor-based pagination over <code>Account.domains</code>.
           </p>
           <ul>
-            {domains.edges.map((edge) => {
-              const display = edge.node.name ?? "Unknown Name";
-              return (
-                <li key={edge.node.id}>
-                  <Link to={`/domain/${display}`}>{display}</Link> ({edge.node.__typename})
-                </li>
-              );
-            })}
+            {domains.edges.map((edge) => (
+              <li key={edge.node.id}>
+                {edge.node.name ? (
+                  <Link to={`/domain/${edge.node.name}`}>{edge.node.name}</Link>
+                ) : (
+                  <em>non-canonical domain</em>
+                )}{" "}
+                ({edge.node.__typename})
+              </li>
+            ))}
           </ul>
 
           {domains.pageInfo.hasNextPage && domains.pageInfo.endCursor !== null && (

--- a/examples/enskit-react-example/src/App.tsx
+++ b/examples/enskit-react-example/src/App.tsx
@@ -4,9 +4,12 @@ import { omnigraph } from "enssdk/omnigraph";
 import { StrictMode } from "react";
 import { HashRouter, Link, Outlet, Route, Routes } from "react-router";
 
+import { AccountView } from "./AccountView";
 import { DomainView } from "./DomainView";
 import { RegistryView } from "./RegistryView";
 import { SearchView } from "./SearchView";
+
+const EXAMPLE_ACCOUNT_ADDRESS = "0x2f8e8b1126e75fde0b7f731e7cb5847eba2d2574";
 
 /**
  * Gets the ENSNODE_URL from the environment, defaulting to the NameHash-hosted Sepolia-V2 Namespace
@@ -29,6 +32,7 @@ function Layout() {
     <>
       <nav>
         <Link to="/">Home</Link> | <Link to="/domain/eth">Domain Browser</Link> |{" "}
+        <Link to={`/account/${EXAMPLE_ACCOUNT_ADDRESS}`}>Account Browser</Link> |{" "}
         <Link to="/registry">Registry Cache Demo</Link> | <Link to="/search">Search Demo</Link>
       </nav>
       <hr />
@@ -53,6 +57,7 @@ export function App() {
             <Route element={<Layout />}>
               <Route path="/" element={<Home />} />
               <Route path="/domain/:name" element={<DomainView />} />
+              <Route path="/account/:address" element={<AccountView />} />
               <Route path="/search" element={<SearchView />} />
               <Route path="/registry" element={<RegistryView />} />
             </Route>

--- a/examples/enskit-react-example/src/DomainView.tsx
+++ b/examples/enskit-react-example/src/DomainView.tsx
@@ -45,7 +45,10 @@ function SubdomainLink({ data }: { data: FragmentOf<typeof DomainFragment> }) {
       <Link to={`/domain/${domain.name}`}>{domain.name}</Link> ({domain.__typename})
       <span>
         {" "}
-        — Owner <code>{domain.owner?.address ?? "none"}</code>
+        — Owner{" "}
+        <code>
+          {domain.owner?.address ?? (domain.__typename === "ENSv2Domain" ? "Reserved" : "0x0")}
+        </code>
       </span>
     </li>
   );

--- a/examples/enskit-react-example/src/DomainView.tsx
+++ b/examples/enskit-react-example/src/DomainView.tsx
@@ -42,7 +42,12 @@ function SubdomainLink({ data }: { data: FragmentOf<typeof DomainFragment> }) {
 
   return (
     <li>
-      <Link to={`/domain/${domain.name}`}>{domain.name}</Link> ({domain.__typename})
+      {domain.name ? (
+        <Link to={`/domain/${domain.name}`}>{domain.name}</Link>
+      ) : (
+        <em>non-canonical domain</em>
+      )}{" "}
+      ({domain.__typename})
       <span>
         {" "}
         — Owner{" "}

--- a/examples/enskit-react-example/src/DomainView.tsx
+++ b/examples/enskit-react-example/src/DomainView.tsx
@@ -75,7 +75,9 @@ function RenderDomain({ name }: { name: InterpretedName }) {
   return (
     <div>
       <h2>{domain.name ?? name}</h2>
-      <p>Owner: {domain.owner?.address ?? "none"}</p>
+      <p>
+        Owner: {domain.owner?.address ?? (domain.__typename === "ENSv2Domain" ? "Reserved" : "0x0")}
+      </p>
       <p>Version: {domain.__typename}</p>
 
       {parentName && (

--- a/examples/enskit-react-example/src/SearchView.tsx
+++ b/examples/enskit-react-example/src/SearchView.tsx
@@ -74,7 +74,7 @@ export function SearchView() {
         type="text"
         value={input}
         onChange={(e) => setInput(e.target.value)}
-        placeholder="tryingagain.eth"
+        placeholder="vitalik.eth"
       />
 
       {query.length === 0 ? (

--- a/examples/enskit-react-example/src/SearchView.tsx
+++ b/examples/enskit-react-example/src/SearchView.tsx
@@ -2,6 +2,8 @@ import { graphql, useOmnigraphQuery } from "enskit/react/omnigraph";
 import { useEffect, useState } from "react";
 import { Link, useSearchParams } from "react-router";
 
+// `canonical: true` guarantees `node.name` is non-null on every result, so the link
+// target / label below can use it directly without a fallback.
 const DomainsByNameQuery = graphql(`
   query DomainsByName($name: String!, $first: Int!, $after: String) {
     domains(where: { name: $name, canonical: true }, first: $first, after: $after) {

--- a/examples/enskit-react-example/src/SearchView.tsx
+++ b/examples/enskit-react-example/src/SearchView.tsx
@@ -88,7 +88,7 @@ export function SearchView() {
             {data?.domains?.edges.map((edge) => (
               <li key={edge.node.id}>
                 ({edge.node.__typename === "ENSv1Domain" ? "v1" : "v2"}){" "}
-                <Link to={`/domain/${edge.node.name}`}>{edge.node.name ?? edge.node.id}</Link>
+                <Link to={`/domain/${edge.node.name}`}>{edge.node.name}</Link>
               </li>
             ))}
           </ul>

--- a/packages/ensindexer-perf-testing/README.md
+++ b/packages/ensindexer-perf-testing/README.md
@@ -22,7 +22,7 @@ Dashboard panels are tuned for indexer perf work:
 From this package's directory:
 
 ```bash
-pnpm up       # start prometheus + grafana
+pnpm start    # start prometheus + grafana
 pnpm down     # stop and remove containers
 pnpm logs     # tail container logs
 pnpm wipe     # purge prometheus series (useful between benchmark runs)

--- a/packages/ensindexer-perf-testing/package.json
+++ b/packages/ensindexer-perf-testing/package.json
@@ -5,7 +5,7 @@
   "description": "Local Prometheus + Grafana bundle for benchmarking ENSIndexer throughput.",
   "license": "MIT",
   "scripts": {
-    "up": "docker compose up -d",
+    "start": "docker compose up -d",
     "down": "docker compose down",
     "logs": "docker compose logs -f",
     "wipe": "./wipe.sh",

--- a/packages/enskit/src/react/omnigraph/_lib/cache-exchange.ts
+++ b/packages/enskit/src/react/omnigraph/_lib/cache-exchange.ts
@@ -31,6 +31,9 @@ export const omnigraphCacheExchange = cacheExchange({
       return stringifyAccountId(data as unknown as AccountId);
     },
 
+    // Accounts are keyable by just `address` if `id` is not provided
+    Account: (data) => (data.id ?? data.address ?? null) as string | null,
+
     // These entities are Embedded Data and don't have a relevant key
     Label: EMBEDDED_DATA,
     WrappedBaseRegistrarRegistration: EMBEDDED_DATA,

--- a/packages/enskit/src/react/omnigraph/_lib/cache-exchange.ts
+++ b/packages/enskit/src/react/omnigraph/_lib/cache-exchange.ts
@@ -32,7 +32,10 @@ export const omnigraphCacheExchange = cacheExchange({
     },
 
     // Accounts are keyable by just `address` if `id` is not provided
-    Account: (data) => (data.id ?? data.address ?? null) as string | null,
+    Account: (data) => {
+      const key = data.id ?? data.address;
+      return typeof key === "string" ? key : null;
+    },
 
     // These entities are Embedded Data and don't have a relevant key
     Label: EMBEDDED_DATA,

--- a/packages/ensnode-sdk/src/omnigraph-api/example-queries.ts
+++ b/packages/ensnode-sdk/src/omnigraph-api/example-queries.ts
@@ -32,12 +32,12 @@ const ENS_TEST_ENV_V2_ETH_REGISTRAR = maybeGetDatasourceContract(
 
 const VITALIK_ADDRESS = toNormalizedAddress("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
 
-// owns tryingagain.eth + debuggincrap.eth on sepolia-v2 and has resolver permissions on each
-const SEPOLIA_V2_USER_ADDRESS = toNormalizedAddress("0x205d2686da3bf33f64c17f21462c51b5ead462cf");
+// owns sfmonicdeb*.eth (mix of v1 + v2) on sepolia-v2 and holds v2 ETHRegistry permissions
+const SEPOLIA_V2_USER_ADDRESS = toNormalizedAddress("0x2f8e8b1126e75fde0b7f731e7cb5847eba2d2574");
 
 const DEVNET_NAME_WITH_OWNED_RESOLVER = asInterpretedName("example.eth");
 
-const SEPOLIA_V2_NAME_WITH_OWNED_RESOLVER = asInterpretedName("tryingagain.eth");
+const SEPOLIA_V2_NAME_WITH_OWNED_RESOLVER = asInterpretedName("sfmonicdebmig.eth");
 
 export const GRAPHQL_API_EXAMPLE_QUERIES: Array<{
   query: string;
@@ -90,7 +90,7 @@ query FindDomains(
     variables: {
       default: { name: "vitalik", order: { by: "NAME", dir: "DESC" } },
       [ENSNamespaceIds.EnsTestEnv]: { name: "c", order: { by: "NAME", dir: "DESC" } },
-      [ENSNamespaceIds.SepoliaV2]: { name: "trying", order: { by: "NAME", dir: "DESC" } },
+      [ENSNamespaceIds.SepoliaV2]: { name: "sfmonic", order: { by: "NAME", dir: "DESC" } },
     },
   },
 
@@ -120,7 +120,7 @@ query DomainByName($name: InterpretedName!) {
 }`,
     variables: {
       default: { name: "eth" },
-      [ENSNamespaceIds.SepoliaV2]: { name: "tryingagain.eth" },
+      [ENSNamespaceIds.SepoliaV2]: { name: "sfmonicdebmig.eth" },
     },
   },
 
@@ -168,7 +168,7 @@ query DomainEvents($name: InterpretedName!) {
 }`,
     variables: {
       default: { name: "newowner.eth" },
-      [ENSNamespaceIds.SepoliaV2]: { name: "tryingagain.eth" },
+      [ENSNamespaceIds.SepoliaV2]: { name: "sfmonicdebmig.eth" },
     },
   },
 


### PR DESCRIPTION
## Summary

- new `/account/:address` route in the enskit example app rendering `Account.domains` with cursor-based pagination
- normalize `Account` entities by `address` in graphcache so queries like `owner { address }` (without `id`) don't trigger urql warnings — `id` and `address` are equivalent on `Account`
- distinguish v2 reservations from real zero-address owners in the subdomain list (shows "Reserved" for `ENSv2Domain` with null owner instead of "none")
- update sepolia-v2 example query variables (user address, name with owned resolver, search prefix) to entities present in the current deployment
- minor: rename `ensindexer-perf-testing` `up` script to `start`

## Test plan

- [x] /account/:address loads, paginates, links into /domain/:name
- [x] no urql graphcache warnings in console when navigating account → domain
- [x] sepolia-v2 example queries return non-empty results in the omnigraph playground

🤖 Generated with [Claude Code](https://claude.com/claude-code)