### PR TITLE
hotfix: find-resolver correctly construct new domain ids

### DIFF
--- a/.changeset/eager-yaks-shout.md
+++ b/.changeset/eager-yaks-shout.md
@@ -1,0 +1,5 @@
+---
+"ensapi": patch
+---
+
+Hotfixes an issue where Accelerated records would always be null

--- a/.changeset/eager-yaks-shout.md
+++ b/.changeset/eager-yaks-shout.md
@@ -2,4 +2,4 @@
 "ensapi": patch
 ---
 
-Hotfixes an issue where Accelerated records would always be null
+Resolution API: Protocol Accelerated records now correctly resolve instead of incorrectly always returning `null`.

--- a/apps/ensapi/src/lib/protocol-acceleration/find-resolver.ts
+++ b/apps/ensapi/src/lib/protocol-acceleration/find-resolver.ts
@@ -9,13 +9,14 @@ import {
   type DomainId,
   getNameHierarchy,
   type InterpretedName,
+  makeENSv1DomainId,
   namehashInterpretedName,
 } from "enssdk";
 import { isAddressEqual, type PublicClient, toHex, zeroAddress } from "viem";
 import { packetToBytes } from "viem/ens";
 
 import { DatasourceNames, getDatasource } from "@ensnode/datasources";
-import { accountIdEqual, getDatasourceContract, isENSv1Registry } from "@ensnode/ensnode-sdk";
+import { accountIdEqual, isENSv1Registry } from "@ensnode/ensnode-sdk";
 
 import { ensDb } from "@/lib/ensdb/singleton";
 import { withActiveSpanAsync, withSpanAsync } from "@/lib/instrumentation/auto-span";
@@ -186,8 +187,9 @@ async function findResolverWithIndex(
 
       // 2. compute domainId of each node
       // NOTE: this is currently ENSv1-specific
-      const nodes = names.map((name) => namehashInterpretedName(name));
-      const domainIds = nodes as DomainId[];
+      const domainIds = names.map(
+        (name) => makeENSv1DomainId(registry, namehashInterpretedName(name)) as DomainId,
+      );
 
       // 3. for each domain, find its associated resolver in the selected registry
       const domainResolverRelations = await withSpanAsync(
@@ -195,29 +197,13 @@ async function findResolverWithIndex(
         "domainResolverRelation.findMany",
         {},
         async () => {
-          const ENSv1RegistryOld = getDatasourceContract(
-            config.namespace,
-            DatasourceNames.ENSRoot,
-            "ENSv1RegistryOld",
-          );
-          // the current ENS Root Chain Registry is actually ENSRegistryWithFallback: if a node
-          // doesn't exist in its own storage, it directs the lookup to RegistryOld. We must encode
-          // this logic here, so that the active resolver of unmigrated nodes can be correctly identified.
-          // https://github.com/ensdomains/ens-contracts/blob/be53b9c25be5b2c7326f524bbd34a3939374ab1f/contracts/registry/ENSRegistryWithFallback.sol#L19
+          // NOTE: because DRRs are now canonicalized against the managedName's Registry, we no longer
+          // need to also join ENSv1RegistryOld DRRs if the registry is the ENSv1Registry
           const records = await ensDb.query.domainResolverRelation.findMany({
-            where: (t, { inArray, and, or, eq }) =>
+            where: (t, { inArray, and, eq }) =>
               and(
-                or(
-                  // filter for Domain-Resolver Relationship in the current Registry
-                  and(eq(t.chainId, registry.chainId), eq(t.address, registry.address)),
-                  // OR, if the registry is the ENS Root Registry, also include records from RegistryOld
-                  isENSv1Registry(config.namespace, registry)
-                    ? and(
-                        eq(t.chainId, ENSv1RegistryOld.chainId),
-                        eq(t.address, ENSv1RegistryOld.address),
-                      )
-                    : undefined,
-                ),
+                // filter for Domain-Resolver Relationship in the current Registry
+                and(eq(t.chainId, registry.chainId), eq(t.address, registry.address)),
                 // filter for Domain-Resolver Relations for the following DomainIds
                 inArray(t.domainId, domainIds),
               ),

--- a/apps/ensindexer/src/plugins/protocol-acceleration/handlers/ENSv1Registry.ts
+++ b/apps/ensindexer/src/plugins/protocol-acceleration/handlers/ENSv1Registry.ts
@@ -29,7 +29,7 @@ export default function () {
     const { node, resolver } = event.args;
 
     // Canonicalize to the concrete ENSv1 Registry that governs this contract's namegraph
-    // (ENSv1Registry vs. ENSv1RegistryOld both canonicalize to the new Registry on mainnet).
+    // (ENSv1Registry vs. ENSv1RegistryOld both canonicalize to ENSv1Registry)
     const { registry } = getManagedName(getThisAccountId(context, event));
     const domainId = makeENSv1DomainId(registry, node);
 


### PR DESCRIPTION
caused during id refactor (unified datamodel) that made ensv1domainids `(registry, node)` instead of just `node`. the type-unsafe cast in forward-resolution wasn't updated, so the active resolver for a name couldn't be identified, leading to null results

 the ENSv1RegistryOld change need not be included but it's safe; the indexer writes all records to ENSv1Registry now, (appropriately ignoring the Old ones after migration) so the DRRs attached to ENSv1Registry are guaranteed to implement the fallback correctly