### PR TITLE
fix(ensindexer): repair canonicality cascade Phase B (execute() result + array binding)

### DIFF
--- a/.changeset/sparkly-teams-cross.md
+++ b/.changeset/sparkly-teams-cross.md
@@ -1,0 +1,5 @@
+---
+"ensindexer": patch
+---
+
+ENSIndexer no longer crashes at Basenames/Lineanames L1 Resolver update block.

--- a/apps/ensindexer/src/lib/ensv2/canonicality-db-helpers.ts
+++ b/apps/ensindexer/src/lib/ensv2/canonicality-db-helpers.ts
@@ -536,7 +536,7 @@ async function cascadeCanonicality(
     await context.ensDb.sql.execute(sql`
       UPDATE ${ensIndexerSchema.domain} AS d
         SET canonical_node = upd.canonical_node
-        FROM unnest(${ids}::text[], ${nodes}::text[]) AS upd(id, canonical_node)
+        FROM unnest(${sql.param(ids)}::text[], ${sql.param(nodes)}::text[]) AS upd(id, canonical_node)
         WHERE d.id = upd.id;
     `);
   }

--- a/apps/ensindexer/src/lib/ensv2/canonicality-db-helpers.ts
+++ b/apps/ensindexer/src/lib/ensv2/canonicality-db-helpers.ts
@@ -523,7 +523,11 @@ async function cascadeCanonicality(
   // https://github.com/namehash/ensnode/issues/1962
   if (!nextCanonical) return;
 
-  const rows = changed.rows as { id: DomainId; canonical_label_hash_path: LabelHashPath }[];
+  // NOTE: Ponder types `db.sql` as a NodePg/Pglite Drizzle (whose `.execute()` resolves to a
+  // `{ rows }` result), but at runtime it's a pg-proxy Drizzle whose `.execute()` resolves to the
+  // rows array directly. The declared type lies (Ponder `@ts-ignore`s the mismatch), so reading
+  // `changed.rows` is `undefined` at runtime — `changed` itself is the array.
+  const rows = changed as unknown as { id: DomainId; canonical_label_hash_path: LabelHashPath }[];
   for (let i = 0; i < rows.length; i += CANONICAL_NODE_UPDATE_BATCH_SIZE) {
     const batch = rows.slice(i, i + CANONICAL_NODE_UPDATE_BATCH_SIZE);
     const ids = batch.map((r) => r.id);


### PR DESCRIPTION
Two bugs in `cascadeCanonicality` Phase B, both surfaced on the same `unigraph,protocol-acceleration` mainnet run. Phase B only executes when a cascade flips a registry **to** canonical and that registry has descendants — the first such event was mainnet block 20421425, which is why neither bug had appeared before.

## 1. `execute()` result read as `{ rows }` instead of an array

`changed.rows` was `undefined` at runtime → `Cannot read properties of undefined (reading 'length')`.

Ponder types `context.db.sql` as `NodePgDatabase | PgliteDatabase` (whose `.execute()` returns a `{ rows }` result), but builds it at runtime with the **pg-proxy** driver, whose `.execute()` returns the bare row array (`pg-proxy/session.js` → `return rows`). Ponder bridges the two with a `@ts-ignore`, so `changed.rows` typechecked against a value that's really an array. Fix: read `changed` directly.

## 2. `canonical_node` update arrays expanded into a ROW expression

Once Phase B got past #1, the batched update threw `ROW expressions can have at most 1664 entries`.

`unnest(${ids}::text[], ...)` interpolated JS arrays directly, which drizzle expands into a `(p1, …, pN)` ROW expression. Postgres caps ROW expressions at 1664 entries, so the 10,000-row batch blew the limit — and even under it, casting a ROW to `text[]` is invalid. Fix: wrap each array in `sql.param` so it binds as a single `text[]` parameter.

scope: two lines + a comment. the other two `db.sql.execute` calls in the file ignore their results, so they were unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)