### PR TITLE
docs(changeset): Fixes BasenamesL1Resolver and LineanamesL1Resolver

### DIFF
--- a/.changeset/hot-moose-camp.md
+++ b/.changeset/hot-moose-camp.md
@@ -1,0 +1,5 @@
+---
+"@ensnode/datasources": minor
+---
+
+Fixes BasenamesL1Resolver and LineanamesL1Resolver not being defined in the Sepolia namespace, causing ENSIndexer to crash when indexing Sepolia.


### PR DESCRIPTION
worth noting was caused by poor type safety via the `getDatasourceContract` fn