### PR TITLE
feat(omnigraph): ENSIP-15 beautified Name & Label fields

### DIFF
--- a/.changeset/ensapi-beautified-fields.md
+++ b/.changeset/ensapi-beautified-fields.md
@@ -1,0 +1,5 @@
+---
+"ensapi": minor
+---
+
+**Omnigraph**: add `BeautifiedName` and `BeautifiedLabel` scalars, a `CanonicalName.beautified: BeautifiedName!` field, and a `Label.beautified: BeautifiedLabel!` field. These expose the Name/Label beautified per [ENSIP-15](https://docs.ens.domains/ensip/15) for display — continue using `interpreted` for navigation targets and lookup keys.

--- a/.changeset/enssdk-beautify-interpreted-label.md
+++ b/.changeset/enssdk-beautify-interpreted-label.md
@@ -1,0 +1,5 @@
+---
+"enssdk": minor
+---
+
+Add `beautifyInterpretedLabel`, which beautifies a single `InterpretedLabel` per [ENSIP-15](https://docs.ens.domains/ensip/15), preserving Encoded LabelHashes verbatim, and returns the new `BeautifiedLabel` branded type. `beautifyInterpretedName` is now defined in terms of `beautifyInterpretedLabel`.

--- a/apps/ensapi/src/omnigraph-api/builder.ts
+++ b/apps/ensapi/src/omnigraph-api/builder.ts
@@ -6,6 +6,8 @@ import TracingPlugin, { isRootField } from "@pothos/plugin-tracing";
 import ZodPlugin from "@pothos/plugin-zod";
 import { AttributeNames, createOpenTelemetryWrapper } from "@pothos/tracing-opentelemetry";
 import type {
+  BeautifiedLabel,
+  BeautifiedName,
   ChainId,
   CoinType,
   DomainId,
@@ -66,6 +68,8 @@ export type BuilderScalars = {
   Node: { Input: Node; Output: Node };
   InterpretedName: { Input: InterpretedName; Output: InterpretedName };
   InterpretedLabel: { Input: InterpretedLabel; Output: InterpretedLabel };
+  BeautifiedName: { Input: BeautifiedName; Output: BeautifiedName };
+  BeautifiedLabel: { Input: BeautifiedLabel; Output: BeautifiedLabel };
   DomainId: { Input: DomainId; Output: DomainId };
   RegistryId: { Input: RegistryId; Output: RegistryId };
   ResolverId: { Input: ResolverId; Output: ResolverId };

--- a/apps/ensapi/src/omnigraph-api/schema/canonical-name.ts
+++ b/apps/ensapi/src/omnigraph-api/schema/canonical-name.ts
@@ -1,3 +1,5 @@
+import { beautifyInterpretedName } from "enssdk";
+
 import { builder } from "@/omnigraph-api/builder";
 import type { Domain } from "@/omnigraph-api/schema/domain";
 
@@ -22,6 +24,21 @@ CanonicalNameRef.implement({
         }
 
         return domain.canonicalName;
+      },
+    }),
+    beautified: t.field({
+      description:
+        "The Canonical Name as a BeautifiedName: the InterpretedName with its normalized labels beautified per ENSIP-15 (https://docs.ens.domains/ensip/15) for display. Encoded LabelHash labels are preserved verbatim. Display-only; use `interpreted` for navigation targets and lookup keys.",
+      type: "BeautifiedName",
+      nullable: false,
+      resolve: (domain) => {
+        if (!domain.canonicalName) {
+          throw new Error(
+            `Invariant(CanonicalName.beautified): canonical Domain '${domain.id}' is missing canonicalName.`,
+          );
+        }
+
+        return beautifyInterpretedName(domain.canonicalName);
       },
     }),
   }),

--- a/apps/ensapi/src/omnigraph-api/schema/label.ts
+++ b/apps/ensapi/src/omnigraph-api/schema/label.ts
@@ -1,3 +1,5 @@
+import { beautifyInterpretedLabel } from "enssdk";
+
 import type { ensIndexerSchema } from "@/lib/ensdb/singleton";
 import { builder } from "@/omnigraph-api/builder";
 
@@ -25,6 +27,17 @@ LabelRef.implement({
       type: "InterpretedLabel",
       nullable: false,
       resolve: (parent) => parent.interpreted,
+    }),
+
+    ///////////////////
+    // Label.beautified
+    ///////////////////
+    beautified: t.field({
+      description:
+        "The Label as a BeautifiedLabel: the Interpreted Label beautified per ENSIP-15 (https://docs.ens.domains/ensip/15) for display. An Encoded LabelHash is preserved verbatim. Display-only; use `interpreted` for lookup keys. \n(@see https://ensnode.io/docs/reference/terminology#interpreted-label)",
+      type: "BeautifiedLabel",
+      nullable: false,
+      resolve: (parent) => beautifyInterpretedLabel(parent.interpreted),
     }),
   }),
 });

--- a/apps/ensapi/src/omnigraph-api/schema/scalars.ts
+++ b/apps/ensapi/src/omnigraph-api/schema/scalars.ts
@@ -1,6 +1,8 @@
 import {
   asInterpretedLabel,
   asInterpretedName,
+  type BeautifiedLabel,
+  type BeautifiedName,
   type ChainId,
   type CoinType,
   type DomainId,
@@ -128,6 +130,28 @@ builder.scalarType("InterpretedLabel", {
         }
       })
       .transform((val) => asInterpretedLabel(val))
+      .parse(value),
+});
+
+builder.scalarType("BeautifiedName", {
+  description:
+    "BeautifiedName represents a enssdk#BeautifiedName: an InterpretedName whose normalized labels have been beautified per ENSIP-15 (https://docs.ens.domains/ensip/15) for display. It is display-only and MUST NOT be used as a navigation target or lookup key.",
+  serialize: (value: BeautifiedName) => value,
+  parseValue: (value) =>
+    z.coerce
+      .string()
+      .transform((val) => val as BeautifiedName)
+      .parse(value),
+});
+
+builder.scalarType("BeautifiedLabel", {
+  description:
+    "BeautifiedLabel represents a enssdk#BeautifiedLabel: an InterpretedLabel beautified per ENSIP-15 (https://docs.ens.domains/ensip/15) for display. It is display-only and MUST NOT be used as a lookup key.",
+  serialize: (value: BeautifiedLabel) => value,
+  parseValue: (value) =>
+    z.coerce
+      .string()
+      .transform((val) => val as BeautifiedLabel)
       .parse(value),
 });
 

--- a/apps/ensapi/src/omnigraph-api/schema/scalars.ts
+++ b/apps/ensapi/src/omnigraph-api/schema/scalars.ts
@@ -64,19 +64,19 @@ builder.scalarType("Hex", {
 });
 
 builder.scalarType("ChainId", {
-  description: "ChainId represents a enssdk#ChainId.",
+  description: "ChainId represents an enssdk#ChainId.",
   serialize: (value: ChainId) => value,
   parseValue: (value) => makeChainIdSchema("ChainId").parse(value),
 });
 
 builder.scalarType("CoinType", {
-  description: "CoinType represents a enssdk#CoinType.",
+  description: "CoinType represents an enssdk#CoinType.",
   serialize: (value: CoinType) => value,
   parseValue: (value) => makeCoinTypeSchema("CoinType").parse(value),
 });
 
 builder.scalarType("Node", {
-  description: "Node represents a enssdk#Node.",
+  description: "Node represents an enssdk#Node.",
   serialize: (value: Node) => value,
   parseValue: (value) =>
     z.coerce
@@ -95,7 +95,7 @@ builder.scalarType("Node", {
 });
 
 builder.scalarType("InterpretedName", {
-  description: "InterpretedName represents a enssdk#InterpretedName.",
+  description: "InterpretedName represents an enssdk#InterpretedName.",
   serialize: (value: Name) => value,
   parseValue: (value) =>
     z.coerce
@@ -115,7 +115,7 @@ builder.scalarType("InterpretedName", {
 });
 
 builder.scalarType("InterpretedLabel", {
-  description: "InterpretedLabel represents a enssdk#InterpretedLabel.",
+  description: "InterpretedLabel represents an enssdk#InterpretedLabel.",
   serialize: (value: Name) => value,
   parseValue: (value) =>
     z.coerce
@@ -135,7 +135,7 @@ builder.scalarType("InterpretedLabel", {
 
 builder.scalarType("BeautifiedName", {
   description:
-    "BeautifiedName represents a enssdk#BeautifiedName: an InterpretedName whose normalized labels have been beautified per ENSIP-15 (https://docs.ens.domains/ensip/15) for display. It is display-only and MUST NOT be used as a navigation target or lookup key.",
+    "BeautifiedName represents an enssdk#BeautifiedName: an InterpretedName whose normalized labels have been beautified per ENSIP-15 (https://docs.ens.domains/ensip/15) for display. It is display-only and MUST NOT be used as a navigation target or lookup key.",
   serialize: (value: BeautifiedName) => value,
   parseValue: (value) =>
     z.coerce
@@ -146,7 +146,7 @@ builder.scalarType("BeautifiedName", {
 
 builder.scalarType("BeautifiedLabel", {
   description:
-    "BeautifiedLabel represents a enssdk#BeautifiedLabel: an InterpretedLabel beautified per ENSIP-15 (https://docs.ens.domains/ensip/15) for display. It is display-only and MUST NOT be used as a lookup key.",
+    "BeautifiedLabel represents an enssdk#BeautifiedLabel: an InterpretedLabel beautified per ENSIP-15 (https://docs.ens.domains/ensip/15) for display. It is display-only and MUST NOT be used as a lookup key.",
   serialize: (value: BeautifiedLabel) => value,
   parseValue: (value) =>
     z.coerce
@@ -156,7 +156,7 @@ builder.scalarType("BeautifiedLabel", {
 });
 
 builder.scalarType("DomainId", {
-  description: "DomainId represents a enssdk#DomainId.",
+  description: "DomainId represents an enssdk#DomainId.",
   serialize: (value: DomainId) => value,
   parseValue: (value) =>
     z.coerce
@@ -166,7 +166,7 @@ builder.scalarType("DomainId", {
 });
 
 builder.scalarType("RegistryId", {
-  description: "RegistryId represents a enssdk#RegistryId.",
+  description: "RegistryId represents an enssdk#RegistryId.",
   serialize: (value: RegistryId) => value,
   parseValue: (value) =>
     z.coerce
@@ -176,7 +176,7 @@ builder.scalarType("RegistryId", {
 });
 
 builder.scalarType("ResolverId", {
-  description: "ResolverId represents a enssdk#ResolverId.",
+  description: "ResolverId represents an enssdk#ResolverId.",
   serialize: (value: ResolverId) => value,
   parseValue: (value) =>
     z.coerce
@@ -186,7 +186,7 @@ builder.scalarType("ResolverId", {
 });
 
 builder.scalarType("PermissionsId", {
-  description: "PermissionsId represents a enssdk#PermissionsId.",
+  description: "PermissionsId represents an enssdk#PermissionsId.",
   serialize: (value: PermissionsId) => value,
   parseValue: (value) =>
     z.coerce
@@ -196,7 +196,7 @@ builder.scalarType("PermissionsId", {
 });
 
 builder.scalarType("PermissionsResourceId", {
-  description: "PermissionsResourceId represents a enssdk#PermissionsResourceId.",
+  description: "PermissionsResourceId represents an enssdk#PermissionsResourceId.",
   serialize: (value: PermissionsResourceId) => value,
   parseValue: (value) =>
     z.coerce
@@ -206,7 +206,7 @@ builder.scalarType("PermissionsResourceId", {
 });
 
 builder.scalarType("PermissionsUserId", {
-  description: "PermissionsUserId represents a enssdk#PermissionsUserId.",
+  description: "PermissionsUserId represents an enssdk#PermissionsUserId.",
   serialize: (value: PermissionsUserId) => value,
   parseValue: (value) =>
     z.coerce
@@ -216,7 +216,7 @@ builder.scalarType("PermissionsUserId", {
 });
 
 builder.scalarType("RegistrationId", {
-  description: "RegistrationId represents a enssdk#RegistrationId.",
+  description: "RegistrationId represents an enssdk#RegistrationId.",
   serialize: (value: RegistrationId) => value,
   parseValue: (value) =>
     z.coerce
@@ -226,7 +226,7 @@ builder.scalarType("RegistrationId", {
 });
 
 builder.scalarType("RenewalId", {
-  description: "RenewalId represents a enssdk#RenewalId.",
+  description: "RenewalId represents an enssdk#RenewalId.",
   serialize: (value: RenewalId) => value,
   parseValue: (value) =>
     z.coerce
@@ -236,7 +236,7 @@ builder.scalarType("RenewalId", {
 });
 
 builder.scalarType("ResolverRecordsId", {
-  description: "ResolverRecordsId represents a enssdk#ResolverRecordsId.",
+  description: "ResolverRecordsId represents an enssdk#ResolverRecordsId.",
   serialize: (value: ResolverRecordsId) => value,
   parseValue: (value) =>
     z.coerce

--- a/packages/enssdk/src/lib/beautify.test.ts
+++ b/packages/enssdk/src/lib/beautify.test.ts
@@ -1,8 +1,21 @@
 import { describe, expect, it } from "vitest";
 
-import { beautifyInterpretedName } from "./beautify";
+import { beautifyInterpretedLabel, beautifyInterpretedName } from "./beautify";
 import { ENS_ROOT_NAME } from "./constants";
 import { asInterpretedName } from "./interpreted-names-and-labels";
+import type { InterpretedLabel } from "./types";
+
+describe("beautifyInterpretedLabel", () => {
+  it("beautifies a normalized label", () => {
+    expect(beautifyInterpretedLabel("♾♾♾♾" as InterpretedLabel)).toEqual("♾️♾️♾️♾️");
+  });
+
+  it("preserves an Encoded LabelHash label verbatim", () => {
+    const label =
+      "[0000000000000000000000000000000000000000000000000000000000000001]" as InterpretedLabel;
+    expect(beautifyInterpretedLabel(label)).toEqual(label);
+  });
+});
 
 describe("beautifyInterpretedName", () => {
   it("returns the ENS Root Name unchanged", () => {

--- a/packages/enssdk/src/lib/beautify.ts
+++ b/packages/enssdk/src/lib/beautify.ts
@@ -1,17 +1,31 @@
 import { ens_beautify } from "@adraffy/ens-normalize";
 
-import { ENS_ROOT_NAME } from "./constants";
 import { interpretedNameToInterpretedLabels } from "./interpreted-names-and-labels";
 import { isEncodedLabelHash } from "./labelhash";
-import type { BeautifiedName, InterpretedName } from "./types";
+import type { BeautifiedLabel, BeautifiedName, InterpretedLabel, InterpretedName } from "./types";
 
 /**
- * Converts an {@link InterpretedName} into a {@link BeautifiedName} suitable for presentation in a UI.
+ * Converts an {@link InterpretedLabel} into a {@link BeautifiedLabel} suitable for presentation in a UI.
  *
- * Each label of the InterpretedName is either an Encoded LabelHash or a normalized Label:
  * - Encoded LabelHash labels are preserved verbatim.
  * - Normalized Labels are passed through {@link ens_beautify}, producing a Label that is
  *   normalizable (and normalizes back to the input) but may itself be unnormalized.
+ *
+ * The resulting BeautifiedLabel is suitable for display but is NOT an InterpretedLabel, and the
+ * branded return type prevents it from being passed to APIs that expect one. Continue to use the
+ * source InterpretedLabel for lookup keys and anywhere else that expects an InterpretedLabel.
+ *
+ * @example
+ * ```ts
+ * beautifyInterpretedLabel("♾♾♾♾" as InterpretedLabel) // → "♾️♾️♾️♾️"
+ * ```
+ */
+export const beautifyInterpretedLabel = (label: InterpretedLabel): BeautifiedLabel =>
+  (isEncodedLabelHash(label) ? label : ens_beautify(label)) as BeautifiedLabel;
+
+/**
+ * Converts an {@link InterpretedName} into a {@link BeautifiedName} suitable for presentation in a UI
+ * by beautifying each of its labels via {@link beautifyInterpretedLabel}.
  *
  * The resulting BeautifiedName is suitable for display but is NOT an InterpretedName, and the
  * branded return type prevents it from being passed to APIs that expect one. Continue to use the
@@ -23,10 +37,7 @@ import type { BeautifiedName, InterpretedName } from "./types";
  * beautifyInterpretedName("♾♾♾♾.eth" as InterpretedName) // → "♾️♾️♾️♾️.eth"
  * ```
  */
-export const beautifyInterpretedName = (name: InterpretedName): BeautifiedName => {
-  if (name === ENS_ROOT_NAME) return name as string as BeautifiedName;
-
-  return interpretedNameToInterpretedLabels(name)
-    .map((label) => (isEncodedLabelHash(label) ? label : ens_beautify(label)))
+export const beautifyInterpretedName = (name: InterpretedName): BeautifiedName =>
+  interpretedNameToInterpretedLabels(name)
+    .map(beautifyInterpretedLabel)
     .join(".") as BeautifiedName;
-};

--- a/packages/enssdk/src/lib/types/ens.ts
+++ b/packages/enssdk/src/lib/types/ens.ts
@@ -111,6 +111,23 @@ export type LiteralLabel = Label & { __brand: "LiteralLabel" };
 export type InterpretedLabel = Label & { __brand: "InterpretedLabel" };
 
 /**
+ * A Beautified Label is a Label produced for presentation in a UI from an {@link InterpretedLabel}.
+ *
+ * It is either:
+ * a) an Encoded LabelHash, preserved verbatim from the source InterpretedLabel, or
+ * b) a Label produced by passing a normalized Label through ENSIP-15 beautification, which is
+ *    guaranteed to be normalizable back to the original normalized Label but is itself NOT
+ *    necessarily normalized (e.g. `"♾"` → `"♾️"`).
+ *
+ * Because (b) is not guaranteed to be normalized, a BeautifiedLabel is NOT an InterpretedLabel and
+ * MUST NOT be used as a lookup key or anywhere else that expects an InterpretedLabel.
+ *
+ * @see https://docs.ens.domains/ensip/15
+ * @dev nominally typed to enforce usage & enhance codebase clarity
+ */
+export type BeautifiedLabel = Label & { __brand: "BeautifiedLabel" };
+
+/**
  * A Literal Name is a Name as it literally appears onchain, composed of 0 or more Literal Labels
  * joined by dots. It may be an unnormalized name for reasons including:
  * - containing empty labels,
@@ -154,6 +171,7 @@ export type InterpretedName = Name & { __brand: "InterpretedName" };
  * MUST NOT be used as a navigation target, lookup key, or anywhere else that expects an
  * InterpretedName.
  *
+ * @see https://docs.ens.domains/ensip/15
  * @dev nominally typed to enforce usage & enhance codebase clarity
  */
 export type BeautifiedName = Name & { __brand: "BeautifiedName" };

--- a/packages/enssdk/src/omnigraph/generated/introspection.ts
+++ b/packages/enssdk/src/omnigraph/generated/introspection.ts
@@ -1031,6 +1031,14 @@ const introspection = {
       },
       {
         "kind": "SCALAR",
+        "name": "BeautifiedLabel"
+      },
+      {
+        "kind": "SCALAR",
+        "name": "BeautifiedName"
+      },
+      {
+        "kind": "SCALAR",
         "name": "BigInt"
       },
       {
@@ -1041,6 +1049,18 @@ const introspection = {
         "kind": "OBJECT",
         "name": "CanonicalName",
         "fields": [
+          {
+            "name": "beautified",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "BeautifiedName"
+              }
+            },
+            "args": [],
+            "isDeprecated": false
+          },
           {
             "name": "interpreted",
             "type": {
@@ -3571,6 +3591,18 @@ const introspection = {
         "kind": "OBJECT",
         "name": "Label",
         "fields": [
+          {
+            "name": "beautified",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "BeautifiedLabel"
+              }
+            },
+            "args": [],
+            "isDeprecated": false
+          },
           {
             "name": "hash",
             "type": {

--- a/packages/enssdk/src/omnigraph/generated/schema.graphql
+++ b/packages/enssdk/src/omnigraph/generated/schema.graphql
@@ -207,12 +207,12 @@ type BaseRegistrarRegistration implements Registration {
 }
 
 """
-BeautifiedLabel represents a enssdk#BeautifiedLabel: an InterpretedLabel beautified per ENSIP-15 (https://docs.ens.domains/ensip/15) for display. It is display-only and MUST NOT be used as a lookup key.
+BeautifiedLabel represents an enssdk#BeautifiedLabel: an InterpretedLabel beautified per ENSIP-15 (https://docs.ens.domains/ensip/15) for display. It is display-only and MUST NOT be used as a lookup key.
 """
 scalar BeautifiedLabel
 
 """
-BeautifiedName represents a enssdk#BeautifiedName: an InterpretedName whose normalized labels have been beautified per ENSIP-15 (https://docs.ens.domains/ensip/15) for display. It is display-only and MUST NOT be used as a navigation target or lookup key.
+BeautifiedName represents an enssdk#BeautifiedName: an InterpretedName whose normalized labels have been beautified per ENSIP-15 (https://docs.ens.domains/ensip/15) for display. It is display-only and MUST NOT be used as a navigation target or lookup key.
 """
 scalar BeautifiedName
 
@@ -232,10 +232,10 @@ type CanonicalName {
   interpreted: InterpretedName!
 }
 
-"""ChainId represents a enssdk#ChainId."""
+"""ChainId represents an enssdk#ChainId."""
 scalar ChainId
 
-"""CoinType represents a enssdk#CoinType."""
+"""CoinType represents an enssdk#CoinType."""
 scalar CoinType
 
 """
@@ -321,7 +321,7 @@ type DomainEventsConnectionEdge {
   node: Event!
 }
 
-"""DomainId represents a enssdk#DomainId."""
+"""DomainId represents an enssdk#DomainId."""
 scalar DomainId
 
 """Reference a specific Domain."""
@@ -856,10 +856,10 @@ input EventsWhereInput {
 """Hex represents viem#Hex."""
 scalar Hex
 
-"""InterpretedLabel represents a enssdk#InterpretedLabel."""
+"""InterpretedLabel represents an enssdk#InterpretedLabel."""
 scalar InterpretedLabel
 
-"""InterpretedName represents a enssdk#InterpretedName."""
+"""InterpretedName represents an enssdk#InterpretedName."""
 scalar InterpretedName
 
 """
@@ -940,7 +940,7 @@ type NameWrapperRegistration implements Registration {
   unregistrant: Account
 }
 
-"""Node represents a enssdk#Node."""
+"""Node represents an enssdk#Node."""
 scalar Node
 
 """Sort direction"""
@@ -985,7 +985,7 @@ type PermissionsEventsConnectionEdge {
   node: Event!
 }
 
-"""PermissionsId represents a enssdk#PermissionsId."""
+"""PermissionsId represents an enssdk#PermissionsId."""
 scalar PermissionsId
 
 """Address Permissions by ID or AccountId."""
@@ -1012,7 +1012,7 @@ type PermissionsResource {
   users(after: String, before: String, first: Int, last: Int): PermissionsResourceUsersConnection
 }
 
-"""PermissionsResourceId represents a enssdk#PermissionsResourceId."""
+"""PermissionsResourceId represents an enssdk#PermissionsResourceId."""
 scalar PermissionsResourceId
 
 type PermissionsResourceUsersConnection {
@@ -1071,7 +1071,7 @@ type PermissionsUserEventsConnectionEdge {
   node: Event!
 }
 
-"""PermissionsUserId represents a enssdk#PermissionsUserId."""
+"""PermissionsUserId represents an enssdk#PermissionsUserId."""
 scalar PermissionsUserId
 
 type Query {
@@ -1200,7 +1200,7 @@ interface Registration {
   unregistrant: Account
 }
 
-"""RegistrationId represents a enssdk#RegistrationId."""
+"""RegistrationId represents an enssdk#RegistrationId."""
 scalar RegistrationId
 
 type RegistrationRenewalsConnection {
@@ -1256,7 +1256,7 @@ input RegistryDomainsWhereInput {
   name: DomainsNameFilter
 }
 
-"""RegistryId represents a enssdk#RegistryId."""
+"""RegistryId represents an enssdk#RegistryId."""
 scalar RegistryId
 
 """Address a Registry by ID or AccountId."""
@@ -1316,7 +1316,7 @@ type Renewal {
   referrer: Hex
 }
 
-"""RenewalId represents a enssdk#RenewalId."""
+"""RenewalId represents an enssdk#RenewalId."""
 scalar RenewalId
 
 """A Resolver represents a Resolver contract on-chain."""
@@ -1356,7 +1356,7 @@ type ResolverEventsConnectionEdge {
   node: Event!
 }
 
-"""ResolverId represents a enssdk#ResolverId."""
+"""ResolverId represents an enssdk#ResolverId."""
 scalar ResolverId
 
 """Address a Resolver by ID or AccountId."""
@@ -1413,7 +1413,7 @@ type ResolverRecordsConnectionEdge {
   node: ResolverRecords!
 }
 
-"""ResolverRecordsId represents a enssdk#ResolverRecordsId."""
+"""ResolverRecordsId represents an enssdk#ResolverRecordsId."""
 scalar ResolverRecordsId
 
 """Filter for Domain.subdomains query."""

--- a/packages/enssdk/src/omnigraph/generated/schema.graphql
+++ b/packages/enssdk/src/omnigraph/generated/schema.graphql
@@ -206,11 +206,26 @@ type BaseRegistrarRegistration implements Registration {
   wrapped: WrappedBaseRegistrarRegistration
 }
 
+"""
+BeautifiedLabel represents a enssdk#BeautifiedLabel: an InterpretedLabel beautified per ENSIP-15 (https://docs.ens.domains/ensip/15) for display. It is display-only and MUST NOT be used as a lookup key.
+"""
+scalar BeautifiedLabel
+
+"""
+BeautifiedName represents a enssdk#BeautifiedName: an InterpretedName whose normalized labels have been beautified per ENSIP-15 (https://docs.ens.domains/ensip/15) for display. It is display-only and MUST NOT be used as a navigation target or lookup key.
+"""
+scalar BeautifiedName
+
 """BigInt represents non-fractional signed whole numeric values."""
 scalar BigInt
 
 """A Canonical Name, exposed in each representation we support."""
 type CanonicalName {
+  """
+  The Canonical Name as a BeautifiedName: the InterpretedName with its normalized labels beautified per ENSIP-15 (https://docs.ens.domains/ensip/15) for display. Encoded LabelHash labels are preserved verbatim. Display-only; use `interpreted` for navigation targets and lookup keys.
+  """
+  beautified: BeautifiedName!
+
   """
   The Canonical Name as an InterpretedName: each label is either a normalized literal Label or an Encoded LabelHash.
   """
@@ -851,6 +866,12 @@ scalar InterpretedName
 Represents a Label within ENS, providing its hash and interpreted representation.
 """
 type Label {
+  """
+  The Label as a BeautifiedLabel: the Interpreted Label beautified per ENSIP-15 (https://docs.ens.domains/ensip/15) for display. An Encoded LabelHash is preserved verbatim. Display-only; use `interpreted` for lookup keys. 
+  (@see https://ensnode.io/docs/reference/terminology#interpreted-label)
+  """
+  beautified: BeautifiedLabel!
+
   """
   The Label's LabelHash
   (@see https://ensnode.io/docs/reference/terminology#labels-labelhashes-labelhash-function)

--- a/packages/enssdk/src/omnigraph/graphql.ts
+++ b/packages/enssdk/src/omnigraph/graphql.ts
@@ -1,6 +1,8 @@
 import { initGraphQLTada } from "gql.tada";
 
 import type {
+  BeautifiedLabel,
+  BeautifiedName,
   ChainId,
   CoinType,
   DomainId,
@@ -42,6 +44,8 @@ export type OmnigraphScalars = {
   CoinType: CoinType;
   InterpretedName: InterpretedName;
   InterpretedLabel: InterpretedLabel;
+  BeautifiedName: BeautifiedName;
+  BeautifiedLabel: BeautifiedLabel;
   Node: Node;
   DomainId: DomainId;
   RegistryId: RegistryId;


### PR DESCRIPTION
## Summary

- enssdk: add `beautifyInterpretedLabel` (Encoded LabelHashes verbatim, else `ens_beautify`) + `BeautifiedLabel` branded type; `beautifyInterpretedName` now maps over it.
- omnigraph: add `BeautifiedName`/`BeautifiedLabel` scalars, `CanonicalName.beautified: BeautifiedName!`, and `Label.beautified: BeautifiedLabel!` (beautified per ENSIP-15).

## Why

- expose ENSIP-15 beautification server-side so consumers render `canonical { name { beautified } }` directly instead of calling `beautifyInterpretedName` client-side. closes #1501.

## Testing

- added `beautifyInterpretedLabel` unit tests (normalized label + Encoded LabelHash passthrough).
- `pnpm generate`, full `pnpm typecheck`, `pnpm lint`, and affected `pnpm test --project enssdk --project ensapi` all pass.

## Notes for Reviewer (Optional)

- the `beautified` fields are display-only — `interpreted` remains the value to use for navigation targets and lookup keys; descriptions say so and link ENSIP-15.
- example apps and docs walkthroughs still call `beautifyInterpretedName` client-side; migrating them to the new fields is deferred to #2160 (sub-issue of #1360), gated on 1.14.x prod + v2-sepolia canonical materialization.

## Checklist

- [x] This PR does **not** change runtime behavior or semantics
- [x] This PR is low-risk and safe to review quickly
