### PR TITLE
feat: beautifyInterpretedName helper + example usage

### DIFF
--- a/.changeset/enssdk-beautify-interpreted-name.md
+++ b/.changeset/enssdk-beautify-interpreted-name.md
@@ -1,0 +1,5 @@
+---
+"enssdk": minor
+---
+
+Add `beautifyInterpretedName(name: InterpretedName): BeautifiedName` for converting an InterpretedName into a UI-presentable Name, plus a new `BeautifiedName` nominally-typed alias. Each label is either preserved verbatim (Encoded LabelHashes) or passed through `ens_beautify` (normalized labels), so e.g. `"♾♾♾♾.eth"` renders as `"♾️♾️♾️♾️.eth"`. The branded `BeautifiedName` return type prevents the result from being passed to APIs that expect an `InterpretedName` — continue to use the source InterpretedName for navigation targets and lookups.

--- a/examples/enskit-react-example/src/AccountView.tsx
+++ b/examples/enskit-react-example/src/AccountView.tsx
@@ -1,5 +1,10 @@
 import { graphql, useOmnigraphQuery } from "enskit/react/omnigraph";
-import { isNormalizedAddress, type NormalizedAddress, toNormalizedAddress } from "enssdk";
+import {
+  beautifyInterpretedName,
+  isNormalizedAddress,
+  type NormalizedAddress,
+  toNormalizedAddress,
+} from "enssdk";
 import { useState } from "react";
 import { Link, Navigate, useParams } from "react-router";
 
@@ -56,7 +61,9 @@ function RenderAccount({ address }: { address: NormalizedAddress }) {
             {domains.edges.map((edge) => (
               <li key={edge.node.id}>
                 {edge.node.name ? (
-                  <Link to={`/domain/${edge.node.name}`}>{edge.node.name}</Link>
+                  <Link to={`/domain/${edge.node.name}`}>
+                    {beautifyInterpretedName(edge.node.name)}
+                  </Link>
                 ) : (
                   <em>non-canonical domain</em>
                 )}{" "}

--- a/examples/enskit-react-example/src/App.tsx
+++ b/examples/enskit-react-example/src/App.tsx
@@ -42,7 +42,12 @@ function Layout() {
 }
 
 function Home() {
-  return <p>Welcome — pick a demo above.</p>;
+  return (
+    <div>
+      <p>Welcome — pick a demo above.</p>
+      <p>Connected to ENSNode at {ENSNODE_URL}</p>
+    </div>
+  );
 }
 
 export function App() {

--- a/examples/enskit-react-example/src/DomainView.tsx
+++ b/examples/enskit-react-example/src/DomainView.tsx
@@ -1,6 +1,11 @@
 import { EnsureInterpretedName } from "enskit/react";
 import { type FragmentOf, graphql, readFragment, useOmnigraphQuery } from "enskit/react/omnigraph";
-import { asLiteralName, getParentInterpretedName, type InterpretedName } from "enssdk";
+import {
+  asLiteralName,
+  beautifyInterpretedName,
+  getParentInterpretedName,
+  type InterpretedName,
+} from "enssdk";
 import { useState } from "react";
 import { Link, Navigate, useParams } from "react-router";
 
@@ -43,7 +48,7 @@ function SubdomainLink({ data }: { data: FragmentOf<typeof DomainFragment> }) {
   return (
     <li>
       {domain.name ? (
-        <Link to={`/domain/${domain.name}`}>{domain.name}</Link>
+        <Link to={`/domain/${domain.name}`}>{beautifyInterpretedName(domain.name)}</Link>
       ) : (
         <em>non-canonical domain</em>
       )}{" "}
@@ -71,7 +76,7 @@ function RenderDomain({ name }: { name: InterpretedName }) {
 
   if (!data && fetching) return <p>Loading...</p>;
   if (error) return <p>Error: {error.message}</p>;
-  if (!data?.domain) return <p>No domain was found with name '{name}'.</p>;
+  if (!data?.domain) return <p>No domain was found with name '{beautifyInterpretedName(name)}'.</p>;
 
   const domain = readFragment(DomainFragment, data.domain);
   const parentName = getParentInterpretedName(name);
@@ -79,15 +84,22 @@ function RenderDomain({ name }: { name: InterpretedName }) {
 
   return (
     <div>
-      <h2>{domain.name ?? name}</h2>
+      <h2>{beautifyInterpretedName(domain.name ?? name)}</h2>
       <p>
-        Owner: {domain.owner?.address ?? (domain.__typename === "ENSv2Domain" ? "Reserved" : "0x0")}
+        Owner:{" "}
+        {domain.owner ? (
+          <Link to={`/account/${domain.owner.address}`}>{domain.owner.address}</Link>
+        ) : domain.__typename === "ENSv2Domain" ? (
+          "Reserved"
+        ) : (
+          "0x0"
+        )}
       </p>
       <p>Version: {domain.__typename}</p>
 
       {parentName && (
         <p>
-          ← <Link to={`/domain/${parentName}`}>{parentName}</Link>
+          ← <Link to={`/domain/${parentName}`}>{beautifyInterpretedName(parentName)}</Link>
         </p>
       )}
 
@@ -97,8 +109,9 @@ function RenderDomain({ name }: { name: InterpretedName }) {
       ) : (
         <>
           <p>
-            Showcases trivial cursor-based pagination over a connection (here, a Domain's{" "}
-            <code>subdomains</code>). Use the button below to fetch the next page.
+            Showcases trivial cursor-based pagination over a{" "}
+            <a href="https://relay.dev/graphql/connections.htm">Relay Connection</a> (here, a
+            Domain's <code>subdomains</code>). Use the button below to fetch the next page.
           </p>
           <ul>
             {subdomains?.edges.map((edge) => {

--- a/examples/enskit-react-example/src/DomainView.tsx
+++ b/examples/enskit-react-example/src/DomainView.tsx
@@ -144,36 +144,47 @@ export function DomainView() {
 
   // here we ensure that the provided /domain/:name parameter is an InterpretedName
   return (
-    <EnsureInterpretedName
-      name={asLiteralName(params.name)}
-      //
-      // options for how we interpret user input
-      options={{
-        // while not strictly necessary to specify, since we catch the empty string case above, we'll
-        // be explicit in this example app and tell enskit that for our purposes, we don't want our
-        // downstream `children` component to receive the ENS Root Name ("") as a `name` value
-        allowENSRootName: false,
+    <>
+      <div
+        style={{ border: "1px solid #a94442", padding: "0.75rem", marginBottom: "1rem" }}
+        role="note"
+      >
+        Heads up! sepolia-v2's ENSv1Resolver is misconfigured, and ENSv1-only names aren't
+        resolvable, so they're not currently visible here! This will be fixed by the ENS Team in the
+        near future. If you followed a link to a Domain and it isn't showing up here, it's likely an
+        ENSv1-only name (unmigrated) and isn't currently resolvable.
+      </div>
+      <EnsureInterpretedName
+        name={asLiteralName(params.name)}
+        //
+        // options for how we interpret user input
+        options={{
+          // while not strictly necessary to specify, since we catch the empty string case above, we'll
+          // be explicit in this example app and tell enskit that for our purposes, we don't want our
+          // downstream `children` component to receive the ENS Root Name ("") as a `name` value
+          allowENSRootName: false,
 
-        // allow the incoming LiteralName to contain Encoded LabelHash segments (e.g. [abcd...xyz])
-        allowEncodedLabelHashes: true,
+          // allow the incoming LiteralName to contain Encoded LabelHash segments (e.g. [abcd...xyz])
+          allowEncodedLabelHashes: true,
 
-        // if a user ever navigates to a /domain/:name that contains unnormalizable labels, we want
-        // to represent that label as an encoded labelhash and redirect the user to that canonical page
-        coerceUnnormalizableLabelsToEncodedLabelHashes: true,
-      }}
-      //
-      // this isn't an InterpretedName, but it was coerced to an InterpretedName: redirect the user to the canonical url
-      coerced={(name) => <Navigate to={`/domain/${name}`} replace />}
-      //
-      // this name can't conform to InterpretedName nor can it be coerced: it is malformed: show an error
-      malformed={(name) => (
-        <div>
-          <h2>Invalid name: '{name}'</h2>
-          <Link to="/domain/eth">Back to 'eth' Domain.</Link>
-        </div>
-      )}
-    >
-      {(name) => <RenderDomain key={name} name={name} />}
-    </EnsureInterpretedName>
+          // if a user ever navigates to a /domain/:name that contains unnormalizable labels, we want
+          // to represent that label as an encoded labelhash and redirect the user to that canonical page
+          coerceUnnormalizableLabelsToEncodedLabelHashes: true,
+        }}
+        //
+        // this isn't an InterpretedName, but it was coerced to an InterpretedName: redirect the user to the canonical url
+        coerced={(name) => <Navigate to={`/domain/${name}`} replace />}
+        //
+        // this name can't conform to InterpretedName nor can it be coerced: it is malformed: show an error
+        malformed={(name) => (
+          <div>
+            <h2>Invalid name: '{name}'</h2>
+            <Link to="/domain/eth">Back to 'eth' Domain.</Link>
+          </div>
+        )}
+      >
+        {(name) => <RenderDomain key={name} name={name} />}
+      </EnsureInterpretedName>
+    </>
   );
 }

--- a/examples/enskit-react-example/src/SearchView.tsx
+++ b/examples/enskit-react-example/src/SearchView.tsx
@@ -3,8 +3,6 @@ import { beautifyInterpretedName } from "enssdk";
 import { useEffect, useState } from "react";
 import { Link, useSearchParams } from "react-router";
 
-// `canonical: true` guarantees `node.name` is non-null on every result, so the link
-// target / label below can use it directly without a fallback.
 const DomainsByNameQuery = graphql(`
   query DomainsByName($name: String!, $first: Int!, $after: String) {
     domains(where: { name: $name, canonical: true }, first: $first, after: $after) {

--- a/examples/enskit-react-example/src/SearchView.tsx
+++ b/examples/enskit-react-example/src/SearchView.tsx
@@ -68,6 +68,14 @@ export function SearchView() {
     <div>
       <h2>Domain Search</h2>
 
+      <div
+        style={{ border: "1px solid #a94442", padding: "0.75rem", marginBottom: "1rem" }}
+        role="note"
+      >
+        Heads up! We return both ENSv1 and ENSv2 names due to a small bug in our Canonical Name
+        derivation, which will be fixed in the near future.
+      </div>
+
       <p>
         Showcases live querying via <code>Query.domains(where: {"{ name }"})</code>. Input is
         debounced by {DEBOUNCE_MS}ms and synced to the URL as <code>?query=</code>.

--- a/examples/enskit-react-example/src/SearchView.tsx
+++ b/examples/enskit-react-example/src/SearchView.tsx
@@ -1,4 +1,5 @@
 import { graphql, useOmnigraphQuery } from "enskit/react/omnigraph";
+import { beautifyInterpretedName } from "enssdk";
 import { useEffect, useState } from "react";
 import { Link, useSearchParams } from "react-router";
 
@@ -90,7 +91,11 @@ export function SearchView() {
             {data?.domains?.edges.map((edge) => (
               <li key={edge.node.id}>
                 ({edge.node.__typename === "ENSv1Domain" ? "v1" : "v2"}){" "}
-                <Link to={`/domain/${edge.node.name}`}>{edge.node.name}</Link>
+                {edge.node.name && (
+                  <Link to={`/domain/${edge.node.name}`}>
+                    {beautifyInterpretedName(edge.node.name)}
+                  </Link>
+                )}
               </li>
             ))}
           </ul>

--- a/packages/enssdk/src/lib/beautify.test.ts
+++ b/packages/enssdk/src/lib/beautify.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { beautifyInterpretedName } from "./beautify";
+import { ENS_ROOT_NAME } from "./constants";
+import { asInterpretedName } from "./interpreted-names-and-labels";
+
+describe("beautifyInterpretedName", () => {
+  it("returns the ENS Root Name unchanged", () => {
+    expect(beautifyInterpretedName(ENS_ROOT_NAME)).toEqual(ENS_ROOT_NAME);
+  });
+
+  it("beautifies normalized labels", () => {
+    const name = asInterpretedName("♾♾♾♾.eth");
+    expect(beautifyInterpretedName(name)).toEqual("♾️♾️♾️♾️.eth");
+  });
+
+  it("preserves Encoded LabelHash labels verbatim", () => {
+    const name = asInterpretedName(
+      "[0000000000000000000000000000000000000000000000000000000000000001].eth",
+    );
+    expect(beautifyInterpretedName(name)).toEqual(
+      "[0000000000000000000000000000000000000000000000000000000000000001].eth",
+    );
+  });
+
+  it("selectively beautifies labels alongside Encoded LabelHash labels", () => {
+    const name = asInterpretedName(
+      "♾♾♾♾.[0000000000000000000000000000000000000000000000000000000000000001].eth",
+    );
+    expect(beautifyInterpretedName(name)).toEqual(
+      "♾️♾️♾️♾️.[0000000000000000000000000000000000000000000000000000000000000001].eth",
+    );
+  });
+});

--- a/packages/enssdk/src/lib/beautify.ts
+++ b/packages/enssdk/src/lib/beautify.ts
@@ -1,0 +1,32 @@
+import { ens_beautify } from "@adraffy/ens-normalize";
+
+import { ENS_ROOT_NAME } from "./constants";
+import { interpretedNameToInterpretedLabels } from "./interpreted-names-and-labels";
+import { isEncodedLabelHash } from "./labelhash";
+import type { BeautifiedName, InterpretedName } from "./types";
+
+/**
+ * Converts an {@link InterpretedName} into a {@link BeautifiedName} suitable for presentation in a UI.
+ *
+ * Each label of the InterpretedName is either an Encoded LabelHash or a normalized Label:
+ * - Encoded LabelHash labels are preserved verbatim.
+ * - Normalized Labels are passed through {@link ens_beautify}, producing a Label that is
+ *   normalizable (and normalizes back to the input) but may itself be unnormalized.
+ *
+ * The resulting BeautifiedName is suitable for display but is NOT an InterpretedName, and the
+ * branded return type prevents it from being passed to APIs that expect one. Continue to use the
+ * source InterpretedName for navigation targets, lookup keys, and anywhere else that expects an
+ * InterpretedName.
+ *
+ * @example
+ * ```ts
+ * beautifyInterpretedName("♾♾♾♾.eth" as InterpretedName) // → "♾️♾️♾️♾️.eth"
+ * ```
+ */
+export const beautifyInterpretedName = (name: InterpretedName): BeautifiedName => {
+  if (name === ENS_ROOT_NAME) return name as string as BeautifiedName;
+
+  return interpretedNameToInterpretedLabels(name)
+    .map((label) => (isEncodedLabelHash(label) ? label : ens_beautify(label)))
+    .join(".") as BeautifiedName;
+};

--- a/packages/enssdk/src/lib/index.ts
+++ b/packages/enssdk/src/lib/index.ts
@@ -1,4 +1,5 @@
 export * from "./address";
+export * from "./beautify";
 export * from "./caip";
 export * from "./coin-type";
 export * from "./constants";

--- a/packages/enssdk/src/lib/types/ens.ts
+++ b/packages/enssdk/src/lib/types/ens.ts
@@ -142,6 +142,23 @@ export type LiteralName = Name & { __brand: "LiteralName" };
 export type InterpretedName = Name & { __brand: "InterpretedName" };
 
 /**
+ * A Beautified Name is a Name produced for presentation in a UI from an {@link InterpretedName}.
+ *
+ * Each label is either:
+ * a) an Encoded LabelHash, preserved verbatim from the source InterpretedName, or
+ * b) a Label produced by passing a normalized Label through ENSIP-15 beautification, which is
+ *    guaranteed to be normalizable back to the original normalized Label but is itself NOT
+ *    necessarily normalized (e.g. `"♾"` → `"♾️"`).
+ *
+ * Because (b) is not guaranteed to be normalized, a BeautifiedName is NOT an InterpretedName and
+ * MUST NOT be used as a navigation target, lookup key, or anywhere else that expects an
+ * InterpretedName.
+ *
+ * @dev nominally typed to enforce usage & enhance codebase clarity
+ */
+export type BeautifiedName = Name & { __brand: "BeautifiedName" };
+
+/**
  * A Subgraph Interpreted Label is a Literal Label that is either:
  * a) (if subgraph-indexable): a Literal Label, of unknown normalization status, guaranteed to not
  *   contain any of the subgraph-unindexable UTF-8 characters (and therefore guaranteed not to be


### PR DESCRIPTION
## Summary

- Adds `beautifyInterpretedName(name: InterpretedName): BeautifiedName` to `enssdk` for converting an InterpretedName into a UI-presentable Name. Each label is preserved verbatim if it's an Encoded LabelHash, otherwise passed through `ens_beautify` from `@adraffy/ens-normalize`. Example: `"♾♾♾♾.eth"` → `"♾️♾️♾️♾️.eth"`.
- Introduces a new branded `BeautifiedName` nominal type alongside `InterpretedName`. The branded return type prevents the result from being passed to APIs that expect an `InterpretedName` (navigation targets, lookups, GraphQL variables, etc.).
- Updates the enskit-react example app (`DomainView`, `AccountView`, `SearchView`) so all rendered names are beautified, while link `to=` and lookup keys continue to use the source InterpretedName. Also a small `Home` tweak in `App.tsx` to surface the connected ENSNODE_URL.

## Test plan

- [x] `pnpm -F enssdk typecheck`
- [x] `pnpm -F @ensnode/enskit-react-example typecheck`
- [x] `pnpm -F @namehash/namehash-ui typecheck`
- [x] `pnpm test --project enssdk` (256 passed, includes new `beautify.test.ts`)
- [x] `pnpm lint`
- [x] Smoke test the example app: navigate to a domain whose label benefits from beautification (e.g. `♾♾♾♾.eth`) and confirm the heading/link text renders the variation-selector form while the URL still uses the InterpretedName