### PR TITLE
fix: swap btree on label.interpreted for hash + GIN trgm

### DIFF
--- a/.changeset/swap-label-interpreted-index.md
+++ b/.changeset/swap-label-interpreted-index.md
@@ -1,0 +1,5 @@
+---
+"@ensnode/ensdb-sdk": patch
+---
+
+Replace the default btree index on `label.interpreted` with a hash index (for exact-match lookups) and a GIN trigram index (for substring / prefix `LIKE` queries). Avoids the btree 8191-byte leaf-size hazard that surfaces when a single label exceeds the limit (e.g. spam names), which previously crashed `create_indexes` at the historical→realtime boundary.

--- a/packages/ensdb-sdk/src/ensindexer-abstract/ensv2.schema.ts
+++ b/packages/ensdb-sdk/src/ensindexer-abstract/ensv2.schema.ts
@@ -607,7 +607,12 @@ export const label = onchainTable(
     interpreted: t.text().notNull().$type<InterpretedLabel>(),
   }),
   (t) => ({
-    byInterpreted: index().on(t.interpreted),
+    // hash index avoids the btree 8191-byte row-size hazard for spam labels (a single label can
+    // exceed btree's leaf-size limit)
+    byInterpretedExact: index().using("hash", t.interpreted),
+    // GIN trigram index for substring / similarity queries (inline `gin_trgm_ops` via `sql`
+    // because passing it through `.op()` gets dropped by Ponder)
+    byInterpretedFuzzy: index().using("gin", sql`${t.interpreted} gin_trgm_ops`),
   }),
 );
 


### PR DESCRIPTION
## Summary

- replace the default btree on `label.interpreted` with a hash index (exact match) and a GIN trigram index (substring / prefix `LIKE`) in `packages/ensdb-sdk/src/ensindexer-abstract/ensv2.schema.ts`

## Why

- a single label can exceed Postgres' 8191-byte btree leaf-size limit (spam names), which crashes `create_indexes` at the historical→realtime boundary with `index row requires 23448 bytes, maximum size is 8191` and retries until ponder gives up
- hash covers exact-match label lookups; GIN trgm covers prefix `LIKE` (used by `filter-by-name.ts`); ORDER BY no longer uses an index and falls back to sort over already-filtered subsets

## Testing

- typecheck (`ensdb-sdk`, `ensindexer`, `ensapi`) ✓, lint ✓
- not exercised against a full backfill in this PR — the failing index-build happens at the historical→realtime boundary and requires running the indexer to convergence on a dataset containing the offending labels

## Notes for Reviewer

- pre-existing `label.interpreted` callers audited: selection (`schema/label.ts:27`, `schema/domain.ts:144`), prefix `LIKE` (`filter-by-name.ts:166`), ORDER BY sortableLabel (`base-domain-set.ts:42`, `filter-by-name.ts:157`) — sort no longer index-assisted; flag if you want a separate strategy for it
- mirrors the index strategy already used for `domain.canonicalName` (hash + GIN trgm) on the materialized-name branch

## Checklist

- [x] This PR does **not** change runtime behavior or semantics
- [x] This PR is low-risk and safe to review quickly