### PR TITLE
Patches for 1.13.1

### DIFF
--- a/.changeset/clever-numbers-change.md
+++ b/.changeset/clever-numbers-change.md
@@ -1,0 +1,5 @@
+---
+"@ensnode/ensnode-sdk": minor
+---
+
+Added `globalBlockrangeEndBlock` param to `buildIndexedBlockranges`.

--- a/.changeset/fifty-humans-wait.md
+++ b/.changeset/fifty-humans-wait.md
@@ -2,4 +2,4 @@
 "ensapi": minor
 ---
 
-Protocol accelertation is now available for data indexed from ENSv1 namespaces. ENSv2 namespaces will be supported in the future.
+Continue to support protocol acceleration for data indexed from ENSv1 namespaces. Protocol acceleration for data indexed from ENSv2 namespaces will be supported in the near future.

--- a/.changeset/fifty-humans-wait.md
+++ b/.changeset/fifty-humans-wait.md
@@ -1,0 +1,5 @@
+---
+"ensapi": minor
+---
+
+Protocol accelertation is now available for data indexed from ENSv1 namespaces. ENSv2 namespaces will be supported in the future.

--- a/apps/ensapi/src/middleware/can-accelerate.middleware.ts
+++ b/apps/ensapi/src/middleware/can-accelerate.middleware.ts
@@ -1,5 +1,6 @@
 import config from "@/config";
 
+import { DatasourceNames, maybeGetDatasource } from "@ensnode/datasources";
 import { PluginName } from "@ensnode/ensnode-sdk";
 
 import { factory, producing } from "@/lib/hono-factory";
@@ -35,7 +36,10 @@ export const canAccelerateMiddleware = producing(
     /// Temporary ENSv2 Bailout
     ////////////////////////////
     // TODO: re-enable acceleration for ensv2 once implemented
-    if (config.ensIndexerPublicConfig.plugins.includes(PluginName.ENSv2)) {
+    // NOTE: gate on the namespace containing an ENSv2Root datasource rather than the ENSv2
+    // plugin being configured — a namespace may be ENSv1-only even when the ENSv2 plugin is
+    // defined, and forward resolution must follow the ENSv1 path in that case.
+    if (maybeGetDatasource(config.namespace, DatasourceNames.ENSv2Root)) {
       if (!didWarnCannotAccelerateENSv2) {
         logger.warn(
           `ENSApi is temporarily unable to accelerate Resolution API requests while indexing ENSv2. Protocol Acceleration is DISABLED.`,

--- a/apps/ensindexer/src/lib/indexing-engines/init-indexing-onchain-events.ts
+++ b/apps/ensindexer/src/lib/indexing-engines/init-indexing-onchain-events.ts
@@ -4,8 +4,6 @@
  * event handlers.
  */
 
-import pRetry from "p-retry";
-
 import { migrateEnsNodeSchema } from "@/lib/ensdb/migrate-ensnode-schema";
 import { ensDbClient } from "@/lib/ensdb/singleton";
 import { startEnsDbWriterWorker } from "@/lib/ensdb-writer-worker/singleton";
@@ -17,20 +15,7 @@ import { indexingMetadataContextBuilder } from "@/lib/indexing-metadata-context-
 import { logger } from "@/lib/logger";
 
 async function upsertIndexingMetadataContextRecord(): Promise<void> {
-  // indexingMetadataContextBuilder may face transient errors while trying to
-  // build the Indexing Metadata Context, so we allow to retry this operation
-  // a few times before giving up and crashing the ENSIndexer instance.
-  const indexingMetadataContext = await pRetry(
-    () => indexingMetadataContextBuilder.getIndexingMetadataContext(),
-    {
-      retries: 5,
-      onFailedAttempt: ({ error, attemptNumber, retriesLeft }) => {
-        logger.info({
-          msg: ` Building Indexing Metadata Context attempt ${attemptNumber} failed (${error.message}). ${retriesLeft} retries left.`,
-        });
-      },
-    },
-  );
+  const indexingMetadataContext = await indexingMetadataContextBuilder.getIndexingMetadataContext();
 
   logger.info({
     msg: `Upserting Indexing Metadata Context Initialized`,
@@ -63,6 +48,11 @@ async function upsertIndexingMetadataContextRecord(): Promise<void> {
  * so we need to make sure that this does not cause any unexpected side effects.
  */
 export async function initIndexingOnchainEvents(): Promise<void> {
+  logger.info({
+    msg: "Initializing indexing of onchain events",
+    module: "init-indexing-onchain-events",
+  });
+
   try {
     // Ensure ENSDb instance is healthy before trying to run any queries against it.
     const isEnsDbHealthy = await ensDbClient.isHealthy();

--- a/apps/ensindexer/src/lib/indexing-engines/init-indexing-onchain-events.ts
+++ b/apps/ensindexer/src/lib/indexing-engines/init-indexing-onchain-events.ts
@@ -4,6 +4,8 @@
  * event handlers.
  */
 
+import pRetry from "p-retry";
+
 import { migrateEnsNodeSchema } from "@/lib/ensdb/migrate-ensnode-schema";
 import { ensDbClient } from "@/lib/ensdb/singleton";
 import { startEnsDbWriterWorker } from "@/lib/ensdb-writer-worker/singleton";
@@ -15,7 +17,20 @@ import { indexingMetadataContextBuilder } from "@/lib/indexing-metadata-context-
 import { logger } from "@/lib/logger";
 
 async function upsertIndexingMetadataContextRecord(): Promise<void> {
-  const indexingMetadataContext = await indexingMetadataContextBuilder.getIndexingMetadataContext();
+  // indexingMetadataContextBuilder may face transient errors while trying to
+  // build the Indexing Metadata Context, so we allow to retry this operation
+  // a few times before giving up and crashing the ENSIndexer instance.
+  const indexingMetadataContext = await pRetry(
+    () => indexingMetadataContextBuilder.getIndexingMetadataContext(),
+    {
+      retries: 5,
+      onFailedAttempt: ({ error, attemptNumber, retriesLeft }) => {
+        logger.info({
+          msg: ` Building Indexing Metadata Context attempt ${attemptNumber} failed (${error.message}). ${retriesLeft} retries left.`,
+        });
+      },
+    },
+  );
 
   logger.info({
     msg: `Upserting Indexing Metadata Context Initialized`,

--- a/apps/ensindexer/src/lib/indexing-status-builder/indexing-status-builder.test.ts
+++ b/apps/ensindexer/src/lib/indexing-status-builder/indexing-status-builder.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import "@/lib/__test__/mockLogger";
+
 import {
   ChainIndexingStatusIds,
   type ChainIndexingStatusSnapshotBackfill,

--- a/apps/ensindexer/src/lib/indexing-status-builder/indexing-status-builder.test.ts
+++ b/apps/ensindexer/src/lib/indexing-status-builder/indexing-status-builder.test.ts
@@ -476,6 +476,66 @@ describe("IndexingStatusBuilder", () => {
   });
 
   describe("Race condition handling", () => {
+    it("clamps latestIndexedBlock to backfillEndBlock when checkpointBlock advances past it in historical", async () => {
+      // Arrange — simulate a race where the checkpoint block has advanced
+      // past the backfill end block between concurrent fetches.
+      const publicClientMock = buildPublicClientMock();
+
+      // checkpointBlock (laterBlockRef/1025) is ahead of backfillEndBlock (earlierBlockRef/1024)
+      const localMetrics = buildLocalChainsIndexingMetrics(
+        new Map([
+          [
+            chainId,
+            {
+              state: ChainIndexingStates.Historical,
+              latestSyncedBlock: latestBlockRef,
+              historicalTotalBlocks: 100,
+              backfillEndBlock: earlierBlockRef.number, // 1024
+            } satisfies LocalChainIndexingMetricsHistorical,
+          ],
+        ]),
+      );
+
+      const localStatus: PonderIndexingStatus = {
+        chains: new Map([[chainId, { checkpointBlock: laterBlockRef }]]), // 1025, ahead of backfillEndBlock
+      };
+
+      const localPonderClientMock = buildLocalPonderClientMock({
+        metrics: vi.fn().mockResolvedValue(localMetrics),
+        status: vi.fn().mockResolvedValue(localStatus),
+        getIndexedBlockrange: vi
+          .fn()
+          .mockReturnValue(buildBlockNumberRange(earliestBlockRef.number, undefined)),
+        getCachedPublicClient: vi.fn().mockReturnValue(publicClientMock),
+      });
+
+      const builder = new IndexingStatusBuilder(localPonderClientMock as LocalPonderClient);
+
+      // Act
+      const result = await builder.getOmnichainIndexingStatusSnapshot();
+
+      // Assert — latestIndexedBlock should be clamped to backfillEndBlock (earlierBlockRef)
+      // instead of the checkpointBlock (laterBlockRef)
+      expect(result).toStrictEqual({
+        omnichainStatus: OmnichainIndexingStatusIds.Backfill,
+        chains: new Map([
+          [
+            chainId,
+            {
+              chainStatus: ChainIndexingStatusIds.Backfill,
+              latestIndexedBlock: earlierBlockRef, // clamped to backfillEndBlock
+              backfillEndBlock: earlierBlockRef,
+              config: {
+                rangeType: RangeTypeIds.LeftBounded,
+                startBlock: earliestBlockRef,
+              },
+            } satisfies ChainIndexingStatusSnapshotBackfill,
+          ],
+        ]),
+        omnichainIndexingCursor: earlierBlockRef.timestamp,
+      } satisfies OmnichainIndexingStatusSnapshot);
+    });
+
     it("clamps latestKnownBlock when checkpointBlock is ahead of latestSyncedBlock in realtime", async () => {
       // Arrange — simulate a race where the checkpoint block has advanced
       // past the synced block metric between concurrent fetches.

--- a/apps/ensindexer/src/lib/indexing-status-builder/indexing-status-builder.ts
+++ b/apps/ensindexer/src/lib/indexing-status-builder/indexing-status-builder.ts
@@ -31,6 +31,8 @@ import {
   RangeTypeIds,
 } from "@ensnode/ponder-sdk";
 
+import { logger } from "@/lib/logger";
+
 export class IndexingStatusBuilder {
   /**
    * Immutable Indexing Config
@@ -129,6 +131,11 @@ export class IndexingStatusBuilder {
   ): ChainIndexingStatusSnapshot {
     const { checkpointBlock } = chainIndexingStatus;
     const { indexedBlockrange } = chainIndexingConfig;
+
+    logger.info({
+      msg: `Building indexing status snapshot for chain`,
+      payload: { chainIndexingConfig, chainIndexingMetrics, chainIndexingStatus },
+    });
 
     // In omnichain ordering, if the startBlock is the same as the
     // status block, the chain has not started yet.

--- a/apps/ensindexer/src/lib/indexing-status-builder/indexing-status-builder.ts
+++ b/apps/ensindexer/src/lib/indexing-status-builder/indexing-status-builder.ts
@@ -293,7 +293,7 @@ export class IndexingStatusBuilder {
       const errorMessage = error instanceof Error ? error.message : "Unknown error";
 
       throw new Error(
-        `Error fetching block for chain ID ${chainId} at block number ${blockNumber.toString()}: ${errorMessage}`,
+        `Error fetching block for chain ID ${chainId} at block number ${blockNumber}: ${errorMessage}`,
       );
     }
   }

--- a/apps/ensindexer/src/lib/indexing-status-builder/indexing-status-builder.ts
+++ b/apps/ensindexer/src/lib/indexing-status-builder/indexing-status-builder.ts
@@ -113,6 +113,7 @@ export class IndexingStatusBuilder {
         logger.error({
           msg: `Building indexing status snapshot for chain ID ${chainId} failed`,
           payload: { chainIndexingConfig, chainIndexingMetrics, chainIndexingStatus },
+          error,
         });
         throw error;
       }

--- a/apps/ensindexer/src/lib/indexing-status-builder/indexing-status-builder.ts
+++ b/apps/ensindexer/src/lib/indexing-status-builder/indexing-status-builder.ts
@@ -112,7 +112,12 @@ export class IndexingStatusBuilder {
       } catch (error) {
         logger.error({
           msg: `Building indexing status snapshot for chain ID ${chainId} failed`,
-          payload: { chainIndexingConfig, chainIndexingMetrics, chainIndexingStatus },
+          payload: {
+            chainId,
+            chainIndexingConfig,
+            chainIndexingMetrics,
+            chainIndexingStatus,
+          },
           error,
         });
         throw error;

--- a/apps/ensindexer/src/lib/indexing-status-builder/indexing-status-builder.ts
+++ b/apps/ensindexer/src/lib/indexing-status-builder/indexing-status-builder.ts
@@ -92,22 +92,30 @@ export class IndexingStatusBuilder {
       const chainIndexingStatus = chainIndexingStatuses.get(chainId);
       const chainIndexingConfig = chainsIndexingConfig.get(chainId);
 
-      // Invariants ensuring required data is available.
-      if (!chainIndexingStatus) {
-        throw new Error(`Indexing status not found for chain ID ${chainId}`);
+      try {
+        // Invariants ensuring required data is available.
+        if (!chainIndexingStatus) {
+          throw new Error(`Indexing status not found for chain ID ${chainId}`);
+        }
+
+        if (!chainIndexingConfig) {
+          throw new Error(`Indexing config not found for chain ID ${chainId}`);
+        }
+
+        const chainStatusSnapshot = this.buildChainIndexingStatusSnapshot(
+          chainIndexingMetric,
+          chainIndexingStatus,
+          chainIndexingConfig,
+        );
+
+        chainStatusSnapshots.set(chainId, chainStatusSnapshot);
+      } catch (error) {
+        logger.error({
+          msg: `Building indexing status snapshot for chain ID ${chainId} failed`,
+          payload: { chainIndexingConfig, chainIndexingMetrics, chainIndexingStatus },
+        });
+        throw error;
       }
-
-      if (!chainIndexingConfig) {
-        throw new Error(`Indexing config not found for chain ID ${chainId}`);
-      }
-
-      const chainStatusSnapshot = this.buildChainIndexingStatusSnapshot(
-        chainIndexingMetric,
-        chainIndexingStatus,
-        chainIndexingConfig,
-      );
-
-      chainStatusSnapshots.set(chainId, chainStatusSnapshot);
     }
 
     return chainStatusSnapshots;
@@ -131,11 +139,6 @@ export class IndexingStatusBuilder {
   ): ChainIndexingStatusSnapshot {
     const { checkpointBlock } = chainIndexingStatus;
     const { indexedBlockrange } = chainIndexingConfig;
-
-    logger.info({
-      msg: `Building indexing status snapshot for chain`,
-      payload: { chainIndexingConfig, chainIndexingMetrics, chainIndexingStatus },
-    });
 
     // In omnichain ordering, if the startBlock is the same as the
     // status block, the chain has not started yet.
@@ -174,6 +177,15 @@ export class IndexingStatusBuilder {
       }
 
       case ChainIndexingStates.Historical: {
+        // // Metrics and status are fetched concurrently — the checkpoint block
+        // // can briefly advance past the backfill end block. Clamp to maintain
+        // // the invariant: latestIndexedBlock <= backfillEndBlock.
+        // const latestIndexedBlock =
+        //   chainIndexingConfig.backfillEndBlock &&
+        //   isBlockRefBeforeOrEqualTo(chainIndexingConfig.backfillEndBlock, checkpointBlock)
+        //     ? chainIndexingConfig.backfillEndBlock
+        //     : checkpointBlock;
+
         return validateChainIndexingStatusSnapshot({
           chainStatus: ChainIndexingStatusIds.Backfill,
           latestIndexedBlock: checkpointBlock,
@@ -281,7 +293,7 @@ export class IndexingStatusBuilder {
       const errorMessage = error instanceof Error ? error.message : "Unknown error";
 
       throw new Error(
-        `Error fetching block for chain ID ${chainId} at block number ${blockNumber}: ${errorMessage}`,
+        `Error fetching block for chain ID ${chainId} at block number ${blockNumber.toString()}: ${errorMessage}`,
       );
     }
   }

--- a/apps/ensindexer/src/lib/indexing-status-builder/indexing-status-builder.ts
+++ b/apps/ensindexer/src/lib/indexing-status-builder/indexing-status-builder.ts
@@ -177,18 +177,18 @@ export class IndexingStatusBuilder {
       }
 
       case ChainIndexingStates.Historical: {
-        // // Metrics and status are fetched concurrently — the checkpoint block
-        // // can briefly advance past the backfill end block. Clamp to maintain
-        // // the invariant: latestIndexedBlock <= backfillEndBlock.
-        // const latestIndexedBlock =
-        //   chainIndexingConfig.backfillEndBlock &&
-        //   isBlockRefBeforeOrEqualTo(chainIndexingConfig.backfillEndBlock, checkpointBlock)
-        //     ? chainIndexingConfig.backfillEndBlock
-        //     : checkpointBlock;
+        // Metrics and status are fetched concurrently — the checkpoint block
+        // can briefly advance past the backfill end block. Clamp to maintain
+        // the invariant: latestIndexedBlock <= backfillEndBlock.
+        const latestIndexedBlock =
+          chainIndexingConfig.backfillEndBlock &&
+          isBlockRefBeforeOrEqualTo(chainIndexingConfig.backfillEndBlock, checkpointBlock)
+            ? chainIndexingConfig.backfillEndBlock
+            : checkpointBlock;
 
         return validateChainIndexingStatusSnapshot({
           chainStatus: ChainIndexingStatusIds.Backfill,
-          latestIndexedBlock: checkpointBlock,
+          latestIndexedBlock,
           backfillEndBlock: chainIndexingConfig.backfillEndBlock as Unvalidated<BlockRef>,
           config: indexedBlockrange as Unvalidated<BlockRefRangeWithStartBlock>,
         } satisfies Unvalidated<ChainIndexingStatusSnapshotBackfill>);

--- a/apps/ensindexer/src/lib/local-ponder-client.ts
+++ b/apps/ensindexer/src/lib/local-ponder-client.ts
@@ -10,7 +10,11 @@ import { getPluginsAllDatasourceNames } from "@/lib/plugin-helpers";
 import { localPonderContext } from "./local-ponder-context";
 
 const pluginsAllDatasourceNames = getPluginsAllDatasourceNames(config.plugins);
-const indexedBlockranges = buildIndexedBlockranges(config.namespace, pluginsAllDatasourceNames);
+const indexedBlockranges = buildIndexedBlockranges(
+  config.namespace,
+  config.globalBlockrange.endBlock,
+  pluginsAllDatasourceNames,
+);
 
 export const localPonderClient = new LocalPonderClient(
   config.indexedChainIds,

--- a/packages/ensnode-sdk/src/shared/config/indexed-blockranges.test.ts
+++ b/packages/ensnode-sdk/src/shared/config/indexed-blockranges.test.ts
@@ -68,7 +68,11 @@ describe("buildIndexedBlockranges()", () => {
     ]);
 
     // Act
-    const result = buildIndexedBlockranges(ENSNamespaceIds.Mainnet, pluginsRequiredDatasourceNames);
+    const result = buildIndexedBlockranges(
+      ENSNamespaceIds.Mainnet,
+      undefined,
+      pluginsRequiredDatasourceNames,
+    );
 
     const expectedEntries = new Map<ChainId, BlockNumberRangeWithStartBlock>([
       [1, buildBlockNumberRange(80, undefined)],
@@ -104,7 +108,11 @@ describe("buildIndexedBlockranges()", () => {
     ]);
 
     // Act
-    const result = buildIndexedBlockranges(ENSNamespaceIds.Mainnet, pluginsRequiredDatasourceNames);
+    const result = buildIndexedBlockranges(
+      ENSNamespaceIds.Mainnet,
+      undefined,
+      pluginsRequiredDatasourceNames,
+    );
 
     // Assert
 
@@ -137,7 +145,11 @@ describe("buildIndexedBlockranges()", () => {
     ]);
 
     // Act
-    const result = buildIndexedBlockranges(ENSNamespaceIds.Mainnet, pluginsRequiredDatasourceNames);
+    const result = buildIndexedBlockranges(
+      ENSNamespaceIds.Mainnet,
+      undefined,
+      pluginsRequiredDatasourceNames,
+    );
 
     // Assert
     expect(result).toStrictEqual(new Map([[8453, buildBlockNumberRange(17571480, undefined)]]));
@@ -150,9 +162,67 @@ describe("buildIndexedBlockranges()", () => {
     const pluginsDatasourceNames = new Map([[PluginName.Subgraph, [DatasourceNames.Seaport]]]);
 
     // Act
-    const result = buildIndexedBlockranges(ENSNamespaceIds.Mainnet, pluginsDatasourceNames);
+    const result = buildIndexedBlockranges(
+      ENSNamespaceIds.Mainnet,
+      undefined,
+      pluginsDatasourceNames,
+    );
 
     // Assert
     expect(result).toStrictEqual(new Map());
+  });
+
+  it("applies global end block to contracts without end block and skips contracts starting after global end block", () => {
+    // Arrange
+    const ensrootDatasourceConfig: unknown = {
+      chain: { id: 1 },
+      contracts: {
+        registry: { startBlock: 100 }, // no endBlock, should use global end block (500)
+        resolver: { startBlock: 80, endBlock: 200 }, // has endBlock, should keep it
+        registrar: { startBlock: 600 }, // startBlock > global end block, should be skipped
+      },
+    };
+
+    const basenamesDatasourceConfig: unknown = {
+      chain: { id: 8453 },
+      contracts: {
+        registry: { startBlock: 5 }, // no endBlock, should use global end block (500)
+      },
+    };
+
+    const datasourcesByName: Partial<
+      Record<DatasourceName, ReturnType<typeof datasources.maybeGetDatasource>>
+    > = {
+      [DatasourceNames.ENSRoot]: datasourceMock(ensrootDatasourceConfig),
+      [DatasourceNames.Basenames]: datasourceMock(basenamesDatasourceConfig),
+    };
+
+    maybeGetDatasourceMock.mockImplementation(
+      (_namespace, datasourceName) => datasourcesByName[datasourceName as DatasourceName],
+    );
+
+    const pluginsRequiredDatasourceNames = new Map([
+      [PluginName.Subgraph, [DatasourceNames.ENSRoot]],
+      [PluginName.Basenames, [DatasourceNames.Basenames]],
+    ]);
+
+    const globalBlockrangeEndBlock = 500;
+
+    // Act
+    const result = buildIndexedBlockranges(
+      ENSNamespaceIds.Mainnet,
+      globalBlockrangeEndBlock,
+      pluginsRequiredDatasourceNames,
+    );
+
+    // Assert
+    const expectedEntries = new Map<ChainId, BlockNumberRangeWithStartBlock>([
+      // Chain 1: min startBlock = 80, max endBlock = max(500 from registry, 200 from resolver) = 500
+      [1, buildBlockNumberRange(80, 500)],
+      // Chain 8453: startBlock = 5, endBlock = 500 (from global)
+      [8453, buildBlockNumberRange(5, 500)],
+    ]);
+
+    expect(result).toStrictEqual(expectedEntries);
   });
 });

--- a/packages/ensnode-sdk/src/shared/config/indexed-blockranges.ts
+++ b/packages/ensnode-sdk/src/shared/config/indexed-blockranges.ts
@@ -41,7 +41,10 @@ export function buildIndexedBlockranges(
       for (const datasourceContract of datasourceContracts) {
         const currentChainIndexedBlockrange = indexedBlockranges.get(datasourceChainId);
 
-        if (globalBlockrangeEndBlock && datasourceContract.startBlock > globalBlockrangeEndBlock) {
+        if (
+          typeof globalBlockrangeEndBlock === "number" &&
+          datasourceContract.startBlock > globalBlockrangeEndBlock
+        ) {
           // If the contract's start block is greater than the global end block,
           // then this contract is not indexed at all, so we can skip it from
           // consideration in the indexed blockrange.

--- a/packages/ensnode-sdk/src/shared/config/indexed-blockranges.ts
+++ b/packages/ensnode-sdk/src/shared/config/indexed-blockranges.ts
@@ -53,7 +53,7 @@ export function buildIndexedBlockranges(
 
         const contractIndexedBlockrange = buildBlockNumberRange(
           datasourceContract.startBlock,
-          datasourceContract.endBlock || globalBlockrangeEndBlock,
+          datasourceContract.endBlock ?? globalBlockrangeEndBlock,
         );
 
         const indexedBlockrange = currentChainIndexedBlockrange

--- a/packages/ensnode-sdk/src/shared/config/indexed-blockranges.ts
+++ b/packages/ensnode-sdk/src/shared/config/indexed-blockranges.ts
@@ -9,6 +9,7 @@ import {
 
 import type { PluginName } from "../../ensindexer/config/types";
 import {
+  type BlockNumberRange,
   type BlockNumberRangeWithStartBlock,
   buildBlockNumberRange,
   mergeBlockNumberRanges,
@@ -22,6 +23,7 @@ import {
  */
 export function buildIndexedBlockranges(
   namespace: ENSNamespaceId,
+  globalBlockrangeEndBlock: BlockNumberRange["endBlock"],
   pluginsDatasourceNames: Map<PluginName, DatasourceName[]>,
 ): Map<ChainId, BlockNumberRangeWithStartBlock> {
   const indexedBlockranges = new Map<ChainId, BlockNumberRangeWithStartBlock>();
@@ -39,9 +41,16 @@ export function buildIndexedBlockranges(
       for (const datasourceContract of datasourceContracts) {
         const currentChainIndexedBlockrange = indexedBlockranges.get(datasourceChainId);
 
+        if (globalBlockrangeEndBlock && datasourceContract.startBlock > globalBlockrangeEndBlock) {
+          // If the contract's start block is greater than the global end block,
+          // then this contract is not indexed at all, so we can skip it from
+          // consideration in the indexed blockrange.
+          continue;
+        }
+
         const contractIndexedBlockrange = buildBlockNumberRange(
           datasourceContract.startBlock,
-          datasourceContract.endBlock,
+          datasourceContract.endBlock || globalBlockrangeEndBlock,
         );
 
         const indexedBlockrange = currentChainIndexedBlockrange


### PR DESCRIPTION
# Lite PR

[Tip: Review docs on the ENSNode PR process](https://ensnode.io/docs/contributing/prs)

## Summary

- ENSNode SDK
  - `buildIndexedBlockranges` now accepts the `globalBlockrangeEndBlock` in order to take the `END_BLOCK` config value into account while building indexed block range for each indexed chain.
- ENSIndexer: `IndexingStatusBuilder`
  - Print detailed error message when a chain indexing status snapshot could not be built in `buildChainIndexingStatusSnapshots`.
  - Fix how `latestIndexedBlock` is determined for "historical" metrics while building the chain indexing status snapshot. Sometimes after ENSIndexer restarts, the Ponder Metrics and Ponder Status would go slightly out of sync. We resolved that using similar method that was previously applied for the "realtime" metrics.
- ENSApi: `canAccelerateMiddleware`
  - Complete the update initialized in PR #2097 

---

## Why

- > when i index with an END_BLOCK i get this invariant infinitely once the end block is reached
  - https://namehash.slack.com/archives/C086Z6FNBHN/p1778385256256899
- > green's v2-sepolia indexer isn't starting because of a chain indexing snapshot validation error.
  - https://namehash.slack.com/archives/C086Z6FNBHN/p1778361361424079

---

## Testing

- Tested locally, and also deployed preview release to  the Green env.

---

## Notes for Reviewer (Optional)

- Anything non-obvious or worth a heads-up.

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)
