### PR TITLE
fix(ensapi): gate Forward Resolution ENSv2 bailout on datasource presence

### DIFF
--- a/.changeset/forward-resolution-ensv2-datasource.md
+++ b/.changeset/forward-resolution-ensv2-datasource.md
@@ -1,0 +1,5 @@
+---
+"ensapi": patch
+---
+
+Forward Resolution now gates the ENSv2 bailout on the presence of an `ENSv2Root` datasource in the active namespace rather than on whether the ENSv2 plugin is configured. A namespace may be ENSv1-only even when the ENSv2 plugin is defined, and in that case forward resolution must continue down the ENSv1 path.

--- a/.changeset/forward-resolution-ensv2-datasource.md
+++ b/.changeset/forward-resolution-ensv2-datasource.md
@@ -2,4 +2,4 @@
 "ensapi": patch
 ---
 
-Forward Resolution now gates the ENSv2 bailout on the presence of an `ENSv2Root` datasource in the active namespace rather than on whether the ENSv2 plugin is configured. A namespace may be ENSv1-only even when the ENSv2 plugin is defined, and in that case forward resolution must continue down the ENSv1 path.
+Forward Resolution is no longer disabled on ENSv1-only namespaces when the `ensv2` plugin is enabled. Forward Resolution is only (temporarily) disabled when a namespace has been upgraded to ENSv2. The Resolution API continues to operate in either case, just without Protocol Acceleration (temporarily) when ENSv2 is deployed.

--- a/apps/ensapi/src/lib/resolution/forward-resolution.ts
+++ b/apps/ensapi/src/lib/resolution/forward-resolution.ts
@@ -11,7 +11,7 @@ import {
   namehashInterpretedName,
 } from "enssdk";
 
-import { DatasourceNames } from "@ensnode/datasources";
+import { DatasourceNames, maybeGetDatasource } from "@ensnode/datasources";
 import {
   type ForwardResolutionArgs,
   ForwardResolutionProtocolStep,
@@ -19,7 +19,6 @@ import {
   getDatasourceContract,
   getENSv1RootRegistry,
   maybeGetDatasourceContract,
-  PluginName,
   type ResolverRecordsSelection,
   TraceableENSProtocol,
   toJson,
@@ -175,7 +174,10 @@ async function _resolveForward<SELECTION extends ResolverRecordsSelection>(
           /// 0. Temporary ENSv2 Bailout
           ////////////////////////////
           // TODO: re-enable protocol acceleration for ENSv2
-          if (config.ensIndexerPublicConfig.plugins.includes(PluginName.ENSv2)) {
+          // NOTE: gate on the namespace containing an ENSv2Root datasource rather than the ENSv2
+          // plugin being configured — a namespace may be ENSv1-only even when the ENSv2 plugin is
+          // defined, and forward resolution must follow the ENSv1 path in that case.
+          if (maybeGetDatasource(config.namespace, DatasourceNames.ENSv2Root)) {
             const UniversalResolverAddress =
               getUniversalResolverV2()?.address ?? getUniversalResolverV1().address;
             operations = await withEnsProtocolStep(


### PR DESCRIPTION
## Summary

- forward resolution's temporary ENSv2 bailout now checks for an `ENSv2Root` datasource in the active namespace instead of whether the `ENSv2` plugin is configured
- drops the now-unused `PluginName` import in `apps/ensapi/src/lib/resolution/forward-resolution.ts`

---

## Why

- a namespace can be ENSv1-only even when the ENSv2 plugin is defined. in that case forward resolution must follow the ENSv1 path. the previous plugin-based gate would have incorrectly diverted those names into the ENSv2 bailout.

---

## Testing

- `pnpm -F ensapi typecheck`
- `pnpm lint`
- `pnpm test --project ensapi` — 98 tests pass
- no new unit test added; the prior plugin-based gate was not covered by a unit test either

---

## Notes for Reviewer (Optional)

- this is a small but real runtime-behavior change in resolution (a correctness fix), so the "does not change runtime behavior" checkbox is intentionally unchecked. blast radius is contained to the single bailout condition.
- changeset included.

---

## Checklist

- [ ] This PR does **not** change runtime behavior or semantics
- [x] This PR is low-risk and safe to review quickly