### PR TITLE
feat(ensapi): filter Account.domains and Query.domains by ENSProtocolVersion

### DIFF
--- a/.changeset/omnigraph-domains-version-filter.md
+++ b/.changeset/omnigraph-domains-version-filter.md
@@ -1,0 +1,5 @@
+---
+"ensapi": minor
+---
+
+**Omnigraph**: add an `ENSProtocolVersion` enum (`ENSv1` | `ENSv2`) and `where: { version }` filter on `Query.domains` and `Account.domains`.

--- a/apps/ensapi/src/omnigraph-api/lib/find-domains/layers/base-domain-set.ts
+++ b/apps/ensapi/src/omnigraph-api/lib/find-domains/layers/base-domain-set.ts
@@ -9,10 +9,12 @@ import { ensDb, ensIndexerSchema } from "@/lib/ensdb/singleton";
  */
 export type BaseDomainSet = ReturnType<typeof domainsBase>;
 
+export type DomainType = (typeof ensIndexerSchema.domainType.enumValues)[number];
+
 /**
  * Universal base domain set: all ENSv1 and ENSv2 Domains with consistent metadata.
  *
- * Returns `{ domainId, ownerId, registryId, parentId, canonical, labelHash, sortableLabel }`.
+ * Returns `{ domainId, type, ownerId, registryId, parentId, canonical, labelHash, sortableLabel }`.
  * - parentId is the canonical parent Domain, derived inline by joining to the parent Registry of
  *   this Domain (`registry.id = domain.registryId`) and then to the parent Domain named by
  *   `registry.canonicalDomainId`, requiring that parent Domain's `subregistryId` agree back to
@@ -31,6 +33,7 @@ export function domainsBase() {
     ensDb
       .select({
         domainId: sql<DomainId>`${ensIndexerSchema.domain.id}`.as("domainId"),
+        type: sql<DomainType>`${ensIndexerSchema.domain.type}`.as("type"),
         ownerId: sql<NormalizedAddress | null>`${ensIndexerSchema.domain.ownerId}`.as("ownerId"),
         registryId: sql<RegistryId>`${ensIndexerSchema.domain.registryId}`.as("registryId"),
         parentId: sql<DomainId | null>`${parentDomain.id}`.as("parentId"),
@@ -68,6 +71,7 @@ export function domainsBase() {
 export function selectBase(base: BaseDomainSet) {
   return {
     domainId: base.domainId,
+    type: base.type,
     ownerId: base.ownerId,
     registryId: base.registryId,
     parentId: base.parentId,

--- a/apps/ensapi/src/omnigraph-api/lib/find-domains/layers/filter-by-version.ts
+++ b/apps/ensapi/src/omnigraph-api/lib/find-domains/layers/filter-by-version.ts
@@ -1,0 +1,25 @@
+import { eq } from "drizzle-orm";
+
+import { ensDb } from "@/lib/ensdb/singleton";
+import type { ENSProtocolVersion } from "@/omnigraph-api/schema/ens-protocol-version";
+
+import { type BaseDomainSet, type DomainType, selectBase } from "./base-domain-set";
+
+const VERSION_TO_DOMAIN_TYPE: Record<typeof ENSProtocolVersion.$inferType, DomainType> = {
+  ENSv1: "ENSv1Domain",
+  ENSv2: "ENSv2Domain",
+};
+
+/**
+ * Filter a base domain set by ENS protocol version (ENSv1 or ENSv2).
+ */
+export function filterByVersion(
+  base: BaseDomainSet,
+  version: typeof ENSProtocolVersion.$inferType,
+) {
+  return ensDb
+    .select(selectBase(base))
+    .from(base)
+    .where(eq(base.type, VERSION_TO_DOMAIN_TYPE[version]))
+    .as("baseDomains");
+}

--- a/apps/ensapi/src/omnigraph-api/lib/find-domains/layers/index.ts
+++ b/apps/ensapi/src/omnigraph-api/lib/find-domains/layers/index.ts
@@ -1,8 +1,9 @@
-export type { BaseDomainSet } from "./base-domain-set";
+export type { BaseDomainSet, DomainType } from "./base-domain-set";
 export { domainsBase, selectBase } from "./base-domain-set";
 export { filterByCanonical } from "./filter-by-canonical";
 export { filterByName } from "./filter-by-name";
 export { filterByOwner } from "./filter-by-owner";
 export { filterByParent } from "./filter-by-parent";
 export { filterByRegistry } from "./filter-by-registry";
+export { filterByVersion } from "./filter-by-version";
 export { withOrderingMetadata } from "./with-ordering-metadata";

--- a/apps/ensapi/src/omnigraph-api/schema/account.integration.test.ts
+++ b/apps/ensapi/src/omnigraph-api/schema/account.integration.test.ts
@@ -24,13 +24,23 @@ import { gql } from "@/test/integration/omnigraph-api-client";
 
 describe("Account.domains", () => {
   type AccountDomainsResult = {
-    account: { domains: GraphQLConnection<{ name: InterpretedName | null }> };
+    account: {
+      domains: GraphQLConnection<{
+        __typename: "ENSv1Domain" | "ENSv2Domain";
+        name: InterpretedName | null;
+      }>;
+    };
   };
 
   const AccountDomains = gql`
-    query AccountDomains($address: Address!) {
+    query AccountDomains($address: Address!, $version: ENSProtocolVersion) {
       account(by: { address: $address }) {
-        domains(order: { by: NAME, dir: ASC }) { edges { node { name } } }
+        domains(
+          where: { version: $version },
+          order: { by: NAME, dir: ASC }
+        ) {
+          edges { node { __typename, name } }
+        }
       }
     }
   `;
@@ -70,6 +80,38 @@ describe("Account.domains", () => {
     const names = domains.map((d) => d.name);
 
     expect(names, "expected 'newowner.eth' in new owner's domains").toContain("newowner.eth");
+  });
+
+  describe("version?: ENSProtocolVersion", () => {
+    it("returns any version when unspecified", async () => {
+      const result = await request<AccountDomainsResult>(AccountDomains, {
+        address: DevnetAccounts.owner.address,
+        version: undefined,
+      });
+      const domains = flattenConnection(result.account.domains);
+      expect(domains.find((d) => d.__typename === "ENSv1Domain")).toBeDefined();
+      expect(domains.find((d) => d.__typename === "ENSv2Domain")).toBeDefined();
+    });
+
+    it("returns only ENSv1Domains when version: ENSv1", async () => {
+      const result = await request<AccountDomainsResult>(AccountDomains, {
+        address: DevnetAccounts.owner.address,
+        version: "ENSv1",
+      });
+      const domains = flattenConnection(result.account.domains);
+      expect(domains.find((d) => d.__typename === "ENSv1Domain")).toBeDefined();
+      expect(domains.find((d) => d.__typename === "ENSv2Domain")).not.toBeDefined();
+    });
+
+    it("returns only ENSv2Domains when version: ENSv2", async () => {
+      const result = await request<AccountDomainsResult>(AccountDomains, {
+        address: DevnetAccounts.owner.address,
+        version: "ENSv2",
+      });
+      const domains = flattenConnection(result.account.domains);
+      expect(domains.find((d) => d.__typename === "ENSv1Domain")).not.toBeDefined();
+      expect(domains.find((d) => d.__typename === "ENSv2Domain")).toBeDefined();
+    });
   });
 });
 

--- a/apps/ensapi/src/omnigraph-api/schema/account.ts
+++ b/apps/ensapi/src/omnigraph-api/schema/account.ts
@@ -11,6 +11,7 @@ import {
   filterByCanonical,
   filterByName,
   filterByOwner,
+  filterByVersion,
   withOrderingMetadata,
 } from "@/omnigraph-api/lib/find-domains/layers";
 import { resolveFindEvents } from "@/omnigraph-api/lib/find-events/find-events-resolver";
@@ -81,7 +82,8 @@ AccountRef.implement({
         const owned = filterByOwner(base, parent.id);
         const named = filterByName(owned, where?.name);
         const canonical = where?.canonical === true ? filterByCanonical(named) : named;
-        const domains = withOrderingMetadata(canonical);
+        const versioned = where?.version ? filterByVersion(canonical, where.version) : canonical;
+        const domains = withOrderingMetadata(versioned);
         return resolveFindDomains(context, { domains, order, ...connectionArgs });
       },
     }),

--- a/apps/ensapi/src/omnigraph-api/schema/domain.ts
+++ b/apps/ensapi/src/omnigraph-api/schema/domain.ts
@@ -33,6 +33,7 @@ import {
   PAGINATION_DEFAULT_MAX_SIZE,
   PAGINATION_DEFAULT_PAGE_SIZE,
 } from "@/omnigraph-api/schema/constants";
+import { ENSProtocolVersion } from "@/omnigraph-api/schema/ens-protocol-version";
 import { EventRef, EventsWhereInput } from "@/omnigraph-api/schema/event";
 import { LabelRef } from "@/omnigraph-api/schema/label";
 import { OrderDirection } from "@/omnigraph-api/schema/order-direction";
@@ -439,6 +440,11 @@ export const DomainsWhereInput = builder.inputType("DomainsWhereInput", {
       description:
         "A partial Interpreted Name by which to search the set of Domains. ex: 'example', 'example.', 'example.et'.",
     }),
+    version: t.field({
+      type: ENSProtocolVersion,
+      description:
+        "If set, filters the set of Domains to only those of the specified ENS protocol version.",
+    }),
   }),
 });
 
@@ -453,6 +459,11 @@ export const AccountDomainsWhereInput = builder.inputType("AccountDomainsWhereIn
       description:
         "Optional, defaults to false. If true, filters the set of Domains by those that are Canonical (i.e. reachable by ENS Forward Resolution).",
       defaultValue: false,
+    }),
+    version: t.field({
+      type: ENSProtocolVersion,
+      description:
+        "If set, filters the set of Domains to only those of the specified ENS protocol version.",
     }),
   }),
 });

--- a/apps/ensapi/src/omnigraph-api/schema/ens-protocol-version.ts
+++ b/apps/ensapi/src/omnigraph-api/schema/ens-protocol-version.ts
@@ -1,0 +1,6 @@
+import { builder } from "@/omnigraph-api/builder";
+
+export const ENSProtocolVersion = builder.enumType("ENSProtocolVersion", {
+  description: "An ENS protocol version.",
+  values: ["ENSv1", "ENSv2"] as const,
+});

--- a/apps/ensapi/src/omnigraph-api/schema/query.integration.test.ts
+++ b/apps/ensapi/src/omnigraph-api/schema/query.integration.test.ts
@@ -91,8 +91,8 @@ describe("Query.domains", () => {
   };
 
   const QueryDomains = gql`
-    query QueryDomains($name: String!, $order: DomainsOrderInput) {
-      domains(where: { name: $name }, order: $order) {
+    query QueryDomains($name: String!, $version: ENSProtocolVersion, $order: DomainsOrderInput) {
+      domains(where: { name: $name, version: $version }, order: $order) {
         edges {
           node {
             __typename
@@ -147,7 +147,6 @@ describe("Query.domains", () => {
 
   it("returns only canonical domains", async () => {
     const result = await request<QueryDomainsResult>(QueryDomains, { name: "parent" });
-
     const domains = flattenConnection(result.domains);
 
     // parent.eth is canonical (registered under the v2 ETH Registry which descends from the v2 Root)
@@ -162,6 +161,38 @@ describe("Query.domains", () => {
 
   // TODO: devnet fixture needs a known non-canonical Domain to assert exclusion against.
   it.todo("excludes non-canonical domains from the result set");
+
+  describe("version?: ENSProtocolVersion", () => {
+    it("returns any version when unspecified", async () => {
+      const result = await request<QueryDomainsResult>(QueryDomains, {
+        name: "reverse",
+        version: undefined,
+      });
+      const domains = flattenConnection(result.domains);
+      expect(domains.find((d) => d.__typename === "ENSv1Domain")).toBeDefined();
+      expect(domains.find((d) => d.__typename === "ENSv2Domain")).toBeDefined();
+    });
+
+    it("returns only ENSv1Domains when version: ENSv1", async () => {
+      const result = await request<QueryDomainsResult>(QueryDomains, {
+        name: "reverse",
+        version: "ENSv1",
+      });
+      const domains = flattenConnection(result.domains);
+      expect(domains.find((d) => d.__typename === "ENSv1Domain")).toBeDefined();
+      expect(domains.find((d) => d.__typename === "ENSv2Domain")).not.toBeDefined();
+    });
+
+    it("returns only ENSv2Domains when version: ENSv2", async () => {
+      const result = await request<QueryDomainsResult>(QueryDomains, {
+        name: "reverse",
+        version: "ENSv2",
+      });
+      const domains = flattenConnection(result.domains);
+      expect(domains.find((d) => d.__typename === "ENSv1Domain")).not.toBeDefined();
+      expect(domains.find((d) => d.__typename === "ENSv2Domain")).toBeDefined();
+    });
+  });
 });
 
 describe("Query.domain", () => {

--- a/apps/ensapi/src/omnigraph-api/schema/query.ts
+++ b/apps/ensapi/src/omnigraph-api/schema/query.ts
@@ -13,6 +13,7 @@ import {
   domainsBase,
   filterByCanonical,
   filterByName,
+  filterByVersion,
   withOrderingMetadata,
 } from "@/omnigraph-api/lib/find-domains/layers";
 import { getDomainIdByInterpretedName } from "@/omnigraph-api/lib/get-domain-by-interpreted-name";
@@ -110,8 +111,7 @@ builder.queryType({
     // Find Domains
     ////////////////
     domains: t.connection({
-      description:
-        "Find Canonical Domains by Name. Results are always scoped to Canonical Domains — every nameable Domain is canonical by definition, so a non-canonical filter would be empty.",
+      description: "Find Canonical Domains by Name.",
       type: DomainInterfaceRef,
       args: {
         where: t.arg({ type: DomainsWhereInput, required: true }),
@@ -121,7 +121,8 @@ builder.queryType({
         const base = domainsBase();
         const named = filterByName(base, where.name);
         const canonical = filterByCanonical(named);
-        const domains = withOrderingMetadata(canonical);
+        const versioned = where.version ? filterByVersion(canonical, where.version) : canonical;
+        const domains = withOrderingMetadata(versioned);
 
         return resolveFindDomains(context, { domains, order, ...connectionArgs });
       },

--- a/packages/enssdk/src/omnigraph/generated/introspection.ts
+++ b/packages/enssdk/src/omnigraph/generated/introspection.ts
@@ -398,6 +398,13 @@ const introspection = {
               "kind": "SCALAR",
               "name": "String"
             }
+          },
+          {
+            "name": "version",
+            "type": {
+              "kind": "ENUM",
+              "name": "ENSProtocolVersion"
+            }
           }
         ],
         "isOneOf": false
@@ -1621,9 +1628,30 @@ const introspection = {
                 "name": "String"
               }
             }
+          },
+          {
+            "name": "version",
+            "type": {
+              "kind": "ENUM",
+              "name": "ENSProtocolVersion"
+            }
           }
         ],
         "isOneOf": false
+      },
+      {
+        "kind": "ENUM",
+        "name": "ENSProtocolVersion",
+        "enumValues": [
+          {
+            "name": "ENSv1",
+            "isDeprecated": false
+          },
+          {
+            "name": "ENSv2",
+            "isDeprecated": false
+          }
+        ]
       },
       {
         "kind": "OBJECT",

--- a/packages/enssdk/src/omnigraph/generated/schema.graphql
+++ b/packages/enssdk/src/omnigraph/generated/schema.graphql
@@ -54,6 +54,11 @@ input AccountDomainsWhereInput {
   A partial Interpreted Name by which to search the set of Domains. ex: 'example', 'example.', 'example.et'.
   """
   name: String
+
+  """
+  If set, filters the set of Domains to only those of the specified ENS protocol version.
+  """
+  version: ENSProtocolVersion
 }
 
 type AccountEventsConnection {
@@ -328,6 +333,17 @@ input DomainsWhereInput {
   A partial Interpreted Name by which to search the set of Domains. ex: 'example', 'example.', 'example.et'.
   """
   name: String!
+
+  """
+  If set, filters the set of Domains to only those of the specified ENS protocol version.
+  """
+  version: ENSProtocolVersion
+}
+
+"""An ENS protocol version."""
+enum ENSProtocolVersion {
+  ENSv1
+  ENSv2
 }
 
 """An ENSv1Domain represents an ENSv1 Domain."""
@@ -937,9 +953,7 @@ type Query {
   """Identify a Domain by Name or DomainId"""
   domain(by: DomainIdInput!): Domain
 
-  """
-  Find Canonical Domains by Name. Results are always scoped to Canonical Domains — every nameable Domain is canonical by definition, so a non-canonical filter would be empty.
-  """
+  """Find Canonical Domains by Name."""
   domains(after: String, before: String, first: Int, last: Int, order: DomainsOrderInput, where: DomainsWhereInput!): QueryDomainsConnection
 
   """Identify Permissions by ID or AccountId."""


### PR DESCRIPTION
closes https://github.com/namehash/ensnode/issues/2060

## Reviewer Focus (Read This First)

- correctness of `filterByVersion` (ENSv1 → `Domain.type === "ENSv1Domain"`, ENSv2 → `"ENSv2Domain"`) — the only piece doing real work
- intentional asymmetry: filter is exposed on `Account.domains` and `Query.domains` only. omitted from `Registry.domains` and `Domain.subdomains` because both inherit a single protocol version from the parent by namegraph construction

---

## Problem & Motivation

- closes #2060
- apps/manager migration flow (ensdomains/apps-monorepo#593) needs v1-only domains for an account — the migration UI is "pick which V1 names to upgrade"
- today the client has to fetch both versions and post-filter on `__typename`. wasteful for accounts with many v2 names; impossible to combine with server-side `where`/`order`

---

## What Changed (Concrete)

1. `domainsBase()` now selects `Domain.type` into the base set; `selectBase()` carries it through filter layers
2. new `DomainType` alias derived from `ensIndexerSchema.domainType.enumValues[number]` (single source of truth, no hand-written literal)
3. new `filterByVersion(base, version)` layer
4. new `ENSProtocolVersion` GraphQL enum (`ENSv1` | `ENSv2`) in its own module to avoid an import loop with the filter layer
5. `version?: ENSProtocolVersion` added to `DomainsWhereInput` (Query.domains) and `AccountDomainsWhereInput` (Account.domains)
6. wired into `Query.domains` and `Account.domains` resolvers; omitted from `RegistryDomainsWhereInput` / `SubdomainsWhereInput`
7. regenerated `schema.graphql` and `introspection.ts`
8. minor changeset for ensapi

---

## Design & Planning

planning artifacts: issue #2060 (context + proposed shape).

alternatives considered:
- expose `version` on `Registry.domains` and `Domain.subdomains` too — rejected: parent already pins protocol version; the filter would be a no-op or empty
- materialize a separate `Domain.version` enum that excludes the `Domain` suffix — rejected: `Domain.type` already exists in the indexer schema, deriving the GraphQL filter from it keeps one source of truth

reviewed / approved by: n/a (additive, single-issue scope)

---

## Self-Review

- bugs caught: initial draft used a hand-written `"ENSv1Domain" | "ENSv2Domain"` literal; switched to `(typeof ensIndexerSchema.domainType.enumValues)[number]` so the type can't drift from the indexer enum
- logic simplified: pulled `ENSProtocolVersion` into its own schema module, dropping a circular import risk between `filter-by-version` and `schema/domain`
- naming: kept `version` (per issue), not `protocolVersion`. enum values are `ENSv1` / `ENSv2` (not `ENSv1Domain`) so the filter reads naturally as `where: { version: ENSv1 }`
- dead code: none

---

## Cross-Codebase Alignment

- search terms used: `ENSv1Domain`, `ENSv2Domain`, `domainType`, `filterByCanonical`, `DomainsWhereInput`
- reviewed but unchanged: `Registry.domains` and `Domain.subdomains` resolvers — intentionally do not expose `version`
- deferred alignment: none

---

## Downstream & Consumer Impact

- public api: new optional `where.version` on `Query.domains` and `Account.domains`; new `ENSProtocolVersion` enum in the omnigraph SDL
- additive only, no breaking changes
- consumer: ensdomains/apps-monorepo#593 (apps/manager migration UI)
- docs: changeset describes the new filter; no separate doc page required

---

## Testing Evidence

- integration tests added for `Account.domains` (3 cases: undefined / ENSv1 / ENSv2) and `Query.domains` (same 3 cases) verifying the returned `__typename` set
- `pnpm -F ensapi typecheck`, `pnpm lint`, `pnpm test --project ensapi` (98 passing), `pnpm generate:gqlschema` all green
- known gaps: no integration test for an account with zero domains in one of the versions (would be useful to confirm empty connection rather than error)

---

## Scope Reductions

- follow-ups: none. issue #2059 (\`name_in\` batch lookup) is sibling but unrelated

---

## Risk Analysis

- assumption: every \`Domain\` row has a non-null \`type\` of \`"ENSv1Domain"\` or \`"ENSv2Domain"\` (enforced by the ponder schema's \`domainType\` enum)
- failure mode: wrong enum mapping → client receives wrong subset. integration tests cover both directions
- blast radius: tiny — field is opt-in; omitting it preserves prior behavior
- mitigation: revert; no schema migration (ponder rebuild)
- named owner: @shrugs

---

## Pre-Review Checklist (Blocking)

- [x] I reviewed every line of this diff and understand it end-to-end
- [x] I'm prepared to defend this PR line-by-line in review
- [x] I'm comfortable being the on-call owner for this change
- [x] Relevant changesets are included (or explicitly not required)