### PR TITLE
move labelhash verification from ensrainbow client to ensrainbow server

### DIFF
--- a/.changeset/server-heal-labelhash-verify.md
+++ b/.changeset/server-heal-labelhash-verify.md
@@ -1,0 +1,6 @@
+---
+"ensrainbow": patch
+"@ensnode/ensrainbow-sdk": patch
+---
+
+Labelhash verification for heal responses now runs in `ensrainbow` (server) instead of `@ensnode/ensrainbow-sdk` (client). Malformed rainbow records — where the stored label does not hash back to the requested `labelHash` — are rejected as `NotFound`.

--- a/apps/ensrainbow/src/lib/server.test.ts
+++ b/apps/ensrainbow/src/lib/server.test.ts
@@ -143,8 +143,10 @@ describe("ENSRainbowServer", () => {
     });
 
     afterEach(async () => {
-      await server.close();
-      await rm(tempDir, { recursive: true, force: true });
+      await server?.close();
+      if (tempDir) {
+        await rm(tempDir, { recursive: true, force: true });
+      }
     });
 
     it("should heal a label when the stored label matches the requested labelHash", async () => {

--- a/apps/ensrainbow/src/lib/server.test.ts
+++ b/apps/ensrainbow/src/lib/server.test.ts
@@ -1,8 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import type { EnsRainbowClientLabelSet } from "@ensnode/ensrainbow-sdk";
+import { asLiteralLabel, labelhashLiteralLabel } from "enssdk";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import type { VersionedRainbowRecord } from "./rainbow-record";
+import { labelHashToBytes } from "@ensnode/ensnode-sdk";
+import { type EnsRainbowClientLabelSet, ErrorCode, StatusCode } from "@ensnode/ensrainbow-sdk";
+
+import { ENSRainbowDB } from "./database";
+import { buildEncodedVersionedRainbowRecord, type VersionedRainbowRecord } from "./rainbow-record";
 import { ENSRainbowServer } from "./server";
 
 describe("ENSRainbowServer", () => {
@@ -113,6 +120,61 @@ describe("ENSRainbowServer", () => {
       );
 
       expect(result).toBe(true);
+    });
+  });
+
+  describe("heal", () => {
+    let tempDir: string;
+    let db: ENSRainbowDB;
+    let server: ENSRainbowServer;
+
+    const clientLabelSet: EnsRainbowClientLabelSet = {
+      labelSetId: "test-label-set-id",
+    };
+
+    beforeEach(async () => {
+      tempDir = await mkdtemp(join(tmpdir(), "ensrainbow-test-server-heal-"));
+      db = await ENSRainbowDB.create(tempDir);
+      await db.setPrecalculatedRainbowRecordCount(0);
+      await db.markIngestionFinished();
+      await db.setLabelSetId("test-label-set-id");
+      await db.setHighestLabelSetVersion(0);
+      server = await ENSRainbowServer.init(db);
+    });
+
+    afterEach(async () => {
+      await server.close();
+      await rm(tempDir, { recursive: true, force: true });
+    });
+
+    it("should heal a label when the stored label matches the requested labelHash", async () => {
+      const label = asLiteralLabel("vitalik");
+      await db.addRainbowRecord(label, 0);
+
+      await expect(
+        server.heal(labelhashLiteralLabel(label), clientLabelSet),
+      ).resolves.toMatchObject({
+        status: StatusCode.Success,
+        label,
+      });
+    });
+
+    it("should reject a record whose label does not hash to the requested labelHash", async () => {
+      const storedLabel = asLiteralLabel("vitalik");
+      const requestedLabelHash = labelhashLiteralLabel(asLiteralLabel("ethereum"));
+
+      const batch = db.batch();
+      batch.put(
+        labelHashToBytes(requestedLabelHash),
+        buildEncodedVersionedRainbowRecord(storedLabel, 0),
+      );
+      await batch.write();
+
+      await expect(server.heal(requestedLabelHash, clientLabelSet)).resolves.toMatchObject({
+        status: StatusCode.Error,
+        error: "Label not found",
+        errorCode: ErrorCode.NotFound,
+      });
     });
   });
 });

--- a/apps/ensrainbow/src/lib/server.ts
+++ b/apps/ensrainbow/src/lib/server.ts
@@ -1,4 +1,4 @@
-import type { LabelHash } from "enssdk";
+import { asLiteralLabel, type LabelHash, labelhashLiteralLabel } from "enssdk";
 import type { ByteArray } from "viem";
 
 import { labelHashToBytes, validateSupportedLabelSetAndVersion } from "@ensnode/ensnode-sdk";
@@ -11,7 +11,7 @@ import {
 } from "@ensnode/ensrainbow-sdk";
 
 import type { DbConfig } from "@/config/types";
-import { type ENSRainbowDB, NoPrecalculatedCountError } from "@/lib/database";
+import { byteArraysEqual, type ENSRainbowDB, NoPrecalculatedCountError } from "@/lib/database";
 import type { VersionedRainbowRecord } from "@/lib/rainbow-record";
 import { getErrorMessage } from "@/utils/error-utils";
 import { logger } from "@/utils/logger";
@@ -198,6 +198,23 @@ export class ENSRainbowServer {
       }
 
       const { labelSetVersion: labelSetVersionNumber, label: actualLabel } = versionedRainbowRecord;
+
+      // avoid returning malformed heals, treating as not-found
+      const computedLabelHashBytes = labelHashToBytes(
+        labelhashLiteralLabel(asLiteralLabel(actualLabel)),
+      );
+      if (!byteArraysEqual(computedLabelHashBytes, labelHashBytes)) {
+        logger.error(
+          `Hash mismatch for healed label "${actualLabel}": requested=${labelHash}, computed=0x${Buffer.from(
+            computedLabelHashBytes,
+          ).toString("hex")}`,
+        );
+        return {
+          status: StatusCode.Error,
+          error: "Label not found",
+          errorCode: ErrorCode.NotFound,
+        } satisfies EnsRainbow.HealError;
+      }
 
       logger.info(
         `Successfully healed labelHash ${labelHash} to label "${actualLabel}" (set ${labelSetVersionNumber})`,

--- a/apps/ensrainbow/src/lib/server.ts
+++ b/apps/ensrainbow/src/lib/server.ts
@@ -200,6 +200,7 @@ export class ENSRainbowServer {
       const { labelSetVersion: labelSetVersionNumber, label: actualLabel } = versionedRainbowRecord;
 
       // avoid returning malformed heals, treating as not-found
+      // TODO: remove after fixing https://github.com/namehash/ensnode/issues/2188
       const computedLabelHashBytes = labelHashToBytes(
         labelhashLiteralLabel(asLiteralLabel(actualLabel)),
       );

--- a/packages/ensrainbow-sdk/src/client.test.ts
+++ b/packages/ensrainbow-sdk/src/client.test.ts
@@ -1,4 +1,3 @@
-import { asLiteralLabel, labelhashLiteralLabel } from "enssdk";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -124,29 +123,6 @@ describe("EnsRainbowApiClient", () => {
       status: StatusCode.Success,
       label: "vitalik",
     } satisfies EnsRainbow.HealSuccess);
-  });
-
-  it("should return a not found error for a malformed record whose label does not hash back to the labelHash", async () => {
-    // Malformed rainbow record: the on-chain label is `"007"` (quotes included), but a CSV-mangled
-    // label set heals it to `007` (quotes stripped), which hashes to a different labelHash. The
-    // client must reject it as unhealable rather than returning a label keyed under the wrong hash.
-    const labelHash = labelhashLiteralLabel(asLiteralLabel('"007"'));
-
-    mockFetch.mockResolvedValueOnce({
-      json: () =>
-        Promise.resolve({
-          status: StatusCode.Success,
-          label: "007", // quote-stripped; does not hash back to labelHash
-        } satisfies EnsRainbow.HealSuccess),
-    });
-
-    const response = await client.heal(labelHash);
-
-    expect(response).toEqual({
-      status: StatusCode.Error,
-      error: "Label not found",
-      errorCode: ErrorCode.NotFound,
-    } satisfies EnsRainbow.HealNotFoundError);
   });
 
   it("should return a not found error for an unknown labelHash", async () => {

--- a/packages/ensrainbow-sdk/src/client.ts
+++ b/packages/ensrainbow-sdk/src/client.ts
@@ -1,5 +1,5 @@
 import type { EncodedLabelHash, Label, LabelHash } from "enssdk";
-import { asLiteralLabel, labelhashLiteralLabel, parseLabelHashOrEncodedLabelHash } from "enssdk";
+import { parseLabelHashOrEncodedLabelHash } from "enssdk";
 
 import {
   buildEnsRainbowClientLabelSet,
@@ -379,19 +379,7 @@ export class EnsRainbowApiClient implements EnsRainbow.ApiClient {
     });
 
     const response = await fetch(url);
-    let healResponse = (await response.json()) as EnsRainbow.HealResponse;
-
-    // Sanity Check: avoid returning malformed heals to consumers, treating as not-found
-    if (
-      healResponse.status === StatusCode.Success &&
-      labelhashLiteralLabel(asLiteralLabel(healResponse.label)) !== normalizedLabelHash
-    ) {
-      healResponse = {
-        status: StatusCode.Error,
-        error: "Label not found",
-        errorCode: ErrorCode.NotFound,
-      } satisfies EnsRainbow.HealNotFoundError;
-    }
+    const healResponse = (await response.json()) as EnsRainbow.HealResponse;
 
     if (isCacheableHealResponse(healResponse)) {
       this.cache.set(normalizedLabelHash, healResponse);


### PR DESCRIPTION
# Lite PR

[Tip: Review docs on the ENSNode PR process](https://ensnode.io/docs/contributing/prs)

## Summary

- Move labelhash verification from `EnsRainbowApiClient` to `ENSRainbowServer.heal()` — the server now recomputes the hash of the stored label and rejects mismatches as `NotFound`.
- Add unit tests in `apps/ensrainbow/src/lib/server.test.ts` for matching and mismatched records.

---

## Why

A corrupted rainbow record can store a label under the wrong labelHash key (e.g. CSV ingestion mangling `"007"` → `007`). Returning that label would heal the wrong hash. The server is the right place to enforce this invariant so all clients (SDK, direct HTTP, etc.) get consistent behavior without duplicating the check.

---

## Testing

- `pnpm test src/lib/server.test.ts` in `apps/ensrainbow` — success path and hash-mismatch rejection.
- tested locally with `0x00677002a68cb48598b0a3fec5d666ecb3641db6efd494d01ca33eb0b05e98ed` - now returns not found

---

## Notes for Reviewer (Optional)



---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)
