### PR TITLE
Prevent the "Release" workflow from running for any commit merged into `main` branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
     name: ${{ matrix.apps.name }} ${{ matrix.apps.version }}
     # if changesets published our npm packages, also build docker images
     needs: changesets
-    if: startsWith(github.event.head_commit.message, 'Release New Version') && needs.changesets.outputs.published == 'true' && needs.changesets.outputs.publishedApps != '[]'
+    if: needs.changesets.outputs.published == 'true' && needs.changesets.outputs.publishedApps != '[]'
     runs-on: blacksmith-4vcpu-ubuntu-2204
     strategy:
       fail-fast: false
@@ -160,7 +160,7 @@ jobs:
   build-lambdas:
     name: ${{ matrix.lambdas.name }} ${{ matrix.lambdas.version }}
     needs: changesets
-    if: startsWith(github.event.head_commit.message, 'Release New Version') && needs.changesets.outputs.published == 'true' && needs.changesets.outputs.publishedLambdas != '[]'
+    if: needs.changesets.outputs.published == 'true' && needs.changesets.outputs.publishedLambdas != '[]'
     runs-on: blacksmith-4vcpu-ubuntu-2204
     strategy:
       fail-fast: false
@@ -183,7 +183,7 @@ jobs:
     name: Create GitHub Release
     runs-on: blacksmith-4vcpu-ubuntu-2204
     # run only if (1) changesets published our npm packages AND
-    if: startsWith(github.event.head_commit.message, 'Release New Version') && needs.changesets.outputs.published == 'true'
+    if: needs.changesets.outputs.published == 'true'
     # (2) we built and pushed the docker images
     needs: [changesets, build-and-push-ensnode]
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,12 +69,8 @@ jobs:
           title: "Release New Version"
           version: pnpm changeset:version
           # Only publish when this is a merged Release PR (squash merge uses PR title as commit subject)
-          publish: >-
-            ${{
-              startsWith(github.event.head_commit.message, 'Release New Version')
-              && 'pnpm changeset:publish'
-              || ''
-            }}
+          # Only publish when this is a merged Release PR (squash merge uses PR title as commit subject)
+          publish: ${{ startsWith(github.event.head_commit.message, 'Release New Version') && 'pnpm changeset:publish' || '' }}
           createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,13 @@ jobs:
           commit: "chore(release): version apps"
           title: "Release New Version"
           version: pnpm changeset:version
-          publish: pnpm changeset:publish
+          # Only publish when this is a merged Release PR (squash merge uses PR title as commit subject)
+          publish: >-
+            ${{
+              startsWith(github.event.head_commit.message, 'Release New Version')
+              && 'pnpm changeset:publish'
+              || ''
+            }}
           createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -130,7 +136,7 @@ jobs:
     name: ${{ matrix.apps.name }} ${{ matrix.apps.version }}
     # if changesets published our npm packages, also build docker images
     needs: changesets
-    if: needs.changesets.outputs.published == 'true' && needs.changesets.outputs.publishedApps != '[]'
+    if: startsWith(github.event.head_commit.message, 'Release New Version') && needs.changesets.outputs.published == 'true' && needs.changesets.outputs.publishedApps != '[]'
     runs-on: blacksmith-4vcpu-ubuntu-2204
     strategy:
       fail-fast: false
@@ -159,7 +165,7 @@ jobs:
   build-lambdas:
     name: ${{ matrix.lambdas.name }} ${{ matrix.lambdas.version }}
     needs: changesets
-    if: needs.changesets.outputs.published == 'true' && needs.changesets.outputs.publishedLambdas != '[]'
+    if: startsWith(github.event.head_commit.message, 'Release New Version') && needs.changesets.outputs.published == 'true' && needs.changesets.outputs.publishedLambdas != '[]'
     runs-on: blacksmith-4vcpu-ubuntu-2204
     strategy:
       fail-fast: false
@@ -182,7 +188,7 @@ jobs:
     name: Create GitHub Release
     runs-on: blacksmith-4vcpu-ubuntu-2204
     # run only if (1) changesets published our npm packages AND
-    if: needs.changesets.outputs.published == 'true'
+    if: startsWith(github.event.head_commit.message, 'Release New Version') && needs.changesets.outputs.published == 'true'
     # (2) we built and pushed the docker images
     needs: [changesets, build-and-push-ensnode]
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,6 @@ jobs:
           title: "Release New Version"
           version: pnpm changeset:version
           # Only publish when this is a merged Release PR (squash merge uses PR title as commit subject)
-          # Only publish when this is a merged Release PR (squash merge uses PR title as commit subject)
           publish: ${{ startsWith(github.event.head_commit.message, 'Release New Version') && 'pnpm changeset:publish' || '' }}
           createGithubReleases: false
         env:


### PR DESCRIPTION
# Lite PR

[Tip: Review docs on the ENSNode PR process](https://ensnode.io/docs/contributing/prs)

## Summary

- Made the `publish` input to `changesets/action@v1.7.0` conditional: only set to `pnpm changeset:publish` when the commit message starts with `Release New Version` (i.e., a merged Release PR). On regular pushes to `main`, the input is empty so the action skips publish mode.
- Preserved commit-message guards on downstream jobs (`build-and-push-ensnode`, `build-lambdas`, `create-github-release`) so they only run for actual release PR merges.

---

## Why

- The previous workflow triggered `changeset publish` on every push to `main` that had no pending changesets. A regular docs commit could cause the action to enter publish mode and attempt to publish packages, which in turn set `published: 'true'` and caused downstream Docker/lambda builds to run.
- By conditionally providing the `publish` input, the `changesets` job can still run on every push to keep the Release PR up to date, but `changeset publish` and downstream builds are restricted to actual release merges.

Related run: https://github.com/namehash/ensnode/actions/runs/25669535621/job/75350813075

---

## Testing

- Not tested end-to-end in CI (requires a merge to `main`). The logic was verified by reviewing the `changesets/action` source code to confirm it skips `runPublish` when the `publish` input is empty.

---

## Notes for Reviewer (Optional)

- The `changesets` job must remain unguarded at the job level so that regular commits with new changesets still update the Release PR. The guard is applied only to the `publish` input.
- Resolves #2087 

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)
