### PR TITLE
hotfix: promote Queued chains past omnichain cursor on crash recovery

### DIFF
--- a/.changeset/fix-crash-recovery-queued-chain-promotion.md
+++ b/.changeset/fix-crash-recovery-queued-chain-promotion.md
@@ -1,0 +1,5 @@
+---
+"ensindexer": patch
+---
+
+ENSIndexer: fix crash on startup after crash recovery when one or more chains were in Queued status pre-crash. The omnichain status snapshot builder now promotes such chains to Backfill once other chains' progress has advanced past their `startBlock` timestamp, instead of failing the `omnichainIndexingCursor < earliestQueuedStartBlock` invariant.

--- a/apps/ensindexer/src/lib/indexing-status-builder/indexing-status-builder.test.ts
+++ b/apps/ensindexer/src/lib/indexing-status-builder/indexing-status-builder.test.ts
@@ -613,6 +613,187 @@ describe("IndexingStatusBuilder", () => {
     });
   });
 
+  describe("Crash recovery handling", () => {
+    it("promotes a Queued chain to Backfill when other chains' progress has advanced past its startBlock", async () => {
+      // Arrange — simulate post-crash-recovery snapshot:
+      // - Chain A: was actively backfilling pre-crash; checkpoint is ahead of startBlock.
+      // - Chain B: was Queued pre-crash (cursor hadn't reached its startBlock yet),
+      //   so its checkpoint == startBlock. But Chain A's checkpoint timestamp now
+      //   exceeds Chain B's startBlock timestamp, so Chain B is no longer Queued —
+      //   Ponder just hasn't bumped its per-chain checkpoint because no events on
+      //   Chain B have been processed yet.
+      const chainA = 1;
+      const chainB = 10;
+
+      const publicClientMock = buildPublicClientMock();
+
+      const localMetrics = buildLocalChainsIndexingMetrics(
+        new Map([
+          [
+            chainA,
+            {
+              state: ChainIndexingStates.Historical,
+              latestSyncedBlock: laterBlockRef,
+              historicalTotalBlocks: 100,
+              backfillEndBlock: latestBlockRef.number,
+            } satisfies LocalChainIndexingMetricsHistorical,
+          ],
+          [
+            chainB,
+            {
+              state: ChainIndexingStates.Historical,
+              latestSyncedBlock: earlierBlockRef,
+              historicalTotalBlocks: 100,
+              backfillEndBlock: latestBlockRef.number,
+            } satisfies LocalChainIndexingMetricsHistorical,
+          ],
+        ]),
+      );
+
+      const localStatus: PonderIndexingStatus = {
+        chains: new Map([
+          [chainA, { checkpointBlock: laterBlockRef }],
+          [chainB, { checkpointBlock: earlierBlockRef }], // == Chain B's startBlock
+        ]),
+      };
+
+      const localPonderClientMock = buildLocalPonderClientMock({
+        metrics: vi.fn().mockResolvedValue(localMetrics),
+        status: vi.fn().mockResolvedValue(localStatus),
+        getIndexedBlockrange: vi.fn((id: number) => {
+          if (id === chainA) return buildBlockNumberRange(earliestBlockRef.number, undefined);
+          if (id === chainB) return buildBlockNumberRange(earlierBlockRef.number, undefined);
+          throw new Error(`Unexpected chain ID ${id}`);
+        }),
+        getCachedPublicClient: vi.fn().mockReturnValue(publicClientMock),
+      });
+
+      const builder = new IndexingStatusBuilder(localPonderClientMock as LocalPonderClient);
+
+      // Act
+      const result = await builder.getOmnichainIndexingStatusSnapshot();
+
+      // Assert — Chain B is promoted from Queued to Backfill with a degenerate
+      // `latestIndexedBlock = startBlock`, and the snapshot validates as Backfill.
+      expect(result).toStrictEqual({
+        omnichainStatus: OmnichainIndexingStatusIds.Backfill,
+        chains: new Map([
+          [
+            chainA,
+            {
+              chainStatus: ChainIndexingStatusIds.Backfill,
+              latestIndexedBlock: laterBlockRef,
+              backfillEndBlock: latestBlockRef,
+              config: {
+                rangeType: RangeTypeIds.LeftBounded,
+                startBlock: earliestBlockRef,
+              },
+            } satisfies ChainIndexingStatusSnapshotBackfill,
+          ],
+          [
+            chainB,
+            {
+              chainStatus: ChainIndexingStatusIds.Backfill,
+              latestIndexedBlock: earlierBlockRef, // == Chain B's startBlock
+              backfillEndBlock: latestBlockRef,
+              config: {
+                rangeType: RangeTypeIds.LeftBounded,
+                startBlock: earlierBlockRef,
+              },
+            } satisfies ChainIndexingStatusSnapshotBackfill,
+          ],
+        ]),
+        omnichainIndexingCursor: laterBlockRef.timestamp,
+      } satisfies OmnichainIndexingStatusSnapshot);
+    });
+
+    it("leaves a Queued chain alone when the omnichain cursor has not reached its startBlock", async () => {
+      // Arrange — the inverse case: Chain B's startBlock is in the future
+      // relative to Chain A's progress, so it is genuinely Queued.
+      const chainA = 1;
+      const chainB = 10;
+
+      const publicClientMock = buildPublicClientMock();
+
+      const localMetrics = buildLocalChainsIndexingMetrics(
+        new Map([
+          [
+            chainA,
+            {
+              state: ChainIndexingStates.Historical,
+              latestSyncedBlock: earlierBlockRef,
+              historicalTotalBlocks: 100,
+              backfillEndBlock: latestBlockRef.number,
+            } satisfies LocalChainIndexingMetricsHistorical,
+          ],
+          [
+            chainB,
+            {
+              state: ChainIndexingStates.Historical,
+              latestSyncedBlock: laterBlockRef,
+              historicalTotalBlocks: 100,
+              backfillEndBlock: latestBlockRef.number,
+            } satisfies LocalChainIndexingMetricsHistorical,
+          ],
+        ]),
+      );
+
+      const localStatus: PonderIndexingStatus = {
+        chains: new Map([
+          [chainA, { checkpointBlock: earlierBlockRef }],
+          [chainB, { checkpointBlock: laterBlockRef }], // == Chain B's startBlock
+        ]),
+      };
+
+      const localPonderClientMock = buildLocalPonderClientMock({
+        metrics: vi.fn().mockResolvedValue(localMetrics),
+        status: vi.fn().mockResolvedValue(localStatus),
+        getIndexedBlockrange: vi.fn((id: number) => {
+          if (id === chainA) return buildBlockNumberRange(earliestBlockRef.number, undefined);
+          if (id === chainB) return buildBlockNumberRange(laterBlockRef.number, undefined);
+          throw new Error(`Unexpected chain ID ${id}`);
+        }),
+        getCachedPublicClient: vi.fn().mockReturnValue(publicClientMock),
+      });
+
+      const builder = new IndexingStatusBuilder(localPonderClientMock as LocalPonderClient);
+
+      // Act
+      const result = await builder.getOmnichainIndexingStatusSnapshot();
+
+      // Assert — Chain B stays Queued because Chain A's cursor is at earlierBlockRef.ts,
+      // which is < Chain B's startBlock.ts (laterBlockRef.ts).
+      expect(result).toStrictEqual({
+        omnichainStatus: OmnichainIndexingStatusIds.Backfill,
+        chains: new Map([
+          [
+            chainA,
+            {
+              chainStatus: ChainIndexingStatusIds.Backfill,
+              latestIndexedBlock: earlierBlockRef,
+              backfillEndBlock: latestBlockRef,
+              config: {
+                rangeType: RangeTypeIds.LeftBounded,
+                startBlock: earliestBlockRef,
+              },
+            } satisfies ChainIndexingStatusSnapshotBackfill,
+          ],
+          [
+            chainB,
+            {
+              chainStatus: ChainIndexingStatusIds.Queued,
+              config: {
+                rangeType: RangeTypeIds.LeftBounded,
+                startBlock: laterBlockRef,
+              },
+            } satisfies ChainIndexingStatusSnapshotQueued,
+          ],
+        ]),
+        omnichainIndexingCursor: earlierBlockRef.timestamp,
+      } satisfies OmnichainIndexingStatusSnapshot);
+    });
+  });
+
   describe("Error handling", () => {
     it("throws when indexing status is missing for a chain", async () => {
       // Arrange

--- a/apps/ensindexer/src/lib/indexing-status-builder/indexing-status-builder.test.ts
+++ b/apps/ensindexer/src/lib/indexing-status-builder/indexing-status-builder.test.ts
@@ -707,6 +707,97 @@ describe("IndexingStatusBuilder", () => {
       } satisfies OmnichainIndexingStatusSnapshot);
     });
 
+    it("promotes a Queued chain when its startBlock.ts equals the omnichain cursor", async () => {
+      // Arrange — boundary case: the Queued chain's `startBlock.timestamp`
+      // equals the max `latestIndexedBlock.timestamp` across non-Queued chains.
+      // The SDK invariant requires `cursor < earliestQueuedStartBlock` (strict),
+      // so leaving the chain Queued would still violate the invariant. Validate
+      // that the chain is promoted at equality, not just strict inequality.
+      const chainA = 1;
+      const chainB = 10;
+
+      const publicClientMock = buildPublicClientMock();
+
+      const localMetrics = buildLocalChainsIndexingMetrics(
+        new Map([
+          [
+            chainA,
+            {
+              state: ChainIndexingStates.Historical,
+              latestSyncedBlock: laterBlockRef,
+              historicalTotalBlocks: 100,
+              backfillEndBlock: latestBlockRef.number,
+            } satisfies LocalChainIndexingMetricsHistorical,
+          ],
+          [
+            chainB,
+            {
+              state: ChainIndexingStates.Historical,
+              latestSyncedBlock: laterBlockRef,
+              historicalTotalBlocks: 100,
+              backfillEndBlock: latestBlockRef.number,
+            } satisfies LocalChainIndexingMetricsHistorical,
+          ],
+        ]),
+      );
+
+      const localStatus: PonderIndexingStatus = {
+        chains: new Map([
+          [chainA, { checkpointBlock: laterBlockRef }],
+          [chainB, { checkpointBlock: laterBlockRef }], // == Chain B's startBlock
+        ]),
+      };
+
+      const localPonderClientMock = buildLocalPonderClientMock({
+        metrics: vi.fn().mockResolvedValue(localMetrics),
+        status: vi.fn().mockResolvedValue(localStatus),
+        getIndexedBlockrange: vi.fn((id: number) => {
+          if (id === chainA) return buildBlockNumberRange(earliestBlockRef.number, undefined);
+          if (id === chainB) return buildBlockNumberRange(laterBlockRef.number, undefined);
+          throw new Error(`Unexpected chain ID ${id}`);
+        }),
+        getCachedPublicClient: vi.fn().mockReturnValue(publicClientMock),
+      });
+
+      const builder = new IndexingStatusBuilder(localPonderClientMock as LocalPonderClient);
+
+      // Act
+      const result = await builder.getOmnichainIndexingStatusSnapshot();
+
+      // Assert — Chain B is promoted, snapshot validates as Backfill with
+      // omnichainIndexingCursor == Chain B's startBlock.ts.
+      expect(result).toStrictEqual({
+        omnichainStatus: OmnichainIndexingStatusIds.Backfill,
+        chains: new Map([
+          [
+            chainA,
+            {
+              chainStatus: ChainIndexingStatusIds.Backfill,
+              latestIndexedBlock: laterBlockRef,
+              backfillEndBlock: latestBlockRef,
+              config: {
+                rangeType: RangeTypeIds.LeftBounded,
+                startBlock: earliestBlockRef,
+              },
+            } satisfies ChainIndexingStatusSnapshotBackfill,
+          ],
+          [
+            chainB,
+            {
+              chainStatus: ChainIndexingStatusIds.Backfill,
+              latestIndexedBlock: laterBlockRef, // == Chain B's startBlock
+              backfillEndBlock: latestBlockRef,
+              config: {
+                rangeType: RangeTypeIds.LeftBounded,
+                startBlock: laterBlockRef,
+              },
+            } satisfies ChainIndexingStatusSnapshotBackfill,
+          ],
+        ]),
+        omnichainIndexingCursor: laterBlockRef.timestamp,
+      } satisfies OmnichainIndexingStatusSnapshot);
+    });
+
     it("leaves a Queued chain alone when the omnichain cursor has not reached its startBlock", async () => {
       // Arrange — the inverse case: Chain B's startBlock is in the future
       // relative to Chain A's progress, so it is genuinely Queued.

--- a/apps/ensindexer/src/lib/indexing-status-builder/indexing-status-builder.ts
+++ b/apps/ensindexer/src/lib/indexing-status-builder/indexing-status-builder.ts
@@ -161,7 +161,10 @@ export class IndexingStatusBuilder {
 
     for (const [chainId, snapshot] of chainStatusSnapshots.entries()) {
       if (snapshot.chainStatus !== ChainIndexingStatusIds.Queued) continue;
-      if (snapshot.config.startBlock.timestamp >= maxAdvancedTimestamp) continue;
+      // Strict `>`: the SDK invariant requires `cursor < earliestQueuedStartBlock`,
+      // so a chain whose `startBlock.timestamp` equals the cursor must also be
+      // promoted to keep the snapshot valid.
+      if (snapshot.config.startBlock.timestamp > maxAdvancedTimestamp) continue;
 
       const chainConfig = chainsIndexingConfig.get(chainId);
       const chainMetric = chainIndexingMetrics.get(chainId);

--- a/apps/ensindexer/src/lib/indexing-status-builder/indexing-status-builder.ts
+++ b/apps/ensindexer/src/lib/indexing-status-builder/indexing-status-builder.ts
@@ -124,7 +124,65 @@ export class IndexingStatusBuilder {
       }
     }
 
+    // After crash recovery, a chain that was Queued in the prior run can still
+    // have `checkpointBlock == startBlock` even though the omnichain cursor
+    // (derived from other chains' progress) has advanced past its
+    // `startBlock.timestamp`. The chain is no longer omnichain-queued: Ponder's
+    // per-chain checkpoint just hasn't been bumped yet because no events on
+    // this chain have been processed. Promote it to a degenerate Backfill
+    // snapshot (`latestIndexedBlock = startBlock`) so the snapshot's invariants
+    // hold until Ponder's per-chain checkpoint catches up.
+    this.promoteQueuedChainsPastOmnichainCursor(
+      chainStatusSnapshots,
+      chainIndexingMetrics,
+      chainsIndexingConfig,
+    );
+
     return chainStatusSnapshots;
+  }
+
+  /**
+   * In-place promotion of {@link ChainIndexingStatusIds.Queued} chains to
+   * {@link ChainIndexingStatusIds.Backfill} when the omnichain cursor has
+   * advanced past their startBlock. See call site for full rationale.
+   */
+  private promoteQueuedChainsPastOmnichainCursor(
+    chainStatusSnapshots: Map<ChainId, ChainIndexingStatusSnapshot>,
+    chainIndexingMetrics: Map<ChainId, LocalChainIndexingMetrics>,
+    chainsIndexingConfig: Map<ChainId, ChainIndexingConfig>,
+  ): void {
+    const advancedTimestamps = Array.from(chainStatusSnapshots.values())
+      .filter((s) => s.chainStatus !== ChainIndexingStatusIds.Queued)
+      .map((s) => s.latestIndexedBlock.timestamp);
+
+    if (advancedTimestamps.length === 0) return;
+
+    const maxAdvancedTimestamp = Math.max(...advancedTimestamps);
+
+    for (const [chainId, snapshot] of chainStatusSnapshots.entries()) {
+      if (snapshot.chainStatus !== ChainIndexingStatusIds.Queued) continue;
+      if (snapshot.config.startBlock.timestamp >= maxAdvancedTimestamp) continue;
+
+      const chainConfig = chainsIndexingConfig.get(chainId);
+      const chainMetric = chainIndexingMetrics.get(chainId);
+
+      // backfillEndBlock is only populated when Ponder reports historical state;
+      // if it's missing we lack the data to construct a valid Backfill snapshot,
+      // so leave the chain as Queued.
+      if (chainMetric?.state !== ChainIndexingStates.Historical || !chainConfig?.backfillEndBlock) {
+        continue;
+      }
+
+      chainStatusSnapshots.set(
+        chainId,
+        validateChainIndexingStatusSnapshot({
+          chainStatus: ChainIndexingStatusIds.Backfill,
+          latestIndexedBlock: snapshot.config.startBlock,
+          backfillEndBlock: chainConfig.backfillEndBlock as Unvalidated<BlockRef>,
+          config: snapshot.config as Unvalidated<BlockRefRangeWithStartBlock>,
+        } satisfies Unvalidated<ChainIndexingStatusSnapshotBackfill>),
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

After crash recovery, a chain that was omnichain-Queued in the prior run still has its Ponder per-chain checkpoint at `startBlock` until its first event is processed in the new run. Meanwhile, other chains' per-chain checkpoints persist past that chain's `startBlock.timestamp`. The snapshot builder classified such chains as Queued purely on `checkpoint == startBlock`, which then violated the `omnichainIndexingCursor < earliestQueuedStartBlock` invariant and crashed the indexer on every restart.

Observed on alpha green (config: subgraph + ensv2 + 4 other plugins, mainnet namespace, 6 indexed chains). Before this fix the indexer was looping through:
1. Start → crash recovery → snapshot validation fails → exit code 1.
2. Same checkpoint state on next start → same failure.

Confirmed via `_ponder_checkpoint`: chains 42161 and 534352 were pinned exactly at their startBlocks (tx/event index columns all zero) while chains 1, 10, 8453, 59144 had advanced well past those `startBlock.timestamp`s.

## Fix

`buildChainIndexingStatusSnapshots` now does a second pass after per-chain classification. Any chain that:
- is currently classified Queued,
- has Ponder state = Historical (so a `backfillEndBlock` is available),
- and whose `startBlock.timestamp` is **below** the max `latestIndexedBlock.timestamp` among non-Queued chains,

is promoted to a degenerate Backfill snapshot (`latestIndexedBlock = startBlock`). The omnichain snapshot invariants then hold until Ponder's per-chain checkpoint catches up naturally as the chain processes its first event.

Fresh-run behavior is unchanged: when no chain has advanced yet, the second pass is a no-op. When some chains have advanced but the cursor hasn't reached a queued chain's startBlock, that chain stays Queued.

## Test plan

- [x] New unit test: 2-chain crash-recovery scenario — Queued chain whose startBlock.ts is behind the other chain's progress is promoted to Backfill and the omnichain snapshot validates as Backfill.
- [x] New unit test: 2-chain inverse — Queued chain whose startBlock.ts is *ahead* of other chains stays Queued.
- [x] `pnpm -F ensindexer typecheck`
- [x] `pnpm test --project ensindexer` (220/220 passing)
- [x] `pnpm lint`
- [ ] Deploy to alpha green and confirm the indexer can complete crash recovery without crashing on the snapshot invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)