### PR TITLE
fix(ensnode-react): use skipToken for disabled useQuery branches

### DIFF
--- a/.changeset/disabled-query-skiptoken.md
+++ b/.changeset/disabled-query-skiptoken.md
@@ -1,0 +1,5 @@
+---
+"@ensnode/ensnode-react": patch
+---
+
+Fix tanstack-query missing-queryFn warning when `useRecords`, `usePrimaryName`, and `usePrimaryNames` are called in a disabled state. Extracted a shared `DISABLED_QUERY` constant that uses `skipToken` as `queryFn`.

--- a/packages/ensnode-react/src/hooks/usePrimaryName.ts
+++ b/packages/ensnode-react/src/hooks/usePrimaryName.ts
@@ -3,7 +3,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import type { UsePrimaryNameParameters, WithEnsNodeProviderOptions } from "../types";
-import { createPrimaryNameQueryOptions } from "../utils/query";
+import { createPrimaryNameQueryOptions, DISABLED_QUERY } from "../utils/query";
 import { useEnsNodeProviderOptions } from "./useEnsNodeProviderOptions";
 
 /**
@@ -46,11 +46,11 @@ export function usePrimaryName(parameters: UsePrimaryNameParameters & WithEnsNod
 
   const queryOptions = canEnable
     ? createPrimaryNameQueryOptions(providerOptions, { ...args, address })
-    : { enabled: false, queryKey: ["disabled"] as const };
+    : DISABLED_QUERY;
 
   return useQuery({
     ...queryOptions,
     ...query,
-    enabled: canEnable && (query.enabled ?? queryOptions.enabled),
+    enabled: canEnable && (query.enabled ?? true),
   });
 }

--- a/packages/ensnode-react/src/hooks/usePrimaryNames.ts
+++ b/packages/ensnode-react/src/hooks/usePrimaryNames.ts
@@ -3,7 +3,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import type { UsePrimaryNamesParameters, WithEnsNodeProviderOptions } from "../types";
-import { createPrimaryNamesQueryOptions } from "../utils/query";
+import { createPrimaryNamesQueryOptions, DISABLED_QUERY } from "../utils/query";
 import { useEnsNodeProviderOptions } from "./useEnsNodeProviderOptions";
 
 /**
@@ -50,11 +50,11 @@ export function usePrimaryNames(
 
   const queryOptions = canEnable
     ? createPrimaryNamesQueryOptions(providerOptions, { ...args, address })
-    : { enabled: false, queryKey: ["disabled"] as const };
+    : DISABLED_QUERY;
 
   return useQuery({
     ...queryOptions,
     ...query,
-    enabled: canEnable && (query.enabled ?? queryOptions.enabled),
+    enabled: canEnable && (query.enabled ?? true),
   });
 }

--- a/packages/ensnode-react/src/hooks/useRecords.ts
+++ b/packages/ensnode-react/src/hooks/useRecords.ts
@@ -5,7 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 import type { ResolverRecordsSelection } from "@ensnode/ensnode-sdk";
 
 import type { UseRecordsParameters, WithEnsNodeProviderOptions } from "../types";
-import { createRecordsQueryOptions } from "../utils/query";
+import { createRecordsQueryOptions, DISABLED_QUERY } from "../utils/query";
 import { useEnsNodeProviderOptions } from "./useEnsNodeProviderOptions";
 
 /**
@@ -60,11 +60,11 @@ export function useRecords<SELECTION extends ResolverRecordsSelection>(
 
   const queryOptions = canEnable
     ? createRecordsQueryOptions(_config, { ...args, name })
-    : { enabled: false, queryKey: ["disabled"] as const };
+    : DISABLED_QUERY;
 
   return useQuery({
     ...queryOptions,
     ...query,
-    enabled: canEnable && (query.enabled ?? queryOptions.enabled),
+    enabled: canEnable && (query.enabled ?? true),
   });
 }

--- a/packages/ensnode-react/src/utils/query.ts
+++ b/packages/ensnode-react/src/utils/query.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import type { UndefinedInitialDataOptions } from "@tanstack/react-query";
+import { skipToken, type UndefinedInitialDataOptions } from "@tanstack/react-query";
 
 import {
   EnsNodeClient,
@@ -36,6 +36,15 @@ export const ASSUME_IMMUTABLE_QUERY = {
   refetchOnReconnect: false,
   refetchOnMount: false,
 } as const satisfies Partial<UndefinedInitialDataOptions>;
+
+/**
+ * Query options that disable a useQuery call. Uses `skipToken` so tanstack-query
+ * does not warn about a missing `queryFn`.
+ */
+export const DISABLED_QUERY = {
+  queryKey: ["disabled"] as const,
+  queryFn: skipToken,
+} as const;
 
 /**
  * Query keys for hooks. Simply keys by path and arguments.


### PR DESCRIPTION
## Summary

- fix tanstack-query missing-queryFn warning emitted by `useRecords`, `usePrimaryName`, and `usePrimaryNames` when their required input is `null`
- extract shared `DISABLED_QUERY` const in `packages/ensnode-react/src/utils/query.ts` that uses `skipToken` as `queryFn`
- drop the redundant `enabled: false` from the disabled branch (the final `enabled: canEnable && (...)` short-circuits anyway, and `skipToken` independently halts execution)

## Why

opening the records inspector in ensadmin without a `?name=` query param surfaced the warning below in the console, since the hook builds a `useQuery` config without a `queryFn` on the disabled branch:

> [["disabled"]]: No queryFn was passed as an option, and no default queryFn was found.

`skipToken` is tanstack-query v5's canonical way to express "skip this query" without tripping the missing-queryFn check.

## Testing

- `pnpm -F @ensnode/ensnode-react typecheck`
- `pnpm -F ensadmin typecheck`
- `pnpm lint`
- did not boot the ensadmin dev server to visually confirm — the warning is emitted from a clearly identified code path and the fix is mechanical

## Notes for Reviewer (Optional)

- changeset is a patch bump on `@ensnode/ensnode-react`

## Checklist

- [x] This PR does **not** change runtime behavior or semantics
- [x] This PR is low-risk and safe to review quickly