### PR TITLE
fix: enable publishing of enscli

### DIFF
--- a/packages/enscli/package.json
+++ b/packages/enscli/package.json
@@ -1,5 +1,4 @@
 {
-  "private": true,
   "name": "enscli",
   "version": "1.14.0",
   "description": "Reserved for the ENSNode project by NameHash Labs. See https://ensnode.io",


### PR DESCRIPTION
makes enscli package public so changesets starts to publish it