### PR TITLE
feat: expand Domain.canonical.name and Domain.resolver

### DIFF
--- a/.changeset/assigned-resolver-rename.md
+++ b/.changeset/assigned-resolver-rename.md
@@ -2,4 +2,6 @@
 "ensapi": minor
 ---
 
-**Omnigraph (breaking)**: Renamed `Domain.resolver` to `Domain.assignedResolver` for clarity. The field's semantics are unchanged — it remains the Domain's _assigned_ Resolver, not its _effective_ Resolver.
+**Omnigraph (breaking)**: `Domain.resolver` is now a non-null `DomainResolver` wrapper exposing `Domain.resolver.assigned: Resolver` (replacing the previous flat `Domain.resolver: Resolver`). The wrapper leaves room for future fields (e.g. `effective`) describing the Domain's resolution graph. Semantics of `assigned` are unchanged — it remains the Domain's _assigned_ Resolver, not its _effective_ Resolver.
+
+**Omnigraph (breaking)**: `DomainCanonical.name` is now a non-null `CanonicalName` wrapper exposing `DomainCanonical.name.interpreted: InterpretedName` (replacing the previous flat `DomainCanonical.name: InterpretedName`). The wrapper leaves room for additional representations (e.g. a future `beautified` field).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,8 +86,11 @@ Fail fast and loudly on invalid inputs.
 
 - Add a changeset when your PR includes a logical change that should bump versions or be communicated in release notes: https://ensnode.io/docs/contributing/prs#changesets
 - Before declaring work complete, run validation in the affected project(s):
-  1. If OpenAPI Specs were affected, run `pnpm generate:openapi`
-  2. If the Omnigraph GraphQL Schema was affected, run `pnpm generate:gqlschema`
-  3. `pnpm -F <affected-project> typecheck`
-  4. `pnpm lint`
-  5. `pnpm test --project <affected-project> [--project <other-affected-project>]`
+  1. If OpenAPI Defs or the Omnigraph GraphQL Schema was affected, run `pnpm generate`
+    - always run `pnpm generate` from the monorepo root, do NOT scope to a specific package
+  2. `pnpm -F <affected-project> typecheck`
+    - at the end of a work session, always run `pnpm typecheck` from the monorepo root
+  3. `pnpm lint`
+    - at the end of a work session, always run `pnpm lint` from the monorepo root
+  4. `pnpm test --project <affected-project> [--project <other-affected-project>]`
+    - at the end of a work session, always run `pnpm test` from the monorepo root

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ An indexer aggregates and reorganizes the representation of ENS's state to make 
 query Domains($adress: String!) {
   domains(where: { owner: $address }) {
     id
-    canonical { name }
+    name
     ...
   }
 }

--- a/apps/ensapi/src/omnigraph-api/schema/account.integration.test.ts
+++ b/apps/ensapi/src/omnigraph-api/schema/account.integration.test.ts
@@ -27,7 +27,7 @@ describe("Account.domains", () => {
     account: {
       domains: GraphQLConnection<{
         __typename: "ENSv1Domain" | "ENSv2Domain";
-        canonical: { name: InterpretedName } | null;
+        canonical: { name: { interpreted: InterpretedName } } | null;
       }>;
     };
   };
@@ -39,7 +39,7 @@ describe("Account.domains", () => {
           where: { version: $version },
           order: { by: NAME, dir: ASC }
         ) {
-          edges { node { __typename, canonical { name } } }
+          edges { node { __typename, canonical { name { interpreted } } } }
         }
       }
     }
@@ -50,7 +50,7 @@ describe("Account.domains", () => {
       address: accounts.owner.address,
     });
     const domains = flattenConnection(result.account.domains);
-    const names = domains.map((d) => d.canonical?.name);
+    const names = domains.map((d) => d.canonical?.name.interpreted);
 
     const expected = [
       "alias.eth",
@@ -77,7 +77,7 @@ describe("Account.domains", () => {
       address: accounts.user.address,
     });
     const domains = flattenConnection(result.account.domains);
-    const names = domains.map((d) => d.canonical?.name);
+    const names = domains.map((d) => d.canonical?.name.interpreted);
 
     expect(names, "expected 'newowner.eth' in new owner's domains").toContain("newowner.eth");
   });

--- a/apps/ensapi/src/omnigraph-api/schema/canonical-name.ts
+++ b/apps/ensapi/src/omnigraph-api/schema/canonical-name.ts
@@ -11,7 +11,7 @@ CanonicalNameRef.implement({
   fields: (t) => ({
     interpreted: t.field({
       description:
-        "The Canonical Name as an InterpretedName: each label is either a normalized literal Label or an Encoded LabelHash. Suitable for navigation, lookup, and as a stable identifier.",
+        "The Canonical Name as an InterpretedName: each label is either a normalized literal Label or an Encoded LabelHash.",
       type: "InterpretedName",
       nullable: false,
       resolve: (domain) => {
@@ -20,6 +20,7 @@ CanonicalNameRef.implement({
             `Invariant(CanonicalName.interpreted): canonical Domain '${domain.id}' is missing canonicalName.`,
           );
         }
+
         return domain.canonicalName;
       },
     }),

--- a/apps/ensapi/src/omnigraph-api/schema/canonical-name.ts
+++ b/apps/ensapi/src/omnigraph-api/schema/canonical-name.ts
@@ -1,0 +1,27 @@
+import { builder } from "@/omnigraph-api/builder";
+import type { Domain } from "@/omnigraph-api/schema/domain";
+
+////////////////////////////////
+// CanonicalName
+////////////////////////////////
+export const CanonicalNameRef = builder.objectRef<Domain>("CanonicalName");
+
+CanonicalNameRef.implement({
+  description: "A Canonical Name, exposed in each representation we support.",
+  fields: (t) => ({
+    interpreted: t.field({
+      description:
+        "The Canonical Name as an InterpretedName: each label is either a normalized literal Label or an Encoded LabelHash. Suitable for navigation, lookup, and as a stable identifier.",
+      type: "InterpretedName",
+      nullable: false,
+      resolve: (domain) => {
+        if (!domain.canonicalName) {
+          throw new Error(
+            `Invariant(CanonicalName.interpreted): canonical Domain '${domain.id}' is missing canonicalName.`,
+          );
+        }
+        return domain.canonicalName;
+      },
+    }),
+  }),
+});

--- a/apps/ensapi/src/omnigraph-api/schema/domain-canonical.ts
+++ b/apps/ensapi/src/omnigraph-api/schema/domain-canonical.ts
@@ -12,7 +12,7 @@ DomainCanonicalRef.implement({
     "Canonicality metadata for a Domain, including its name, depth, path, and node (namehash).",
   fields: (t) => ({
     name: t.field({
-      description: "The Canonical Name for this Domain, in multiple representations.",
+      description: "The Canonical Name for this Domain.",
       type: CanonicalNameRef,
       nullable: false,
       resolve: (domain) => domain,

--- a/apps/ensapi/src/omnigraph-api/schema/domain-canonical.ts
+++ b/apps/ensapi/src/omnigraph-api/schema/domain-canonical.ts
@@ -1,4 +1,5 @@
 import { builder } from "@/omnigraph-api/builder";
+import { CanonicalNameRef } from "@/omnigraph-api/schema/canonical-name";
 import { type Domain, DomainInterfaceRef } from "@/omnigraph-api/schema/domain";
 
 ////////////////////////////////
@@ -11,18 +12,10 @@ DomainCanonicalRef.implement({
     "Canonicality metadata for a Domain, including its name, depth, path, and node (namehash).",
   fields: (t) => ({
     name: t.field({
-      description: "The Canonical Name for this Domain.",
-      type: "InterpretedName",
+      description: "The Canonical Name for this Domain, in multiple representations.",
+      type: CanonicalNameRef,
       nullable: false,
-      resolve: (domain) => {
-        if (!domain.canonicalName) {
-          throw new Error(
-            `Invariant(DomainCanonical.name): canonical Domain '${domain.id}' is missing canonicalName.`,
-          );
-        }
-
-        return domain.canonicalName;
-      },
+      resolve: (domain) => domain,
     }),
     depth: t.field({
       description:
@@ -35,6 +28,7 @@ DomainCanonicalRef.implement({
             `Invariant(DomainCanonical.depth): canonical Domain '${domain.id}' is missing canonicalDepth.`,
           );
         }
+
         return domain.canonicalDepth;
       },
     }),
@@ -49,6 +43,7 @@ DomainCanonicalRef.implement({
             `Invariant(DomainCanonical.path): canonical Domain '${domain.id}' is missing canonicalPath.`,
           );
         }
+
         return domain.canonicalPath;
       },
     }),

--- a/apps/ensapi/src/omnigraph-api/schema/domain-resolver.ts
+++ b/apps/ensapi/src/omnigraph-api/schema/domain-resolver.ts
@@ -1,0 +1,26 @@
+import type { DomainId } from "enssdk";
+
+import { builder } from "@/omnigraph-api/builder";
+import { getDomainResolver } from "@/omnigraph-api/lib/get-domain-resolver";
+import { ResolverRef } from "@/omnigraph-api/schema/resolver";
+
+////////////////////////////////
+// DomainResolver
+////////////////////////////////
+export const DomainResolverRef = builder.objectRef<DomainId>("DomainResolver");
+
+DomainResolverRef.implement({
+  description: "Metadata describing this Domain's relationship to its Resolver(s).",
+  fields: (t) => ({
+    ////////////////////////////
+    // DomainResolver.assigned
+    ////////////////////////////
+    assigned: t.field({
+      description:
+        "The Resolver that this Domain has assigned, if any. NOTE that this is the Domain's _assigned_ Resolver, _not_ its _effective_ Resolver, which can only be determined by following ENS Forward Resolution and ENSIP-10. Do NOT use this Domain-Resolver relationship in isolation to resolve records, that operation is NOT ENS Forward Resolution.",
+      type: ResolverRef,
+      nullable: true,
+      resolve: (domainId) => getDomainResolver(domainId),
+    }),
+  }),
+});

--- a/apps/ensapi/src/omnigraph-api/schema/domain.integration.test.ts
+++ b/apps/ensapi/src/omnigraph-api/schema/domain.integration.test.ts
@@ -72,7 +72,7 @@ describe("Domain.canonical", () => {
     domain: {
       id: DomainId;
       canonical: {
-        name: InterpretedName;
+        name: { interpreted: InterpretedName };
         depth: number;
         node: string;
         path: { id: DomainId }[];
@@ -82,13 +82,13 @@ describe("Domain.canonical", () => {
 
   const DomainCanonicalByName = gql`
     query DomainCanonicalByName($name: InterpretedName!) {
-      domain(by: { name: $name }) { id canonical { name depth node path { id } } }
+      domain(by: { name: $name }) { id canonical { name { interpreted } depth node path { id } } }
     }
   `;
 
   const DomainCanonicalById = gql`
     query DomainCanonicalById($id: DomainId!) {
-      domain(by: { id: $id }) { id canonical { name depth node path { id } } }
+      domain(by: { id: $id }) { id canonical { name { interpreted } depth node path { id } } }
     }
   `;
 
@@ -98,7 +98,7 @@ describe("Domain.canonical", () => {
       const result = await request<DomainCanonicalQueryResult>(DomainCanonicalByName, { name });
       const labelCount = canonical.split(".").length;
       expect(result).toMatchObject({
-        domain: { canonical: { name: canonical, depth: labelCount } },
+        domain: { canonical: { name: { interpreted: canonical }, depth: labelCount } },
       });
       expect(result.domain!.canonical!.path.length).toBe(labelCount);
     },
@@ -116,7 +116,7 @@ describe("Domain.canonical", () => {
     ).resolves.toMatchObject({
       domain: {
         canonical: {
-          name: "wallet.sub1.sub2.parent.eth",
+          name: { interpreted: "wallet.sub1.sub2.parent.eth" },
           path: expect.arrayContaining([{ id: expect.any(String) }]),
         },
       },
@@ -134,7 +134,7 @@ describe("Domain.canonical", () => {
     await expect(
       request<DomainCanonicalQueryResult>(DomainCanonicalById, { id }),
     ).resolves.toMatchObject({
-      domain: { id, canonical: { name: "addr.reverse" } },
+      domain: { id, canonical: { name: { interpreted: "addr.reverse" } } },
     });
   });
 });

--- a/apps/ensapi/src/omnigraph-api/schema/domain.ts
+++ b/apps/ensapi/src/omnigraph-api/schema/domain.ts
@@ -22,7 +22,6 @@ import {
   withOrderingMetadata,
 } from "@/omnigraph-api/lib/find-domains/layers";
 import { resolveFindEvents } from "@/omnigraph-api/lib/find-events/find-events-resolver";
-import { getDomainResolver } from "@/omnigraph-api/lib/get-domain-resolver";
 import { getLatestRegistration } from "@/omnigraph-api/lib/get-latest-registration";
 import { getModelId } from "@/omnigraph-api/lib/get-model-id";
 import { lazyConnection } from "@/omnigraph-api/lib/lazy-connection";
@@ -38,13 +37,13 @@ import {
   DomainsOrderInput,
   SubdomainsWhereInput,
 } from "@/omnigraph-api/schema/domain-inputs";
+import { DomainResolverRef } from "@/omnigraph-api/schema/domain-resolver";
 import { EventRef } from "@/omnigraph-api/schema/event";
 import { EventsWhereInput } from "@/omnigraph-api/schema/event-inputs";
 import { LabelRef } from "@/omnigraph-api/schema/label";
 import { PermissionsUserRef } from "@/omnigraph-api/schema/permissions";
 import { RegistrationInterfaceRef } from "@/omnigraph-api/schema/registration";
 import { RegistryInterfaceRef } from "@/omnigraph-api/schema/registry";
-import { ResolverRef } from "@/omnigraph-api/schema/resolver";
 
 const tracer = trace.getTracer("schema/Domain");
 
@@ -162,15 +161,14 @@ DomainInterfaceRef.implement({
       resolve: (parent) => parent.subregistryId,
     }),
 
-    ///////////////////////////
-    // Domain.assignedResolver
-    ///////////////////////////
-    assignedResolver: t.field({
-      description:
-        "The Resolver that this Domain has assigned, if any. NOTE that this is the Domain's _assigned_ Resolver, _not_ its _effective_ Resolver, which can only be determined by following ENS Forward Resolution and ENSIP-10. Do NOT use this Domain-Resolver relationship in isolation to resolve records, that operation is NOT ENS Forward Resolution.",
-      type: ResolverRef,
-      nullable: true,
-      resolve: (parent) => getDomainResolver(parent.id),
+    ///////////////////
+    // Domain.resolver
+    ///////////////////
+    resolver: t.field({
+      description: "Resolver relationship metadata for this Domain.",
+      type: DomainResolverRef,
+      nullable: false,
+      resolve: (parent) => parent.id,
     }),
 
     ///////////////////////

--- a/apps/ensapi/src/omnigraph-api/schema/permissions.integration.test.ts
+++ b/apps/ensapi/src/omnigraph-api/schema/permissions.integration.test.ts
@@ -309,7 +309,7 @@ describe("Resolver.permissions", () => {
   const ResolverPermissions = gql`
     query ResolverPermissions($name: InterpretedName!) {
       domain(by: { name: $name }) {
-        assignedResolver { permissions { id contract { chainId address } } }
+        resolver { assigned { permissions { id contract { chainId address } } } }
       }
     }
   `;
@@ -317,22 +317,24 @@ describe("Resolver.permissions", () => {
   it("resolves permissions from a resolver", async () => {
     const result = await request<{
       domain: {
-        assignedResolver: {
-          permissions: {
-            id: PermissionsId;
-            contract: AccountId;
+        resolver: {
+          assigned: {
+            permissions: {
+              id: PermissionsId;
+              contract: AccountId;
+            };
           };
         };
       };
     }>(ResolverPermissions, { name: NAME_WITH_RESOLVER });
 
     expect(
-      result.domain.assignedResolver,
+      result.domain.resolver.assigned,
       `expected ${NAME_WITH_RESOLVER} to have a resolver`,
     ).toBeDefined();
-    expect(result.domain.assignedResolver.permissions.id).toBeTruthy();
-    expect(result.domain.assignedResolver.permissions.contract.address).toBeTruthy();
-    expect(result.domain.assignedResolver.permissions.contract.chainId).toBeTruthy();
+    expect(result.domain.resolver.assigned.permissions.id).toBeTruthy();
+    expect(result.domain.resolver.assigned.permissions.contract.address).toBeTruthy();
+    expect(result.domain.resolver.assigned.permissions.contract.chainId).toBeTruthy();
   });
 });
 

--- a/apps/ensapi/src/omnigraph-api/schema/query.integration.test.ts
+++ b/apps/ensapi/src/omnigraph-api/schema/query.integration.test.ts
@@ -83,7 +83,7 @@ describe("Query.domains", () => {
     domains: GraphQLConnection<{
       __typename: "ENSv1Domain" | "ENSv2Domain";
       id: DomainId;
-      canonical: { name: Name } | null;
+      canonical: { name: { interpreted: Name } } | null;
       label: { interpreted: InterpretedLabel };
       owner: { address: NormalizedAddress };
       node?: Node;
@@ -102,7 +102,9 @@ describe("Query.domains", () => {
             __typename
             id
             canonical {
-              name
+              name {
+                interpreted
+              }
             }
             label {
               interpreted
@@ -139,7 +141,7 @@ describe("Query.domains", () => {
       domains.find((d) => d.__typename === "ENSv1Domain" && d.id === V1_ETH_DOMAIN_ID),
     ).toMatchObject({
       id: V1_ETH_DOMAIN_ID,
-      canonical: { name: "eth" },
+      canonical: { name: { interpreted: "eth" } },
       label: { interpreted: "eth" },
       node: ETH_NODE,
     });
@@ -148,7 +150,7 @@ describe("Query.domains", () => {
       domains.find((d) => d.__typename === "ENSv2Domain" && d.id === V2_ETH_DOMAIN_ID),
     ).toMatchObject({
       id: V2_ETH_DOMAIN_ID,
-      canonical: { name: "eth" },
+      canonical: { name: { interpreted: "eth" } },
       label: { interpreted: "eth" },
     });
   });
@@ -160,7 +162,7 @@ describe("Query.domains", () => {
     const domains = flattenConnection(result.domains);
 
     // parent.eth is canonical (registered under the v2 ETH Registry which descends from the v2 Root)
-    const parentEth = domains.find((d) => d.canonical?.name === "parent.eth");
+    const parentEth = domains.find((d) => d.canonical?.name.interpreted === "parent.eth");
     expect(parentEth).toBeDefined();
 
     // every returned domain must be canonical
@@ -220,7 +222,7 @@ describe("Query.domains", () => {
       ).toBeDefined();
 
       // no prefix-matched names like "ethereum" should leak in
-      for (const d of domains) expect(d.canonical?.name).toBe("eth");
+      for (const d of domains) expect(d.canonical?.name.interpreted).toBe("eth");
     });
 
     it("eq + version: ENSv1 returns a single domain", async () => {
@@ -233,7 +235,7 @@ describe("Query.domains", () => {
       expect(domains[0]).toMatchObject({
         __typename: "ENSv1Domain",
         id: V1_ETH_DOMAIN_ID,
-        canonical: { name: "eth" },
+        canonical: { name: { interpreted: "eth" } },
       });
     });
 
@@ -242,10 +244,11 @@ describe("Query.domains", () => {
         name: { in: ["eth", "parent.eth"] },
       });
       const domains = flattenConnection(result.domains);
-      const names = new Set(domains.map((d) => d.canonical?.name));
+      const names = new Set(domains.map((d) => d.canonical?.name.interpreted));
       expect(names.has("eth")).toBe(true);
       expect(names.has("parent.eth")).toBe(true);
-      for (const d of domains) expect(["eth", "parent.eth"]).toContain(d.canonical?.name);
+      for (const d of domains)
+        expect(["eth", "parent.eth"]).toContain(d.canonical?.name.interpreted);
     });
 
     it("in returns empty for an empty set", async () => {
@@ -270,14 +273,14 @@ describe("Query.domain", () => {
   const DomainByName = gql`
     query DomainByName($name: InterpretedName!) {
       domain(by: { name: $name }) {
-        canonical { name }
+        canonical { name { interpreted } }
       }
     }
   `;
 
   it.each(DEVNET_NAMES)("resolves $name", async ({ name, canonical }) => {
     await expect(request(DomainByName, { name })).resolves.toMatchObject({
-      domain: { canonical: { name: canonical } },
+      domain: { canonical: { name: { interpreted: canonical } } },
     });
   });
 

--- a/apps/ensapi/src/omnigraph-api/schema/resolver.integration.test.ts
+++ b/apps/ensapi/src/omnigraph-api/schema/resolver.integration.test.ts
@@ -22,8 +22,10 @@ const DEVNET_NAME_WITH_OWNED_RESOLVER = asInterpretedName("example.eth");
 describe("Resolver.events", () => {
   type ResolverEventsResult = {
     domain: {
-      assignedResolver: {
-        events: GraphQLConnection<EventResult>;
+      resolver: {
+        assigned: {
+          events: GraphQLConnection<EventResult>;
+        };
       };
     };
   };
@@ -31,11 +33,13 @@ describe("Resolver.events", () => {
   const ResolverEvents = gql`
     query ResolverEvents($name: InterpretedName!) {
       domain(by: { name: $name }) {
-        assignedResolver {
-          events {
-            edges {
-              node {
-                ...EventFragment
+        resolver {
+          assigned {
+            events {
+              edges {
+                node {
+                  ...EventFragment
+                }
               }
             }
           }
@@ -51,7 +55,7 @@ describe("Resolver.events", () => {
       name: DEVNET_NAME_WITH_OWNED_RESOLVER,
     });
 
-    const events = flattenConnection(result.domain.assignedResolver.events);
+    const events = flattenConnection(result.domain.resolver.assigned.events);
 
     expect(events.length).toBeGreaterThan(0);
   });
@@ -60,8 +64,8 @@ describe("Resolver.events", () => {
 describe("Resolver.events pagination", () => {
   testEventPagination(async (variables) => {
     const result = await request<{
-      domain: { assignedResolver: { events: PaginatedGraphQLConnection<EventResult> } };
+      domain: { resolver: { assigned: { events: PaginatedGraphQLConnection<EventResult> } } };
     }>(ResolverEventsPaginated, { name: DEVNET_NAME_WITH_OWNED_RESOLVER, ...variables });
-    return result.domain.assignedResolver.events;
+    return result.domain.resolver.assigned.events;
   });
 });

--- a/apps/ensapi/src/test/integration/find-domains/domain-pagination-queries.ts
+++ b/apps/ensapi/src/test/integration/find-domains/domain-pagination-queries.ts
@@ -14,7 +14,7 @@ const PageInfoFragment = gql`
 const PaginatedDomainFragment = gql`
   fragment PaginatedDomainFragment on Domain {
     id
-    canonical { name depth }
+    canonical { name { interpreted } depth }
     registration {
       expiry
       start
@@ -24,7 +24,7 @@ const PaginatedDomainFragment = gql`
 
 export type PaginatedDomainResult = {
   id: DomainId;
-  canonical: { name: InterpretedName; depth: number } | null;
+  canonical: { name: { interpreted: InterpretedName }; depth: number } | null;
   registration: {
     expiry: string | null;
     start: string;

--- a/apps/ensapi/src/test/integration/find-domains/test-domain-pagination.ts
+++ b/apps/ensapi/src/test/integration/find-domains/test-domain-pagination.ts
@@ -41,7 +41,7 @@ function getSortValue(
 ): string | number | null {
   switch (by) {
     case "NAME":
-      return domain.canonical?.name ?? null;
+      return domain.canonical?.name.interpreted ?? null;
     case "DEPTH":
       return domain.canonical?.depth ?? null;
     case "REGISTRATION_TIMESTAMP":

--- a/apps/ensapi/src/test/integration/find-events/event-pagination-queries.ts
+++ b/apps/ensapi/src/test/integration/find-events/event-pagination-queries.ts
@@ -96,10 +96,12 @@ export const ResolverEventsPaginated = gql`
     $before: String
   ) {
     domain(by: { name: $name }) {
-      assignedResolver {
-        events(first: $first, after: $after, last: $last, before: $before) {
-          edges { cursor node { ...EventFragment } }
-          pageInfo { ...PageInfoFragment }
+      resolver {
+        assigned {
+          events(first: $first, after: $after, last: $last, before: $before) {
+            edges { cursor node { ...EventFragment } }
+            pageInfo { ...PageInfoFragment }
+          }
         }
       }
     }

--- a/docs/ensnode.io/src/content/docs/docs/integrate/index.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/integrate/index.mdx
@@ -50,7 +50,7 @@ const DomainFragment = graphql(`
   fragment DomainFragment on Domain {
     __typename
     id
-    canonical { name }
+    canonical { name { interpreted } }
     owner { id address }
   }
 `);
@@ -75,7 +75,7 @@ function RenderDomainFragment({ data }: { data: FragmentOf<typeof DomainFragment
 
   return (
     <>
-      <span>Name: {domain.canonical ? beautifyInterpretedName(domain.canonical.name) : 'Unnamed Domain'}</span>
+      <span>Name: {domain.canonical ? beautifyInterpretedName(domain.canonical.name.interpreted) : 'Unnamed Domain'}</span>
       <span>Protocol Version: {domain.__typename === 'ENSv1Domain' ? 'ENSv1' : 'ENSv2'}</span>
       <span>Owner: {domain.owner ? domain.owner.address : 'Unowned'}</span>
     </>
@@ -141,7 +141,7 @@ const HelloWorldQuery = graphql(`
   query HelloWorld {
     domain(by: { name: "eth" }) {
       id
-      canonical { name }
+      canonical { name { interpreted } }
       owner { address }
     }
   }
@@ -173,7 +173,7 @@ query MyDomains($address: Address!) {
       edges {
         node {
           label { interpreted }
-          canonical { name }
+          canonical { name { interpreted } }
         }
       }
     }

--- a/docs/ensnode.io/src/content/docs/docs/integrate/integration-options/enskit.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/integrate/integration-options/enskit.mdx
@@ -115,7 +115,7 @@ const DomainByNameQuery = graphql(`
   query DomainByName($name: InterpretedName!) {
     domain(by: { name: $name }) {
       __typename
-      canonical { name }
+      canonical { name { interpreted } }
       owner { address }
     }
   }
@@ -141,7 +141,7 @@ export function DomainView() {
     <div>
       <h2>
         {domain.canonical
-          ? beautifyInterpretedName(domain.canonical.name)
+          ? beautifyInterpretedName(domain.canonical.name.interpreted)
           : "Unnamed Domain"}
       </h2>
       <p>Version: {domain.__typename}</p>
@@ -168,12 +168,12 @@ const DomainByNameQuery = graphql(`
   query DomainByName($name: InterpretedName!) {
     domain(by: { name: $name }) {
       __typename
-      canonical { name }
+      canonical { name { interpreted } }
       owner { address }
       subdomains {
         edges {
           node {
-            canonical { name }
+            canonical { name { interpreted } }
             owner { address }
           }
         }
@@ -200,7 +200,7 @@ export function DomainView() {
 
   return (
     <div>
-      <h2>{domain.canonical ? beautifyInterpretedName(domain.canonical.name) : "Unnamed Domain"}</h2>
+      <h2>{domain.canonical ? beautifyInterpretedName(domain.canonical.name.interpreted) : "Unnamed Domain"}</h2>
       <p>Version: {domain.__typename}</p>
       <p>Owner: <code>{domain.owner?.address ?? "0x0"}</code></p>
 
@@ -209,7 +209,7 @@ export function DomainView() {
         {domain.subdomains?.edges.map(({ node }, i) => (
           <li key={i}>
             {node.canonical
-              ? beautifyInterpretedName(node.canonical.name)
+              ? beautifyInterpretedName(node.canonical.name.interpreted)
               : <em>unnamed</em>}{" "}
             — Owner <code>{node.owner?.address ?? "0x0"}</code>
           </li>
@@ -222,7 +222,7 @@ export function DomainView() {
 
 ## 7. Extract a typed fragment
 
-Notice we're selecting the same fields (`canonical { name }`, `owner { address }`) on the parent Domain _and_ on each subdomain. Extract a `DomainFragment` to deduplicate the selection — and get a reusable, fully-typed shape for components that render a Domain.
+Notice we're selecting the same fields (`canonical { name { interpreted } }`, `owner { address }`) on the parent Domain _and_ on each subdomain. Extract a `DomainFragment` to deduplicate the selection — and get a reusable, fully-typed shape for components that render a Domain.
 
 ```tsx title="src/DomainView.tsx" ins={1,2,5,9-15,21,23,28,31-48,66,72}
 import {
@@ -236,7 +236,7 @@ import { asInterpretedName, beautifyInterpretedName } from "enssdk";
 const DomainFragment = graphql(`
   fragment DomainFragment on Domain {
     __typename
-    canonical { name }
+    canonical { name { interpreted } }
     owner { address }
   }
 `);
@@ -263,7 +263,7 @@ function RenderDomain({ data }: { data: FragmentOf<typeof DomainFragment> }) {
     <>
       <span>
         {domain.canonical
-          ? beautifyInterpretedName(domain.canonical.name)
+          ? beautifyInterpretedName(domain.canonical.name.interpreted)
           : "Unnamed Domain"}
       </span>{" "}
       <span>({domain.__typename})</span>{" "}

--- a/docs/ensnode.io/src/content/docs/docs/integrate/integration-options/enssdk.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/integrate/integration-options/enssdk.mdx
@@ -125,7 +125,7 @@ const HelloWorldQuery = graphql(`
   query HelloWorld($name: InterpretedName!) {
     domain(by: { name: $name }) {
       __typename
-      canonical { name }
+      canonical { name { interpreted } }
       owner { address }
     }
   }
@@ -144,7 +144,7 @@ async function main() {
 
   const { domain } = result.data;
 
-  console.log(`Name: ${domain.canonical ? beautifyInterpretedName(domain.canonical.name) : "<unnamed>"}`);
+  console.log(`Name: ${domain.canonical ? beautifyInterpretedName(domain.canonical.name.interpreted) : "<unnamed>"}`);
   console.log(`Version: ${domain.__typename}`);
   console.log(`Owner: ${domain.owner?.address ?? "0x0"}`);
 }
@@ -159,7 +159,7 @@ A few things to notice:
 
 - `graphql(...)` parses your query at typecheck time. Hover over `result.data` and you'll see it's typed exactly to your selection set — try removing `owner { address }` from the query and watch the access below become a type error.
 - `domain` is a union of `ENSv1Domain | ENSv2Domain` (both implement the `Domain` interface). The Omnigraph unifies ENSv1 and ENSv2 behind the same query — `__typename` tells you which one you got.
-- `canonical` is `null` for non-canonical Domains (e.g. Domains whose name cannot be inferred). When non-null, `canonical.name` is the Domain's Canonical Name. **Always** guard the access; TypeScript will help you.
+- `canonical` is `null` for non-canonical Domains (e.g. Domains whose name cannot be inferred). When non-null, `canonical.name.interpreted` is the Domain's Canonical Name as an InterpretedName. **Always** guard the access; TypeScript will help you.
 
 ## 6. List subdomains
 
@@ -170,12 +170,12 @@ const HelloWorldQuery = graphql(`
   query HelloWorld($name: InterpretedName!) {
     domain(by: { name: $name }) {
       __typename
-      canonical { name }
+      canonical { name { interpreted } }
       owner { address }
       subdomains(first: 20) {
         totalCount
         edges {
-          node { canonical { name } owner { address } }
+          node { canonical { name { interpreted } } owner { address } }
         }
       }
     }
@@ -195,13 +195,13 @@ async function main() {
 
   const { domain } = result.data;
 
-  console.log(`Name: ${domain.canonical ? beautifyInterpretedName(domain.canonical.name) : "<unnamed>"}`);
+  console.log(`Name: ${domain.canonical ? beautifyInterpretedName(domain.canonical.name.interpreted) : "<unnamed>"}`);
   console.log(`Version: ${domain.__typename}`);
   console.log(`Owner: ${domain.owner?.address ?? "0x0"}`);
 
   console.log(`\nSubdomains (showing 20 of ${domain.subdomains?.totalCount ?? 0}):`);
   for (const { node } of domain.subdomains?.edges ?? []) {
-    const subName = node.canonical ? beautifyInterpretedName(node.canonical.name) : "<unnamed>";
+    const subName = node.canonical ? beautifyInterpretedName(node.canonical.name.interpreted) : "<unnamed>";
     console.log(`  - ${subName} — Owner ${node.owner?.address ?? "0x0"}`);
   }
 }
@@ -213,7 +213,7 @@ To page beyond the first 20, the connection also exposes `pageInfo { hasNextPage
 
 ## 7. Extract a typed fragment
 
-Notice we're selecting the same fields (`canonical { name }`, `owner { address }`) on the parent Domain _and_ on each subdomain, and rendering them the same way. Extract a `DomainFragment` to deduplicate the selection — and get a reusable, fully-typed function that formats a Domain.
+Notice we're selecting the same fields (`canonical { name { interpreted } }`, `owner { address }`) on the parent Domain _and_ on each subdomain, and rendering them the same way. Extract a `DomainFragment` to deduplicate the selection — and get a reusable, fully-typed function that formats a Domain.
 
 ```ts title="src/index.ts" ins={3,11-17,23,26,31,34-40,56,59}
 import { asInterpretedName, beautifyInterpretedName } from "enssdk";
@@ -229,7 +229,7 @@ const client = createEnsNodeClient({ url: ENSNODE_URL }).extend(omnigraph);
 const DomainFragment = graphql(`
   fragment DomainFragment on Domain {
     __typename
-    canonical { name }
+    canonical { name { interpreted } }
     owner { address }
   }
 `);
@@ -252,7 +252,7 @@ const HelloWorldQuery = graphql(
 function formatDomain(data: FragmentOf<typeof DomainFragment>): string {
   // type-safe access to fragment data!
   const domain = readFragment(DomainFragment, data);
-  const name = domain.canonical ? beautifyInterpretedName(domain.canonical.name) : "<unnamed>";
+  const name = domain.canonical ? beautifyInterpretedName(domain.canonical.name.interpreted) : "<unnamed>";
   const owner = domain.owner?.address ?? "0x0";
   return `${name} (${domain.__typename}) — Owner ${owner}`;
 }

--- a/docs/ensnode.io/src/content/docs/docs/integrate/integration-options/omnigraph-graphql-api.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/integrate/integration-options/omnigraph-graphql-api.mdx
@@ -32,7 +32,7 @@ A minimum-viable hello world over `curl`:
 ```sh
 curl -sS -X POST \
   -H 'Content-Type: application/json' \
-  -d '{"query":"{ domain(by: { name: \"eth\" }) { canonical { name } owner { address } } }"}' \
+  -d '{"query":"{ domain(by: { name: \"eth\" }) { canonical { name { interpreted } } owner { address } } }"}' \
   https://api.alpha.ensnode.io/api/omnigraph
 ```
 
@@ -78,11 +78,11 @@ const HELLO_WORLD_QUERY = /* GraphQL */ `
   query HelloWorld($name: InterpretedName!) {
     domain(by: { name: $name }) {
       __typename
-      canonical { name }
+      canonical { name { interpreted } }
       owner { address }
       subdomains(first: 20) {
         totalCount
-        edges { node { __typename canonical { name } owner { address } } }
+        edges { node { __typename canonical { name { interpreted } } owner { address } } }
       }
     }
   }
@@ -90,7 +90,7 @@ const HELLO_WORLD_QUERY = /* GraphQL */ `
 
 interface Domain {
   __typename: "ENSv1Domain" | "ENSv2Domain";
-  canonical: { name: string } | null;
+  canonical: { name: { interpreted: string } } | null;
   owner: { address: string } | null;
 }
 
@@ -107,7 +107,7 @@ interface QueryResult {
 }
 
 function formatDomain(domain: Domain): string {
-  const name = domain.canonical?.name ?? "<unnamed>";
+  const name = domain.canonical?.name.interpreted ?? "<unnamed>";
   const owner = domain.owner?.address ?? "0x0";
   return `${name} (${domain.__typename}) — Owner ${owner}`;
 }

--- a/examples/enskit-react-example/src/AccountView.tsx
+++ b/examples/enskit-react-example/src/AccountView.tsx
@@ -15,7 +15,7 @@ const AccountDomainsQuery = graphql(`
       domains(first: $first, after: $after) {
         totalCount
         edges {
-          node { __typename id canonical { name } }
+          node { __typename id canonical { name { interpreted } } }
         }
         pageInfo { hasNextPage endCursor }
       }
@@ -61,8 +61,8 @@ function RenderAccount({ address }: { address: NormalizedAddress }) {
             {domains.edges.map((edge) => (
               <li key={edge.node.id}>
                 {edge.node.canonical ? (
-                  <Link to={`/domain/${edge.node.canonical.name}`}>
-                    {beautifyInterpretedName(edge.node.canonical.name)}
+                  <Link to={`/domain/${edge.node.canonical.name.interpreted}`}>
+                    {beautifyInterpretedName(edge.node.canonical.name.interpreted)}
                   </Link>
                 ) : (
                   <em>non-canonical domain</em>

--- a/examples/enskit-react-example/src/DomainView.tsx
+++ b/examples/enskit-react-example/src/DomainView.tsx
@@ -1,11 +1,6 @@
 import { EnsureInterpretedName } from "enskit/react";
 import { type FragmentOf, graphql, readFragment, useOmnigraphQuery } from "enskit/react/omnigraph";
-import {
-  asLiteralName,
-  beautifyInterpretedName,
-  getParentInterpretedName,
-  type InterpretedName,
-} from "enssdk";
+import { asLiteralName, beautifyInterpretedName, type InterpretedName } from "enssdk";
 import { useState } from "react";
 import { Link, Navigate, useParams } from "react-router";
 
@@ -13,7 +8,7 @@ const DomainFragment = graphql(`
   fragment DomainFragment on Domain {
     __typename
     id
-    canonical { name }
+    canonical { name { interpreted } }
     owner { id address }
   }
 `);
@@ -23,6 +18,7 @@ const DomainByNameQuery = graphql(
   query DomainByName($name: InterpretedName!, $first: Int!, $after: String) {
     domain(by: { name: $name }) {
       ...DomainFragment
+      parent { canonical { name { interpreted } } }
       subdomains(first: $first, after: $after) {
         edges {
           node {
@@ -48,8 +44,8 @@ function SubdomainLink({ data }: { data: FragmentOf<typeof DomainFragment> }) {
   return (
     <li>
       {domain.canonical ? (
-        <Link to={`/domain/${domain.canonical.name}`}>
-          {beautifyInterpretedName(domain.canonical.name)}
+        <Link to={`/domain/${domain.canonical.name.interpreted}`}>
+          {beautifyInterpretedName(domain.canonical.name.interpreted)}
         </Link>
       ) : (
         <em>non-canonical domain</em>
@@ -81,12 +77,11 @@ function RenderDomain({ name }: { name: InterpretedName }) {
   if (!data?.domain) return <p>No domain was found with name '{beautifyInterpretedName(name)}'.</p>;
 
   const domain = readFragment(DomainFragment, data.domain);
-  const parentName = getParentInterpretedName(name);
   const { subdomains } = data.domain;
 
   return (
     <div>
-      <h2>{beautifyInterpretedName(domain.canonical?.name ?? name)}</h2>
+      <h2>{beautifyInterpretedName(domain.canonical?.name.interpreted ?? name)}</h2>
       <p>
         Owner:{" "}
         {domain.owner ? (
@@ -99,10 +94,10 @@ function RenderDomain({ name }: { name: InterpretedName }) {
       </p>
       <p>Version: {domain.__typename}</p>
 
-      {parentName && (
-        <p>
-          ← <Link to={`/domain/${parentName}`}>{beautifyInterpretedName(parentName)}</Link>
-        </p>
+      {data.domain.parent?.canonical && (
+        <Link to={`/domain/${data.domain.parent.canonical.name.interpreted}`}>
+          ← {beautifyInterpretedName(data.domain.parent.canonical.name.interpreted)}
+        </Link>
       )}
 
       <h3>Subdomains</h3>

--- a/examples/enskit-react-example/src/SearchView.tsx
+++ b/examples/enskit-react-example/src/SearchView.tsx
@@ -7,7 +7,7 @@ const DomainsByNameQuery = graphql(`
   query DomainsByName($name: String!, $first: Int!, $after: String) {
     domains(where: { name: { starts_with: $name } }, first: $first, after: $after) {
       edges {
-        node { __typename id canonical {name} }
+        node { __typename id canonical { name { interpreted } } }
       }
       pageInfo {
         hasNextPage
@@ -92,8 +92,8 @@ export function SearchView() {
               return (
                 <li key={edge.node.id}>
                   ({edge.node.__typename === "ENSv1Domain" ? "v1" : "v2"}){" "}
-                  <Link to={`/domain/${edge.node.canonical.name}`}>
-                    {beautifyInterpretedName(edge.node.canonical.name)}
+                  <Link to={`/domain/${edge.node.canonical.name.interpreted}`}>
+                    {beautifyInterpretedName(edge.node.canonical.name.interpreted)}
                   </Link>
                 </li>
               );

--- a/examples/enssdk-example/src/index.ts
+++ b/examples/enssdk-example/src/index.ts
@@ -13,7 +13,7 @@ const client = createEnsNodeClient({ url: ENSNODE_URL }).extend(omnigraph);
 const DomainFragment = graphql(`
   fragment DomainFragment on Domain {
     __typename
-    canonical { name }
+    canonical { name { interpreted } }
     owner { address }
   }
 `);
@@ -36,7 +36,9 @@ const HelloWorldQuery = graphql(
 function formatDomain(data: FragmentOf<typeof DomainFragment>): string {
   // type-safe access to fragment data!
   const domain = readFragment(DomainFragment, data);
-  const name = domain.canonical ? beautifyInterpretedName(domain.canonical.name) : "<unnamed>";
+  const name = domain.canonical
+    ? beautifyInterpretedName(domain.canonical.name.interpreted)
+    : "<unnamed>";
   const owner = domain.owner?.address ?? "0x0";
   return `${name} (${domain.__typename}) — Owner ${owner}`;
 }

--- a/examples/omnigraph-graphql-example/src/index.ts
+++ b/examples/omnigraph-graphql-example/src/index.ts
@@ -9,11 +9,11 @@ const HELLO_WORLD_QUERY = /* GraphQL */ `
   query HelloWorld($name: InterpretedName!) {
     domain(by: { name: $name }) {
       __typename
-      canonical { name }
+      canonical { name { interpreted } }
       owner { address }
       subdomains(first: 20) {
         totalCount
-        edges { node { __typename canonical { name } owner { address } } }
+        edges { node { __typename canonical { name { interpreted } } owner { address } } }
       }
     }
   }
@@ -21,7 +21,7 @@ const HELLO_WORLD_QUERY = /* GraphQL */ `
 
 interface Domain {
   __typename: "ENSv1Domain" | "ENSv2Domain";
-  canonical: { name: string } | null;
+  canonical: { name: { interpreted: string } } | null;
   owner: { address: string } | null;
 }
 
@@ -40,7 +40,7 @@ interface QueryResult {
 }
 
 function formatDomain(domain: Domain): string {
-  const name = domain.canonical?.name ?? "<unnamed>";
+  const name = domain.canonical?.name.interpreted ?? "<unnamed>";
   const owner = domain.owner?.address ?? "0x0";
   return `${name} (${domain.__typename}) — Owner ${owner}`;
 }

--- a/packages/ensnode-sdk/src/omnigraph-api/example-queries.ts
+++ b/packages/ensnode-sdk/src/omnigraph-api/example-queries.ts
@@ -56,7 +56,7 @@ export const GRAPHQL_API_EXAMPLE_QUERIES: Array<{
 #
 # There are also example queries in the tabs above ☝️
 query HelloWorld {
-  domain(by: { name: "eth" }) { canonical { name } owner { address } }
+  domain(by: { name: "eth" }) { canonical { name { interpreted } } owner { address } }
 }`,
     variables: { default: {} },
   },
@@ -80,7 +80,7 @@ query FindDomains(
         __typename
         id
         label { interpreted hash }
-        canonical { name }
+        canonical { name { interpreted } }
 
         registration { expiry event { timestamp } }
       }
@@ -110,7 +110,7 @@ query DomainByName($name: InterpretedName!) {
     __typename
     id
     label { interpreted hash }
-    canonical { name node path { id } }
+    canonical { name { interpreted } node path { id } }
     owner { address }
     subregistry { contract { chainId address } }
 
@@ -132,11 +132,11 @@ query DomainByName($name: InterpretedName!) {
     query: `
 query DomainSubdomains($name: InterpretedName!) {
   domain(by: {name: $name}) {
-    canonical { name }
+    canonical { name { interpreted } }
     subdomains(first: 10) {
       edges {
         node {
-          canonical { name }
+          canonical { name { interpreted } }
         }
       }
     }
@@ -186,7 +186,7 @@ query AccountDomains(
       edges {
         node {
           label { interpreted }
-          canonical { name }
+          canonical { name { interpreted } }
         }
       }
     }
@@ -231,7 +231,7 @@ query RegistryDomains(
       edges {
         node {
           label { interpreted }
-          canonical { name }
+          canonical { name { interpreted } }
         }
       }
     }
@@ -335,10 +335,12 @@ query AccountResolverPermissions($address: Address!) {
     query: `
 query DomainResolver($name: InterpretedName!) {
   domain(by: { name: $name }) {
-    assignedResolver {
-      records { edges { node { node keys coinTypes } } }
-      permissions { resources { edges { node { resource users { edges { node { user { address } roles } } } } } } }
-      events { totalCount edges { node { topics data timestamp } } }
+    resolver {
+      assigned {
+        records { edges { node { node keys coinTypes } } }
+        permissions { resources { edges { node { resource users { edges { node { user { address } roles } } } } } } }
+        events { totalCount edges { node { topics data timestamp } } }
+      }
     }
   }
 }`,
@@ -360,17 +362,17 @@ query Namegraph {
     domains {
       edges {
         node {
-          canonical { name }
+          canonical { name { interpreted } }
 
           subdomains {
             edges {
               node {
-                canonical { name }
+                canonical { name { interpreted } }
 
                 subdomains {
                   edges {
                     node {
-                      canonical { name }
+                      canonical { name { interpreted } }
                     }
                   }
                 }

--- a/packages/enssdk/README.md
+++ b/packages/enssdk/README.md
@@ -32,7 +32,7 @@ const client = createEnsNodeClient({ url: "https://api.alpha.ensnode.io" })
 const MyQuery = graphql(`
   query MyQuery($name: Name!) {
     domain(by: { name: $name }) {
-      canonical { name }
+      canonical { name { interpreted } }
       registration { expiry }
     }
   }

--- a/packages/enssdk/src/lib/interpreted-names-and-labels.test.ts
+++ b/packages/enssdk/src/lib/interpreted-names-and-labels.test.ts
@@ -12,7 +12,7 @@ import {
   literalNameToInterpretedName,
 } from "./interpreted-names-and-labels";
 import { encodeLabelHash, labelhashLiteralLabel } from "./labelhash";
-import type { InterpretedLabel, InterpretedName, LiteralLabel, Name } from "./types";
+import type { InterpretedLabel, InterpretedName, LiteralLabel } from "./types";
 
 const ENCODED_LABELHASH_LABEL = /^\[[\da-f]{64}\]$/;
 

--- a/packages/enssdk/src/omnigraph/generated/introspection.ts
+++ b/packages/enssdk/src/omnigraph/generated/introspection.ts
@@ -1039,6 +1039,25 @@ const introspection = {
         "name": "Boolean"
       },
       {
+        "kind": "OBJECT",
+        "name": "CanonicalName",
+        "fields": [
+          {
+            "name": "interpreted",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "InterpretedName"
+              }
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
         "kind": "SCALAR",
         "name": "ChainId"
       },
@@ -1050,15 +1069,6 @@ const introspection = {
         "kind": "INTERFACE",
         "name": "Domain",
         "fields": [
-          {
-            "name": "assignedResolver",
-            "type": {
-              "kind": "OBJECT",
-              "name": "Resolver"
-            },
-            "args": [],
-            "isDeprecated": false
-          },
           {
             "name": "canonical",
             "type": {
@@ -1215,6 +1225,18 @@ const introspection = {
             "isDeprecated": false
           },
           {
+            "name": "resolver",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "DomainResolver"
+              }
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
             "name": "subdomains",
             "type": {
               "kind": "OBJECT",
@@ -1309,8 +1331,8 @@ const introspection = {
             "type": {
               "kind": "NON_NULL",
               "ofType": {
-                "kind": "SCALAR",
-                "name": "InterpretedName"
+                "kind": "OBJECT",
+                "name": "CanonicalName"
               }
             },
             "args": [],
@@ -1577,6 +1599,22 @@ const introspection = {
       },
       {
         "kind": "OBJECT",
+        "name": "DomainResolver",
+        "fields": [
+          {
+            "name": "assigned",
+            "type": {
+              "kind": "OBJECT",
+              "name": "Resolver"
+            },
+            "args": [],
+            "isDeprecated": false
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "OBJECT",
         "name": "DomainSubdomainsConnection",
         "fields": [
           {
@@ -1779,15 +1817,6 @@ const introspection = {
         "name": "ENSv1Domain",
         "fields": [
           {
-            "name": "assignedResolver",
-            "type": {
-              "kind": "OBJECT",
-              "name": "Resolver"
-            },
-            "args": [],
-            "isDeprecated": false
-          },
-          {
             "name": "canonical",
             "type": {
               "kind": "OBJECT",
@@ -1949,6 +1978,18 @@ const introspection = {
               "ofType": {
                 "kind": "INTERFACE",
                 "name": "Registry"
+              }
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "resolver",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "DomainResolver"
               }
             },
             "args": [],
@@ -2343,15 +2384,6 @@ const introspection = {
         "name": "ENSv2Domain",
         "fields": [
           {
-            "name": "assignedResolver",
-            "type": {
-              "kind": "OBJECT",
-              "name": "Resolver"
-            },
-            "args": [],
-            "isDeprecated": false
-          },
-          {
             "name": "canonical",
             "type": {
               "kind": "OBJECT",
@@ -2546,6 +2578,18 @@ const introspection = {
               "ofType": {
                 "kind": "INTERFACE",
                 "name": "Registry"
+              }
+            },
+            "args": [],
+            "isDeprecated": false
+          },
+          {
+            "name": "resolver",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "DomainResolver"
               }
             },
             "args": [],

--- a/packages/enssdk/src/omnigraph/generated/schema.graphql
+++ b/packages/enssdk/src/omnigraph/generated/schema.graphql
@@ -209,6 +209,14 @@ type BaseRegistrarRegistration implements Registration {
 """BigInt represents non-fractional signed whole numeric values."""
 scalar BigInt
 
+"""A Canonical Name, exposed in each representation we support."""
+type CanonicalName {
+  """
+  The Canonical Name as an InterpretedName: each label is either a normalized literal Label or an Encoded LabelHash. Suitable for navigation, lookup, and as a stable identifier.
+  """
+  interpreted: InterpretedName!
+}
+
 """ChainId represents a enssdk#ChainId."""
 scalar ChainId
 
@@ -219,11 +227,6 @@ scalar CoinType
 Represents a Domain, i.e. an individual Label within the ENS namegraph. It may or may not be Canonical. It may be an ENSv1Domain or an ENSv2Domain.
 """
 interface Domain {
-  """
-  The Resolver that this Domain has assigned, if any. NOTE that this is the Domain's _assigned_ Resolver, _not_ its _effective_ Resolver, which can only be determined by following ENS Forward Resolution and ENSIP-10. Do NOT use this Domain-Resolver relationship in isolation to resolve records, that operation is NOT ENS Forward Resolution.
-  """
-  assignedResolver: Resolver
-
   """
   Metadata (name, path, and node) related to the Domain's canonicality, if known. Null when the Domain is not in the canonical nametree.
   """
@@ -257,6 +260,9 @@ interface Domain {
   """The Registry under which this Domain exists."""
   registry: Registry!
 
+  """Resolver relationship metadata for this Domain."""
+  resolver: DomainResolver!
+
   """
   All Domains that are direct descendents of this Domain in the namegraph.
   """
@@ -275,8 +281,8 @@ type DomainCanonical {
   """
   depth: Int!
 
-  """The Canonical Name for this Domain."""
-  name: InterpretedName!
+  """The Canonical Name for this Domain, in multiple representations."""
+  name: CanonicalName!
 
   """
   The namehash of this Domain's Canonical Name. Note that this is NOT a stable reference to this Domain; use `Domain.id`.
@@ -337,6 +343,14 @@ type DomainRegistrationsConnection {
 type DomainRegistrationsConnectionEdge {
   cursor: String!
   node: Registration!
+}
+
+"""Metadata describing this Domain's relationship to its Resolver(s)."""
+type DomainResolver {
+  """
+  The Resolver that this Domain has assigned, if any. NOTE that this is the Domain's _assigned_ Resolver, _not_ its _effective_ Resolver, which can only be determined by following ENS Forward Resolution and ENSIP-10. Do NOT use this Domain-Resolver relationship in isolation to resolve records, that operation is NOT ENS Forward Resolution.
+  """
+  assigned: Resolver
 }
 
 type DomainSubdomainsConnection {
@@ -406,11 +420,6 @@ enum ENSProtocolVersion {
 """An ENSv1Domain represents an ENSv1 Domain."""
 type ENSv1Domain implements Domain {
   """
-  The Resolver that this Domain has assigned, if any. NOTE that this is the Domain's _assigned_ Resolver, _not_ its _effective_ Resolver, which can only be determined by following ENS Forward Resolution and ENSIP-10. Do NOT use this Domain-Resolver relationship in isolation to resolve records, that operation is NOT ENS Forward Resolution.
-  """
-  assignedResolver: Resolver
-
-  """
   Metadata (name, path, and node) related to the Domain's canonicality, if known. Null when the Domain is not in the canonical nametree.
   """
   canonical: DomainCanonical
@@ -445,6 +454,9 @@ type ENSv1Domain implements Domain {
 
   """The Registry under which this Domain exists."""
   registry: Registry!
+
+  """Resolver relationship metadata for this Domain."""
+  resolver: DomainResolver!
 
   """
   The rootRegistryOwner of this Domain, i.e. the owner() of this Domain within the ENSv1 Registry.
@@ -518,11 +530,6 @@ type ENSv1VirtualRegistry implements Registry {
 """An ENSv2Domain represents an ENSv2 Domain."""
 type ENSv2Domain implements Domain {
   """
-  The Resolver that this Domain has assigned, if any. NOTE that this is the Domain's _assigned_ Resolver, _not_ its _effective_ Resolver, which can only be determined by following ENS Forward Resolution and ENSIP-10. Do NOT use this Domain-Resolver relationship in isolation to resolve records, that operation is NOT ENS Forward Resolution.
-  """
-  assignedResolver: Resolver
-
-  """
   Metadata (name, path, and node) related to the Domain's canonicality, if known. Null when the Domain is not in the canonical nametree.
   """
   canonical: DomainCanonical
@@ -559,6 +566,9 @@ type ENSv2Domain implements Domain {
 
   """The Registry under which this Domain exists."""
   registry: Registry!
+
+  """Resolver relationship metadata for this Domain."""
+  resolver: DomainResolver!
 
   """
   All Domains that are direct descendents of this Domain in the namegraph.

--- a/packages/enssdk/src/omnigraph/generated/schema.graphql
+++ b/packages/enssdk/src/omnigraph/generated/schema.graphql
@@ -212,7 +212,7 @@ scalar BigInt
 """A Canonical Name, exposed in each representation we support."""
 type CanonicalName {
   """
-  The Canonical Name as an InterpretedName: each label is either a normalized literal Label or an Encoded LabelHash. Suitable for navigation, lookup, and as a stable identifier.
+  The Canonical Name as an InterpretedName: each label is either a normalized literal Label or an Encoded LabelHash.
   """
   interpreted: InterpretedName!
 }
@@ -281,7 +281,7 @@ type DomainCanonical {
   """
   depth: Int!
 
-  """The Canonical Name for this Domain, in multiple representations."""
+  """The Canonical Name for this Domain."""
   name: CanonicalName!
 
   """

--- a/packages/enssdk/src/omnigraph/module.integration.test.ts
+++ b/packages/enssdk/src/omnigraph/module.integration.test.ts
@@ -13,7 +13,7 @@ const HelloWorldQuery = graphql(`
   query HelloWorld {
     domain(by: { name: "eth" }) {
       id
-      canonical { name }
+      canonical { name { interpreted } }
       owner { address }
     }
   }
@@ -27,13 +27,13 @@ describe("omnigraph module (integration)", () => {
 
     // look, our semantic types!
     expectTypeOf(result.data!.domain!.id).toEqualTypeOf<DomainId>();
-    expectTypeOf(result.data!.domain!.canonical!.name).toEqualTypeOf<InterpretedName>();
+    expectTypeOf(result.data!.domain!.canonical!.name.interpreted).toEqualTypeOf<InterpretedName>();
     expectTypeOf(result.data!.domain!.owner!.address).toEqualTypeOf<Address>();
 
     // the 'eth' domain should exist
     expect(result.data!.domain).toMatchObject({
       id: expect.any(String),
-      canonical: { name: "eth" },
+      canonical: { name: { interpreted: "eth" } },
       owner: { address: expect.any(String) },
     });
   });

--- a/packages/enssdk/src/omnigraph/module.test.ts
+++ b/packages/enssdk/src/omnigraph/module.test.ts
@@ -20,7 +20,7 @@ describe("omnigraph module", () => {
   });
 
   it("sends a POST request with string query", async () => {
-    const mockResponse = { data: { domain: { canonical: { name: "nick.eth" } } } };
+    const mockResponse = { data: { domain: { canonical: { name: { interpreted: "nick.eth" } } } } };
     const mockFetch = vi.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve(mockResponse),
@@ -29,14 +29,14 @@ describe("omnigraph module", () => {
     const client = createMockClient(mockFetch);
 
     const result = await client.omnigraph.query({
-      query: 'query { domain(by: { name: "nick.eth" }) { canonical { name } } }',
+      query: 'query { domain(by: { name: "nick.eth" }) { canonical { name { interpreted } } } }',
     });
 
     expect(mockFetch).toHaveBeenCalledWith("https://example.com/api/omnigraph", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        query: 'query { domain(by: { name: "nick.eth" }) { canonical { name } } }',
+        query: 'query { domain(by: { name: "nick.eth" }) { canonical { name { interpreted } } } }',
         variables: undefined,
       }),
       signal: undefined,
@@ -54,7 +54,8 @@ describe("omnigraph module", () => {
     const client = createMockClient(mockFetch);
 
     await client.omnigraph.query({
-      query: "query($name: String!) { domain(by: { name: $name }) { canonical { name } } }",
+      query:
+        "query($name: String!) { domain(by: { name: $name }) { canonical { name { interpreted } } } }",
       variables: { name: "nick.eth" },
     });
 
@@ -72,7 +73,7 @@ describe("omnigraph module", () => {
     const client = createMockClient(mockFetch);
 
     await client.omnigraph.query({
-      query: "query { domains { canonical { name } } }",
+      query: "query { domains { canonical { name { interpreted } } } }",
       signal: controller.signal,
     });
 
@@ -92,7 +93,7 @@ describe("omnigraph module", () => {
 
     await expect(
       client.omnigraph.query({
-        query: 'query { domain(by: { name: "eth" }) { canonical { name } } }',
+        query: 'query { domain(by: { name: "eth" }) { canonical { name { interpreted } } } }',
       }),
     ).rejects.toThrow(`Omnigraph query failed: 401 Unauthorized\n${errorBody}`);
   });
@@ -104,7 +105,9 @@ describe("omnigraph module", () => {
     });
 
     const client = createMockClient(mockFetch);
-    const doc = parse('query { domain(by: { name: "nick.eth" }) { canonical { name } } }');
+    const doc = parse(
+      'query { domain(by: { name: "nick.eth" }) { canonical { name { interpreted } } } }',
+    );
 
     await client.omnigraph.query({ query: doc });
 


### PR DESCRIPTION
- expands `Domain.canonical.name` into `Domain.canonical.name.interpreted` to make room for `Domain.canonical.name.beautified` in the near future
- refactors `Domain.resolver` into `Domain.resolver.assigned` to make room for `Domain.resolver.effective` in the near future