### PR TITLE
fix(ensindexer): handle non-UTF-8 label args in RegistrarController invariants

### DIFF
--- a/.changeset/registrar-controller-non-utf8-label.md
+++ b/.changeset/registrar-controller-non-utf8-label.md
@@ -1,0 +1,5 @@
+---
+"ensindexer": patch
+---
+
+**ENSIndexer**: handle non-UTF-8 `string label` args in `RegistrarController:NameRegistered` and `:NameRenewed` events without crashing the indexer. ABI-decoding replaces non-UTF-8 byte sequences with U+FFFD, which then fails the labelhash round-trip. Previously this threw a fatal `Invariant(RegistrarController:NameRegistered)` and aborted the run; now the label is treated as unemitted and the heal path indexes the registration under the canonical `labelHash`.

--- a/apps/ensindexer/src/plugins/ensv2/handlers/ensv1/RegistrarController.ts
+++ b/apps/ensindexer/src/plugins/ensv2/handlers/ensv1/RegistrarController.ts
@@ -41,14 +41,16 @@ export default function () {
     }>;
   }) {
     const { labelHash, baseCost: base, premium, referrer } = event.args;
-    const label = event.args.label ? asLiteralLabel(event.args.label) : undefined;
-
-    // Invariant: If emitted, label must align with labelHash
-    if (label !== undefined && labelHash !== labelhashLiteralLabel(label)) {
-      throw new Error(
-        `Invariant(RegistrarController:NameRegistered): Emitted label '${label}' does not labelhash to emitted labelHash '${labelHash}'.`,
-      );
-    }
+    // If emitted, the label arg should round-trip to the emitted labelHash. ABI-decoding
+    // substitutes U+FFFD for non-UTF-8 bytes (some legacy contracts emit raw bytes in `string`
+    // event args), and the original bytes can't be recovered post-decode. When that happens we
+    // treat the label as unemitted and fall through to the heal path; the labelHash is canonical
+    // (bytes32) so the registration still indexes correctly under an unknown label.
+    const rawLabel = event.args.label ? asLiteralLabel(event.args.label) : undefined;
+    const label =
+      rawLabel !== undefined && labelhashLiteralLabel(rawLabel) === labelHash
+        ? rawLabel
+        : undefined;
 
     const controller = getThisAccountId(context, event);
     const { node: managedNode, registry } = getManagedName(controller);
@@ -63,7 +65,7 @@ export default function () {
       );
     }
 
-    // if the contract emitted a healed label, ensure that it is indexed
+    // if the contract emitted a (verified) healed label, ensure that it is indexed
     if (label !== undefined) {
       await ensureLabel(context, label);
     } else {
@@ -97,16 +99,15 @@ export default function () {
     }>;
   }) {
     const { labelHash, baseCost: base, premium, referrer } = event.args;
-    const label = event.args.label ? asLiteralLabel(event.args.label) : undefined;
+    // See note on RegistrarController:NameRegistered above for why this guards against
+    // labelhash-mismatch (non-UTF-8 byte sequences in `string` event args) rather than throwing.
+    const rawLabel = event.args.label ? asLiteralLabel(event.args.label) : undefined;
+    const label =
+      rawLabel !== undefined && labelhashLiteralLabel(rawLabel) === labelHash
+        ? rawLabel
+        : undefined;
 
-    // Invariant: If emitted, label must align with labelHash
-    if (label !== undefined && labelHash !== labelhashLiteralLabel(label)) {
-      throw new Error(
-        `Invariant(RegistrarController:NameRegistered): Emitted label '${label}' does not labelhash to emitted labelHash '${labelHash}'.`,
-      );
-    }
-
-    // if the contract emitted a healed label, ensure that it is indexed
+    // if the contract emitted a (verified) healed label, ensure that it is indexed
     if (label !== undefined) {
       await ensureLabel(context, label);
     } else {

--- a/apps/ensindexer/src/plugins/ensv2/handlers/ensv1/RegistrarController.ts
+++ b/apps/ensindexer/src/plugins/ensv2/handlers/ensv1/RegistrarController.ts
@@ -20,6 +20,7 @@ import {
   ensIndexerSchema,
   type IndexingEngineContext,
 } from "@/lib/indexing-engines/ponder";
+import { logger } from "@/lib/logger";
 import { getManagedName } from "@/lib/managed-names";
 import { namespaceContract } from "@/lib/plugin-helpers";
 import type { EventWithArgs } from "@/lib/ponder-helpers";
@@ -47,10 +48,14 @@ export default function () {
     // treat the label as unemitted and fall through to the heal path; the labelHash is canonical
     // (bytes32) so the registration still indexes correctly under an unknown label.
     const rawLabel = event.args.label ? asLiteralLabel(event.args.label) : undefined;
-    const label =
-      rawLabel !== undefined && labelhashLiteralLabel(rawLabel) === labelHash
-        ? rawLabel
-        : undefined;
+    const labelMatchesHash =
+      rawLabel !== undefined && labelhashLiteralLabel(rawLabel) === labelHash;
+    if (rawLabel !== undefined && !labelMatchesHash) {
+      logger.warn({
+        msg: `RegistrarController:NameRegistered label/labelHash mismatch (non-UTF-8 bytes?): label='${rawLabel}' labelHash='${labelHash}' — treating label as unemitted`,
+      });
+    }
+    const label = labelMatchesHash ? rawLabel : undefined;
 
     const controller = getThisAccountId(context, event);
     const { node: managedNode, registry } = getManagedName(controller);
@@ -102,10 +107,14 @@ export default function () {
     // See note on RegistrarController:NameRegistered above for why this guards against
     // labelhash-mismatch (non-UTF-8 byte sequences in `string` event args) rather than throwing.
     const rawLabel = event.args.label ? asLiteralLabel(event.args.label) : undefined;
-    const label =
-      rawLabel !== undefined && labelhashLiteralLabel(rawLabel) === labelHash
-        ? rawLabel
-        : undefined;
+    const labelMatchesHash =
+      rawLabel !== undefined && labelhashLiteralLabel(rawLabel) === labelHash;
+    if (rawLabel !== undefined && !labelMatchesHash) {
+      logger.warn({
+        msg: `RegistrarController:NameRenewed label/labelHash mismatch (non-UTF-8 bytes?): label='${rawLabel}' labelHash='${labelHash}' — treating label as unemitted`,
+      });
+    }
+    const label = labelMatchesHash ? rawLabel : undefined;
 
     // if the contract emitted a (verified) healed label, ensure that it is indexed
     if (label !== undefined) {


### PR DESCRIPTION
## Summary

- The \`Invariant\` check on \`RegistrarController:NameRegistered\` and \`:NameRenewed\` required the emitted \`string label\` arg to round-trip to the emitted \`labelHash\`. Some contracts emit raw bytes in \`string\` args; viem replaces non-UTF-8 sequences with U+FFFD during ABI decoding, breaking the round-trip and crashing the indexer with a fatal \`IndexingFunctionError\`.
- Replace the throwing invariant with a defensive fall-through: if the decoded label doesn't round-trip, treat it as unemitted and use the heal path. The \`labelHash\` is canonical \`bytes32\` so the registration still indexes correctly under an unknown label.

## Repro

Discovered on a mainnet backfill that crashed at **block 24,026,216** after ~8h of progress. The crashing tx was \`0x405f2c36...2cfff8\` (from \`0xe747...6e1c\` to \`0x5815...24c0\`); the \`string label\` arg decoded to ~580 U+FFFD characters, indicating the contract emitted non-UTF-8 bytes.

## Scope

Two call sites: \`handleNameRegisteredByController\` and \`handleNameRenewedByController\` in \`apps/ensindexer/src/plugins/ensv2/handlers/ensv1/RegistrarController.ts\`.

## Related, not in this PR

There's a structurally similar \`Sanity Check\` in \`apps/ensindexer/src/plugins/ensv2/handlers/ensv2/ENSv2Registry.ts:77-81\` that throws on the same labelhash-mismatch condition for ENSv2-native \`LabelRegistered\`/\`LabelReserved\` events. Same anti-pattern, but the v2 contracts are new and well-controlled; the bug is far less likely to fire there in practice. Worth a follow-up cleanup but kept out of this PR to keep the change tight.

## Test plan

- [x] \`pnpm -F ensindexer typecheck\` — clean
- [x] \`pnpm lint\` — clean (biome reformatted one ternary)
- [x] \`pnpm test --project ensindexer\` — 217/217 passed
- [ ] Verify on a fresh mainnet backfill that crosses block 24,026,216 without aborting

🤖 Generated with [Claude Code](https://claude.com/claude-code)