### PR TITLE
Add temporary note on `v1.13` compatility requirements

### DIFF
--- a/docs/ensnode.io/src/components/molecules/HostedInstanceSdkVersionWarning.astro
+++ b/docs/ensnode.io/src/components/molecules/HostedInstanceSdkVersionWarning.astro
@@ -1,0 +1,40 @@
+---
+import { Aside } from "@astrojs/starlight/components";
+
+interface Props {
+  /**
+   * Which SDK(s) the warning is for.
+   * - "enssdk": only enssdk
+   * - "enskit": both enskit and enssdk (enskit depends on enssdk)
+   * - "both": mention both enssdk and enskit, show both install commands
+   */
+  for?: "enssdk" | "enskit" | "both";
+}
+
+const { for: target = "enssdk" } = Astro.props;
+
+const isEnskit = target === "enskit";
+const isBoth = target === "both";
+
+const sdkList = isEnskit
+  ? "`enskit@1.13.1` and `enssdk@1.13.1`"
+  : isBoth
+    ? "`enssdk@1.13.1` (and `enskit@1.13.1` when using React)"
+    : "`enssdk@1.13.1`";
+---
+
+<Aside type="caution" title="Version compatibility with hosted instances">
+  Our hosted ENSNode instances currently run ENSNode v1.13. If you are querying them from your own app, you **must** use {sdkList}. The latest published versions (`1.14.0+`) contain breaking changes in the Omnigraph API data model not yet deployed to our hosted infrastructure. Use these exact install commands:
+
+  {isBoth ? (
+    <pre><code>npm install enssdk@1.13.1
+# or, for React apps:
+npm install enskit@1.13.1 enssdk@1.13.1</code></pre>
+  ) : isEnskit ? (
+    <pre><code>npm install enskit@1.13.1 enssdk@1.13.1</code></pre>
+  ) : (
+    <pre><code>npm install enssdk@1.13.1</code></pre>
+  )}
+
+  This notice will be removed once the hosted instances are upgraded.
+</Aside>

--- a/docs/ensnode.io/src/components/molecules/HostedInstanceSdkVersionWarning.astro
+++ b/docs/ensnode.io/src/components/molecules/HostedInstanceSdkVersionWarning.astro
@@ -17,23 +17,23 @@ const isEnskit = target === "enskit";
 const isBoth = target === "both";
 
 const sdkList = isEnskit
-  ? "`enskit@1.13.1` and `enssdk@1.13.1`"
+  ? "<code>enskit@1.13.1</code> and <code>enssdk@1.13.1</code>"
   : isBoth
-    ? "`enssdk@1.13.1` (and `enskit@1.13.1` when using React)"
-    : "`enssdk@1.13.1`";
+    ? "<code>enssdk@1.13.1</code> (and <code>enskit@1.13.1</code> when using React)"
+    : "<code>enssdk@1.13.1</code>";
 ---
 
 <Aside type="caution" title="Version compatibility with hosted instances">
-  Our hosted ENSNode instances currently run ENSNode v1.13. If you are querying them from your own app, you **must** use {sdkList}. The latest published versions (`1.14.0+`) contain breaking changes in the Omnigraph API data model not yet deployed to our hosted infrastructure. Use these exact install commands:
+  Our hosted ENSNode instances currently run ENSNode v1.13. If you are querying them from your own app, you <strong>must</strong> use <span set:html={sdkList} />. The latest published versions (<code>1.14.0+</code>) contain breaking changes in the Omnigraph API data model not yet deployed to our hosted infrastructure. Use these exact install commands:
 
   {isBoth ? (
-    <pre><code>npm install enssdk@1.13.1
+    <pre>npm install enssdk@1.13.1
 # or, for React apps:
-npm install enskit@1.13.1 enssdk@1.13.1</code></pre>
+npm install enskit@1.13.1 enssdk@1.13.1</pre>
   ) : isEnskit ? (
-    <pre><code>npm install enskit@1.13.1 enssdk@1.13.1</code></pre>
+    <pre>npm install enskit@1.13.1 enssdk@1.13.1</pre>
   ) : (
-    <pre><code>npm install enssdk@1.13.1</code></pre>
+    <pre>npm install enssdk@1.13.1</pre>
   )}
 
   This notice will be removed once the hosted instances are upgraded.

--- a/docs/ensnode.io/src/components/molecules/IntegrateHostedEnsNodeTip.astro
+++ b/docs/ensnode.io/src/components/molecules/IntegrateHostedEnsNodeTip.astro
@@ -1,13 +1,25 @@
 ---
 import { Aside, LinkCard } from "@astrojs/starlight/components";
+import HostedInstanceSdkVersionWarning from "./HostedInstanceSdkVersionWarning.astro";
+
+interface Props {
+  /**
+   * Which SDK the warning should target. Passed through to HostedInstanceSdkVersionWarning.
+   * - "enssdk": enssdk-only warning
+   * - "enskit": both enskit and enssdk warning
+   * - "both": mention both enssdk and enskit, show both install commands (default)
+   */
+  for?: "enssdk" | "enskit" | "both";
+}
+
+const { for: target = "both" } = Astro.props;
 ---
 
 <Aside type="tip" title="No backend required">
 You don't need to run your own ENSNode to follow this guide — the steps below default to a NameHash-hosted instance. Browse the available deployments below.
 </Aside>
+<HostedInstanceSdkVersionWarning for={target} />
 <LinkCard
   title="Hosted ENSNode Instances"
   href="/docs/integrate/hosted-instances"
 />
-
-

--- a/docs/ensnode.io/src/content/docs/docs/integrate/hosted-instances.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/integrate/hosted-instances.mdx
@@ -6,12 +6,15 @@ sidebar:
 ---
 
 import HostedEnsNodeInstances from "@components/molecules/HostedEnsNodeInstances.astro";
+import HostedInstanceSdkVersionWarning from "@components/molecules/HostedInstanceSdkVersionWarning.astro";
 
 ## Hosted Instances
 
 NameHash Labs provides freely available hosted instances for ENS developers looking to get started quickly.
 
 These instances are provided free of charge with no API key required, have no rate limiting, and are maintained and monitored by the NameHash Labs team.
+
+<HostedInstanceSdkVersionWarning for="both" />
 
 ### Available instance configurations
 

--- a/docs/ensnode.io/src/content/docs/docs/integrate/index.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/integrate/index.mdx
@@ -7,6 +7,7 @@ sidebar:
 ---
 
 import { LinkCard, CardGrid, Aside } from "@astrojs/starlight/components";
+import HostedInstanceSdkVersionWarning from "@components/molecules/HostedInstanceSdkVersionWarning.astro";
 import OmnigraphAPIExample from "@components/organisms/OmnigraphAPIExample.astro";
 
 ## What is ENSv2?
@@ -43,6 +44,8 @@ Here's a summary of some popular integration strategies:
 ### 1. `enskit` + Omnigraph
 
 With `enskit`, leverage ENSNode and the Omnigraph to power your React components using `useOmnigraphQuery`. `enskit` comes with built-in type-safety, Omnigraph-specific cache directives, easy infinite pagination, and much much more.
+
+<HostedInstanceSdkVersionWarning for="enskit" />
 
 
 ```tsx
@@ -137,6 +140,8 @@ export function RenderDomainAndSubdomains({ name }: { name: InterpretedName }) {
 ### 2. `enssdk` + Omnigraph
 
 With `enssdk`, leverage ENSNode and the Omnigraph from any JavaScript runtime to power your frontend or backend apps. `enssdk` comes with built-in type-safety and editor autocomplete for Omnigraph queries.
+
+<HostedInstanceSdkVersionWarning for="enssdk" />
 
 
 ```ts

--- a/docs/ensnode.io/src/content/docs/docs/integrate/integration-options/enskit/example.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/integrate/integration-options/enskit/example.mdx
@@ -8,8 +8,11 @@ sidebar:
 ---
 
 import EnskitExampleInteractivePlayground from "@components/organisms/EnskitExampleInteractivePlayground";
+import HostedInstanceSdkVersionWarning from "@components/molecules/HostedInstanceSdkVersionWarning.astro";
 
 This playground loads the same source as [`enskit-react-example`](https://github.com/namehash/ensnode/tree/main/examples/enskit-react-example): a Vite + React app with routing, domain and account browsers, registry cache, and search — powered by [`enskit`](/docs/integrate/integration-options/enskit) and the [ENS Omnigraph API](/docs/integrate/omnigraph).
+
+<HostedInstanceSdkVersionWarning for="enskit" />
 
 :::note[First load may take a moment]
 The editor runs entirely in your browser. Downloading of **enskit**, **enssdk** and their heavy dependencies may take 30-60 seconds.

--- a/docs/ensnode.io/src/content/docs/docs/integrate/integration-options/enskit/index.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/integrate/integration-options/enskit/index.mdx
@@ -10,7 +10,7 @@ import IntegrateHostedEnsNodeTip from '@components/molecules/IntegrateHostedEnsN
 
 This guide walks you from an empty directory to a working React component that renders an [ENS Domain](/docs/concepts/the-ens-protocol) and a paginated list of its subdomains — the same flow as the [`DomainView`](https://github.com/namehash/ensnode/blob/main/examples/enskit-react-example/src/DomainView.tsx) in our example app.
 
-<IntegrateHostedEnsNodeTip />
+<IntegrateHostedEnsNodeTip for="enskit" />
 
 
 ## 1. Scaffold a React app
@@ -31,8 +31,10 @@ npm install
 npm install enskit@1.13.1 enssdk@1.13.1
 ```
 
-:::tip[Pin exact versions]
+:::caution[Pin exact versions — hosted instance compatibility]
 Always pin **exact** versions (no `^` or `~`) of `enskit` and `enssdk`, and keep them on the same version. The Omnigraph GraphQL schema is bundled inside `enssdk` and consumed by the `gql.tada` TypeScript plugin to type your queries — a minor or patch bump can change the schema and silently drift your generated types away from your queries. Locking exact versions keeps types and runtime in sync.
+
+**Important:** Our hosted ENSNode instances currently run ENSNode v1.13. The latest published versions of `enskit` and `enssdk` are `1.14.0+`, which contain breaking changes in the Omnigraph API data model not yet deployed to our hosted infrastructure. If you are querying a hosted instance from your own app, you **must** use `enskit@1.13.1` and `enssdk@1.13.1` to avoid type errors and runtime mismatches. This notice will be removed once the hosted instances are upgraded.
 :::
 
 ## 3. Configure the `gql.tada` TypeScript plugin

--- a/docs/ensnode.io/src/content/docs/docs/integrate/integration-options/enssdk/example.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/integrate/integration-options/enssdk/example.mdx
@@ -8,8 +8,11 @@ sidebar:
 ---
 
 import EnssdkExampleInteractivePlayground from "@components/organisms/EnssdkExampleInteractivePlayground";
+import HostedInstanceSdkVersionWarning from "@components/molecules/HostedInstanceSdkVersionWarning.astro";
 
 This playground loads the same source as [`enssdk-example`](https://github.com/namehash/ensnode/tree/main/examples/enssdk-example): a TypeScript script that queries the `eth` domain and lists its first 20 subdomains via [`enssdk`](/docs/integrate/integration-options/enssdk) and the [ENS Omnigraph API](/docs/integrate/omnigraph).
+
+<HostedInstanceSdkVersionWarning for="enssdk" />
 
 :::note[First load may take a moment]
 The editor runs entirely in your browser. The editor runs entirely in your browser. Downloading of **enssdk** and heavy dependencies may take 30-60 seconds.

--- a/docs/ensnode.io/src/content/docs/docs/integrate/integration-options/enssdk/example.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/integrate/integration-options/enssdk/example.mdx
@@ -15,7 +15,7 @@ This playground loads the same source as [`enssdk-example`](https://github.com/n
 <HostedInstanceSdkVersionWarning for="enssdk" />
 
 :::note[First load may take a moment]
-The editor runs entirely in your browser. The editor runs entirely in your browser. Downloading of **enssdk** and heavy dependencies may take 30-60 seconds.
+The editor runs entirely in your browser. Downloading of **enssdk** and heavy dependencies may take 30-60 seconds.
 :::
 
 You can edit the script and run **`npm start`** in the terminal to run it again.

--- a/docs/ensnode.io/src/content/docs/docs/integrate/integration-options/enssdk/index.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/integrate/integration-options/enssdk/index.mdx
@@ -12,7 +12,7 @@ import IntegrateHostedEnsNodeTip from '@components/molecules/IntegrateHostedEnsN
 
 This guide walks you from an empty directory to a working TypeScript script that queries the `eth` Domain and queries its subdomains — the same flow as our [enssdk-example](https://github.com/namehash/ensnode/tree/main/examples/enssdk-example).
 
-<IntegrateHostedEnsNodeTip />
+<IntegrateHostedEnsNodeTip for="enssdk" />
 
 ## 1. Scaffold a TypeScript project
 
@@ -35,8 +35,10 @@ npm install enssdk@1.13.1
 npm install -D tsx typescript @types/node
 ```
 
-:::tip[Pin exact versions]
+:::caution[Pin exact versions — hosted instance compatibility]
 Always pin an **exact** version (no `^` or `~`) of `enssdk`. The Omnigraph GraphQL schema is bundled inside `enssdk` and consumed by the `gql.tada` TypeScript plugin to type your queries — a minor or patch bump can change the schema and silently drift your generated types away from your queries. Locking the exact version keeps types and runtime in sync.
+
+**Important:** Our hosted ENSNode instances currently run ENSNode v1.13. The latest published version of `enssdk` is `1.14.0+`, which contains breaking changes in the Omnigraph API data model not yet deployed to our hosted infrastructure. If you are querying a hosted instance from your own app, you **must** use `enssdk@1.13.1` to avoid type errors and runtime mismatches. This notice will be removed once the hosted instances are upgraded.
 :::
 
 

--- a/examples/enskit-react-example/README.md
+++ b/examples/enskit-react-example/README.md
@@ -8,6 +8,8 @@ This app is hosted at [https://enskit-react-example.ensnode.io/](https://enskit-
 
 ## Usage (with NameHash Hosted Instance)
 
+> **Version compatibility:** Our hosted ENSNode instances currently run ENSNode v1.13. If you are querying them from your own app, you **must** use `enskit@1.13.1` and `enssdk@1.13.1`. The latest published versions (`1.14.0+`) contain breaking changes in the Omnigraph API data model not yet deployed to our hosted infrastructure. This notice will be removed once the hosted instances are upgraded.
+
 ```sh
 # from the ENSNode monorepo root
 pnpm install

--- a/examples/enssdk-example/README.md
+++ b/examples/enssdk-example/README.md
@@ -6,6 +6,8 @@ Companion to the [enssdk integration guide](https://ensnode.io/docs/integrate/in
 
 ## Usage (with NameHash Hosted Instance)
 
+> **Version compatibility:** Our hosted ENSNode instances currently run ENSNode v1.13. If you are querying them from your own app, you **must** use `enssdk@1.13.1`. The latest published version (`1.14.0+`) contains breaking changes in the Omnigraph API data model not yet deployed to our hosted infrastructure. This notice will be removed once the hosted instances are upgraded.
+
 ```sh
 # from the ENSNode monorepo root
 pnpm install

--- a/examples/omnigraph-graphql-example/README.md
+++ b/examples/omnigraph-graphql-example/README.md
@@ -8,6 +8,8 @@ Companion to the [ENS Omnigraph GraphQL API integration guide](https://ensnode.i
 
 ## Usage (with NameHash Hosted Instance)
 
+> **Version compatibility:** Our hosted ENSNode instances currently run ENSNode v1.13. If you are querying them from your own app, you **must** use `enssdk@1.13.1` (and `enskit@1.13.1` when using React). The latest published versions (`1.14.0+`) contain breaking changes in the Omnigraph API data model not yet deployed to our hosted infrastructure. This notice will be removed once the hosted instances are upgraded.
+
 ```sh
 # from the ENSNode monorepo root
 pnpm install

--- a/packages/enskit/README.md
+++ b/packages/enskit/README.md
@@ -1,5 +1,19 @@
 # enskit
 
+The React toolkit for ENSv2 development. Provides typed Omnigraph API hooks, providers, and utilities powered by [`urql`](https://nearform.com/open-source/urql/) and [`gql.tada`](https://gql-tada.0no.co/).
+
 This package name is reserved for the [ENSNode](https://ensnode.io) project by [NameHash Labs](https://namehashlabs.org).
 
 For more information, visit [ensnode.io](https://ensnode.io).
+
+## Installation
+
+```bash
+npm install enskit enssdk
+```
+
+> **Version compatibility:** Our hosted ENSNode instances currently run ENSNode v1.13. If you are querying them from your own app, you **must** use `enskit@1.13.1` and `enssdk@1.13.1`. The latest published versions (`1.14.0+`) contain breaking changes in the Omnigraph API data model not yet deployed to our hosted infrastructure. This notice will be removed once the hosted instances are upgraded.
+>
+> ```bash
+> npm install enskit@1.13.1 enssdk@1.13.1
+> ```

--- a/packages/enssdk/README.md
+++ b/packages/enssdk/README.md
@@ -10,6 +10,12 @@ Learn more about [ENSNode](https://ensnode.io/) from [the ENSNode docs](https://
 npm install enssdk
 ```
 
+> **Version compatibility:** Our hosted ENSNode instances currently run ENSNode v1.13. If you are querying them from your own app, you **must** use `enssdk@1.13.1`. The latest published version (`1.14.0+`) contains breaking changes in the Omnigraph API data model not yet deployed to our hosted infrastructure. This notice will be removed once the hosted instances are upgraded.
+>
+> ```bash
+> npm install enssdk@1.13.1
+> ```
+
 ## Usage
 
 ### Core Client


### PR DESCRIPTION
# Lite PR

[Tip: Review docs on the ENSNode PR process](https://ensnode.io/docs/contributing/prs)

## Summary

- Adds a temporary note highlighting the compatibility requirements for ENSNode `v1.13` that is currently running in production.

---

## Why

- We need to be explicit about the breaking changes introduced to the Omnigraph API data model in ENSNode `v1.14`.

---

## Testing

- How this was tested.
- If you didn't test it, say why.

---

## Notes for Reviewer (Optional)

- Anything non-obvious or worth a heads-up.

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)
