### PR TITLE
Update examples export to be published to NPM

### DIFF
--- a/apps/ensadmin/src/app/api/omnigraph/page.tsx
+++ b/apps/ensadmin/src/app/api/omnigraph/page.tsx
@@ -3,8 +3,7 @@
 import { useSearchParams } from "next/navigation";
 import { useMemo } from "react";
 
-import { getNamespaceSpecificValue } from "@ensnode/ensnode-sdk";
-import { GRAPHQL_API_EXAMPLE_QUERIES } from "@ensnode/ensnode-sdk/internal";
+import { GRAPHQL_API_EXAMPLE_QUERIES, getNamespaceSpecificValue } from "@ensnode/ensnode-sdk";
 
 import { GraphiQLEditor } from "@/components/graphiql-editor";
 import { RequireENSAdminFeature } from "@/components/require-ensadmin-feature";

--- a/packages/ensnode-sdk/src/index.ts
+++ b/packages/ensnode-sdk/src/index.ts
@@ -11,7 +11,7 @@ export * from "./ensnode";
 export * from "./ensrainbow";
 export * from "./identity";
 export * from "./indexing-status";
-export * from "./omnigraph-api/prerequisites";
+export * from "./omnigraph-api";
 export * from "./registrars";
 export * from "./resolution";
 export * from "./shared/account-id";

--- a/packages/ensnode-sdk/src/omnigraph-api/index.ts
+++ b/packages/ensnode-sdk/src/omnigraph-api/index.ts
@@ -1,0 +1,2 @@
+export * from "./example-queries";
+export * from "./prerequisites";


### PR DESCRIPTION
# Lite PR

[Tip: Review docs on the ENSNode PR process](https://ensnode.io/docs/contributing/prs)

## Summary

- Update ENSNode SDK to include `GRAPHQL_API_EXAMPLE_QUERIES`.

---

## Why

- We need ENSAdmin to import a specific version of ENSNode SDK in order to support change management. The production ENSApi version might be incompatible with the latest Omnigraph API examples present in ENSNode SDK. Therefore, we need to control the package version from which we import the examples so the users can use examples without issues.

---

## Testing

- How this was tested.
- If you didn't test it, say why.

---

## Notes for Reviewer (Optional)

- Based on commit sha `89c022b`

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)
