### PR TITLE
Changed accounting minor version bump to patch

### DIFF
--- a/.changeset/purple-frogs-dream.md
+++ b/.changeset/purple-frogs-dream.md
@@ -1,5 +1,5 @@
 ---
-"@namehash/ens-referrals": minor
+"@namehash/ens-referrals": patch
 ---
 
 Add per-event accounting trace for rev-share-cap editions. The new `ReferralEditionSnapshot` (returned by `buildReferralEditionSnapshot*`) bundles the leaderboard with a chronological array of `ReferralAccountingRecordRevShareCap`.

--- a/.changeset/shiny-pandas-account.md
+++ b/.changeset/shiny-pandas-account.md
@@ -1,5 +1,5 @@
 ---
-"ensapi": minor
+"ensapi": patch
 ---
 
 Add `GET /v1/ensanalytics/accounting?edition={slug}` for rev-share-cap editions: returns a CSV dump of the per-event accounting trace, ordered chronologically.


### PR DESCRIPTION
# Changed accounting minor version bump to patch

## Summary

- Simply changed `minor` to `patch` in changesets

---

## Why

- Asked by @lightwalker-eth 

---

## Testing

- NA

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)
