### PR TITLE
docs: remove inline code in headings

### DIFF
--- a/.changeset/upset-kids-drop.md
+++ b/.changeset/upset-kids-drop.md
@@ -1,0 +1,6 @@
+---
+"@namehash/namehash-ui": patch
+"ensadmin": patch
+---
+
+Eliminate the `@ensnode/ensnode-react` package; its provider, context, hooks, and query utilities are now exported from `@namehash/namehash-ui`.

--- a/.changeset/upset-kids-drop.md
+++ b/.changeset/upset-kids-drop.md
@@ -1,6 +1,0 @@
----
-"@namehash/namehash-ui": patch
-"ensadmin": patch
----
-
-Eliminate the `@ensnode/ensnode-react` package; its provider, context, hooks, and query utilities are now exported from `@namehash/namehash-ui`.

--- a/docs/ensnode.io/src/components/walkthroughs/enskit/v1.13.1.mdx
+++ b/docs/ensnode.io/src/components/walkthroughs/enskit/v1.13.1.mdx
@@ -19,7 +19,7 @@ cd my-ens-app
 npm install
 ```
 
-## 2. Install `enskit` and `enssdk`
+## 2. Install enskit and enssdk
 
 ```sh
 npm install enskit@1.13.1 enssdk@1.13.1
@@ -29,7 +29,7 @@ npm install enskit@1.13.1 enssdk@1.13.1
 Always pin **exact** versions (no `^` or `~`) of `enskit` and `enssdk`, and keep them on the same version. The Omnigraph GraphQL schema is bundled inside `enssdk` and consumed by the `gql.tada` TypeScript plugin to type your queries — a minor or patch bump can change the schema and silently drift your generated types away from your queries. Locking exact versions keeps types and runtime in sync, and matched to the ENSNode version your hosted instance runs.
 :::
 
-## 3. Configure the `gql.tada` TypeScript plugin
+## 3. Configure the gql.tada TypeScript plugin
 
 `gql.tada` is what gives your `graphql(...)` query strings end-to-end type safety. It reads the Omnigraph schema from `enssdk` at typecheck time.
 
@@ -62,7 +62,7 @@ If you're using VS Code, make sure your workspace is using the workspace TypeScr
 }
 ```
 
-## 4. Mount the `OmnigraphProvider`
+## 4. Mount the OmnigraphProvider
 
 `OmnigraphProvider` is what `useOmnigraphQuery` reads from. Construct an `EnsNodeClient`, extend it with the `omnigraph` module, and wrap your app:
 

--- a/docs/ensnode.io/src/components/walkthroughs/enskit/v1.15.0.mdx
+++ b/docs/ensnode.io/src/components/walkthroughs/enskit/v1.15.0.mdx
@@ -19,7 +19,7 @@ cd my-ens-app
 npm install
 ```
 
-## 2. Install `enskit` and `enssdk`
+## 2. Install enskit and enssdk
 
 ```sh
 npm install enskit@1.15.0 enssdk@1.15.0
@@ -29,7 +29,7 @@ npm install enskit@1.15.0 enssdk@1.15.0
 Always pin **exact** versions (no `^` or `~`) of `enskit` and `enssdk`, and keep them on the same version. The Omnigraph GraphQL schema is bundled inside `enssdk` and consumed by the `gql.tada` TypeScript plugin to type your queries — a minor or patch bump can change the schema and silently drift your generated types away from your queries. Locking exact versions keeps types and runtime in sync, and matched to the ENSNode version your hosted instance runs.
 :::
 
-## 3. Configure the `gql.tada` TypeScript plugin
+## 3. Configure the gql.tada TypeScript plugin
 
 `gql.tada` is what gives your `graphql(...)` query strings end-to-end type safety. It reads the Omnigraph schema from `enssdk` at typecheck time.
 
@@ -62,7 +62,7 @@ If you're using VS Code, make sure your workspace is using the workspace TypeScr
 }
 ```
 
-## 4. Mount the `OmnigraphProvider`
+## 4. Mount the OmnigraphProvider
 
 `OmnigraphProvider` is what `useOmnigraphQuery` reads from. Construct an `EnsNodeClient`, extend it with the `omnigraph` module, and wrap your app:
 

--- a/docs/ensnode.io/src/components/walkthroughs/enssdk/v1.13.1.mdx
+++ b/docs/ensnode.io/src/components/walkthroughs/enssdk/v1.13.1.mdx
@@ -21,7 +21,7 @@ npm init -y
 mkdir src
 ```
 
-## 2. Install `enssdk`
+## 2. Install enssdk
 
 We'll use [`tsx`](https://tsx.is/) to run TypeScript directly without a bundler.
 
@@ -34,7 +34,7 @@ npm install -D tsx typescript @types/node
 Always pin an **exact** version (no `^` or `~`) of `enssdk`. The Omnigraph GraphQL schema is bundled inside `enssdk` and consumed by the `gql.tada` TypeScript plugin to type your queries — a minor or patch bump can change the schema and silently drift your generated types away from your queries. Locking the exact version keeps types and runtime in sync, and matched to the ENSNode version your hosted instance runs.
 :::
 
-## 3. Configure the `gql.tada` TypeScript plugin
+## 3. Configure the gql.tada TypeScript plugin
 
 `gql.tada` is what gives your `graphql(...)` query strings end-to-end type safety. It reads the Omnigraph schema from `enssdk` at typecheck time.
 

--- a/docs/ensnode.io/src/components/walkthroughs/enssdk/v1.15.0.mdx
+++ b/docs/ensnode.io/src/components/walkthroughs/enssdk/v1.15.0.mdx
@@ -21,7 +21,7 @@ npm init -y
 mkdir src
 ```
 
-## 2. Install `enssdk`
+## 2. Install enssdk
 
 We'll use [`tsx`](https://tsx.is/) to run TypeScript directly without a bundler.
 
@@ -34,7 +34,7 @@ npm install -D tsx typescript @types/node
 Always pin an **exact** version (no `^` or `~`) of `enssdk`. The Omnigraph GraphQL schema is bundled inside `enssdk` and consumed by the `gql.tada` TypeScript plugin to type your queries — a minor or patch bump can change the schema and silently drift your generated types away from your queries. Locking the exact version keeps types and runtime in sync, and matched to the ENSNode version your hosted instance runs.
 :::
 
-## 3. Configure the `gql.tada` TypeScript plugin
+## 3. Configure the gql.tada TypeScript plugin
 
 `gql.tada` is what gives your `graphql(...)` query strings end-to-end type safety. It reads the Omnigraph schema from `enssdk` at typecheck time.
 

--- a/docs/ensnode.io/src/components/walkthroughs/quickstart/v1.13.1.mdx
+++ b/docs/ensnode.io/src/components/walkthroughs/quickstart/v1.13.1.mdx
@@ -28,7 +28,7 @@ ENSNode supports a full range of different integration options across the stack,
 
 Here's a summary of some popular integration strategies:
 
-### 1. `enssdk` + Omnigraph
+### 1. enssdk + Omnigraph
 
 With `enssdk`, leverage ENSNode and the Omnigraph from any JavaScript runtime to power your frontend or backend apps. `enssdk` comes with built-in type-safety and editor autocomplete for Omnigraph queries.
 
@@ -72,7 +72,7 @@ const result = await client.omnigraph.query({ query: HelloWorldQuery });
   href="/docs/integrate/integration-options/enssdk/example"
 />
 
-### 2. `enskit` + Omnigraph
+### 2. enskit + Omnigraph
 
 With `enskit`, leverage ENSNode and the Omnigraph to power your React components using `useOmnigraphQuery`. `enskit` comes with built-in type-safety, Omnigraph-specific cache directives, easy infinite pagination, and much much more.
 

--- a/docs/ensnode.io/src/components/walkthroughs/quickstart/v1.15.0.mdx
+++ b/docs/ensnode.io/src/components/walkthroughs/quickstart/v1.15.0.mdx
@@ -28,7 +28,7 @@ ENSNode supports a full range of different integration options across the stack,
 
 Here's a summary of some popular integration strategies:
 
-### 1. `enssdk` + Omnigraph
+### 1. enssdk + Omnigraph
 
 With `enssdk`, leverage ENSNode and the Omnigraph from any JavaScript runtime to power your frontend or backend apps. `enssdk` comes with built-in type-safety and editor autocomplete for Omnigraph queries.
 
@@ -76,7 +76,7 @@ const result = await client.omnigraph.query({ query: HelloWorldQuery });
   href="/docs/integrate/integration-options/enssdk/example"
 />
 
-### 2. `enskit` + Omnigraph
+### 2. enskit + Omnigraph
 
 With `enskit`, leverage ENSNode and the Omnigraph to power your React components using `useOmnigraphQuery`. `enskit` comes with built-in type-safety, Omnigraph-specific cache directives, easy infinite pagination, and much much more.
 

--- a/docs/ensnode.io/src/content/docs/docs/integrate/integration-options/index.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/integrate/integration-options/index.mdx
@@ -9,7 +9,7 @@ ENSNode takes the guesswork out of ENS integrations, whether you need to resolve
 
 There are a few different ways to integrate with ENSNode, depending on your app, runtime, and needs.
 
-## 1. `enssdk`
+## 1. enssdk
 
 With `enssdk`, leverage ENSNode and the Omnigraph from any JavaScript runtime to power your frontend or backend apps. `enssdk` comes with built-in type-safety and editor autocomplete for Omnigraph queries.
 
@@ -18,7 +18,7 @@ With `enssdk`, leverage ENSNode and the Omnigraph from any JavaScript runtime to
   href="/docs/integrate/integration-options/enssdk"
 />
 
-## 2. `enskit`
+## 2. enskit
 
 With `enskit`, leverage ENSNode and the Omnigraph to power your React components using `useOmnigraphQuery`. `enskit` comes with built-in type-safety, Omnigraph-specific cache directives, easy infinite pagination, and much much more.
 
@@ -36,7 +36,7 @@ The Omnigraph API is a GraphQL API following the Relay specification, so you get
   href="/docs/integrate/integration-options/omnigraph-graphql-api"
 />
 
-## 4. `ENSDb`
+## 4. ENSDb
 
 For special use cases that go beyond what the ENS Omnigraph exposes, query the live state of ENSv2 directly via SQL. `ENSDb` stores ENS state in a PostgreSQL database — usable from any language with a Postgres driver.
 
@@ -45,7 +45,7 @@ For special use cases that go beyond what the ENS Omnigraph exposes, query the l
   href="/docs/integrate/integration-options/ensdb"
 />
 
-## 5. `enscli`
+## 5. enscli
 
 `enscli` is a CLI that wraps `enssdk` to bring the ENS Omnigraph to the terminal. Designed for developers exploring or validating integrations, operators wiring ENS lookups into shell pipelines, and AI coding agents driving `ensskills`.
 
@@ -54,7 +54,7 @@ For special use cases that go beyond what the ENS Omnigraph exposes, query the l
   href="/docs/integrate/integration-options/enscli"
 />
 
-## 6. `ensskills`
+## 6. ensskills
 
 `ensskills` is a collection of curated skill bundles that give AI coding agents a well-defined contract for working with ENS — powering conversational ENS lookups and streamlining integration code written with `enskit`, `enssdk`, or the raw Omnigraph API.
 
@@ -63,7 +63,7 @@ For special use cases that go beyond what the ENS Omnigraph exposes, query the l
   href="/docs/integrate/integration-options/ensskills"
 />
 
-## 7. `ensdb-cli` & ENSDb snapshots
+## 7. ensdb-cli & ENSDb snapshots
 
 `ensdb-cli` is the operator-facing tool for ENSDb snapshots — portable, versioned packages of an ENSDb instance. Pull one down, restore it into Postgres, and start querying ENS in minutes instead of waiting days to complete a full historical indexing backfill from scratch.
 

--- a/docs/ensnode.io/src/content/docs/docs/integrate/subgraph/querying-best-practices.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/integrate/subgraph/querying-best-practices.mdx
@@ -141,7 +141,7 @@ ENSNode's handling of unnormalized labels is controlled by the `SUBGRAPH_COMPAT`
 For more details, see [Subgraph Compatibility](/docs/integrate/subgraph#self-hosted-ensnode-instance-configuration-for-ens-subgraph-compatibility).
 :::
 
-### When `SUBGRAPH_COMPAT=true`
+### When SUBGRAPH_COMPAT=true
 
 ENSNode may return unnormalized labels as [Subgraph Interpreted Labels](/docs/reference/terminology#subgraph-interpreted-label) associated with indexed names. It is important to note that **ENSNode clients should never attempt to normalize labels returned by ENSNode**. This is because when ENSNode returns an unnormalized label, that label is associated with a specific node that has been indexed. Normalizing an unnormalized label in this context would represent a different node.
 
@@ -152,7 +152,7 @@ There are effectively two distinct query patterns to consider:
 
 An ENSNode client is permitted to validate that all labels returned by ENSNode are in normalized form, and to reject any names with unnormalized labels from further processing. However, the key principle is that an ENSNode client should never normalize returned labels, as normalization transforms the label and therefore also the node associated with the name the label is contained within.
 
-### When `SUBGRAPH_COMPAT=false` (default)
+### When SUBGRAPH_COMPAT=false (default)
 
 By default, ENSNode is configured to use [Interpreted Labels](/docs/reference/terminology#interpreted-label) instead of [Subgraph Interpreted Labels](/docs/reference/terminology#subgraph-interpreted-label), which helps avoid edge cases related to null bytes, full-stop characters (periods), or exotic unicode characters. When names are returned from any of the ENSNode APIs, including the Subgraph-compatible GraphQL API, names will be [Interpreted Names](/docs/reference/terminology#interpreted-name)
 

--- a/docs/ensnode.io/src/content/docs/docs/integrate/unigraph/schema-reference.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/integrate/unigraph/schema-reference.mdx
@@ -110,7 +110,7 @@ the Event responsible for its existence.
 | `ENSv2RegistryRegistration` |
 | `ENSv2RegistryReservation`  |
 
-## `events`
+## events
 
 | Column              | Type          | Nullable | Description                                                                                                                                                                                                                                                             |
 | ------------------- | ------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -132,7 +132,7 @@ the Event responsible for its existence.
 
 **Indexes:** `selector`, `from`, `sender`, `timestamp`.
 
-## `domain_events`
+## domain_events
 
 Join table linking a `domains` record to its associated `events`.
 
@@ -143,7 +143,7 @@ Join table linking a `domains` record to its associated `events`.
 
 **Primary key:** `(domain_id, event_id)`.
 
-## `resolver_events`
+## resolver_events
 
 Join table linking a `resolvers` record to its associated `events`.
 
@@ -154,7 +154,7 @@ Join table linking a `resolvers` record to its associated `events`.
 
 **Primary key:** `(resolver_id, event_id)`.
 
-## `permissions_events`
+## permissions_events
 
 Join table linking a `permissions` record to its associated `events`.
 
@@ -165,7 +165,7 @@ Join table linking a `permissions` record to its associated `events`.
 
 **Primary key:** `(permissions_id, event_id)`.
 
-## `permissions_user_events`
+## permissions_user_events
 
 Join table linking a `permissions_users` record to its associated `events` — i.e. the per-`(contract, resource, user)` history of role grants, revokes, and bitmap mutations.
 
@@ -176,7 +176,7 @@ Join table linking a `permissions_users` record to its associated `events` — i
 
 **Primary key:** `(permissions_user_id, event_id)`.
 
-## `accounts`
+## accounts
 
 | Column | Type   | Nullable | Description                    |
 | ------ | ------ | -------- | ------------------------------ |
@@ -184,7 +184,7 @@ Join table linking a `permissions_users` record to its associated `events` — i
 
 **Relations:** has many `registrations` (as registrant), has many `domains`, has many `permissions_users`.
 
-## `registries`
+## registries
 
 For ENSv1, each domain that has children implicitly owns a "virtual" Registry (`ENSv1VirtualRegistry`) whose sole parent is that domain. Children of the parent then point their `registry_id` at the virtual registry. Concrete `ENSv1Registry` rows (e.g. the mainnet ENS Registry, the Basenames Registry, the Lineanames Registry) sit at the top. ENSv2 namegraphs are rooted in a single `ENSv2Registry` RootRegistry.
 
@@ -203,7 +203,7 @@ For ENSv1, each domain that has children implicitly owns a "virtual" Registry (`
 
 **Relations:** has many `domains` (as parent registry), has many `domains` (as subregistry), has one `permissions` via `(chain_id, address)`.
 
-## `domains`
+## domains
 
 The `domains.owner_id` for ENSv1 Domains is the materialized effective owner. ENSv1 includes a diverse number of ways to 'own' a domain, including the ENSv1 Registry, various Registrars, and the NameWrapper. The ENSv1 indexing logic materializes the effective owner to simplify this aspect of ENS and enable efficient queries against `domains.owner_id`.
 
@@ -233,7 +233,7 @@ Domain-Resolver relations are tracked via the Protocol Acceleration plugin, not 
 
 **Relations:** belongs to one `registries` record, belongs to one `registries` record (as subregistry), has one `accounts` record (owner), has one `accounts` record (rootRegistryOwner), has one `labels` record, has many `registrations` records.
 
-## `labels`
+## labels
 
 Internal rainbow table mapping a `label_hash` to its interpreted label string. Domains reference labels by hash; names are healed at resolution-time.
 
@@ -246,7 +246,7 @@ Internal rainbow table mapping a `label_hash` to its interpreted label string. D
 
 **Relations:** has many `domains`.
 
-## `registrations`
+## registrations
 
 A registration is keyed by `id`.
 
@@ -274,7 +274,7 @@ A registration is keyed by `id`.
 
 **Relations:** belongs to one `domains` record, has one `accounts` record (registrant), has one `accounts` record (unregistrant), has many `renewals`, has one `events` record.
 
-## `latest_registration_indexes`
+## latest_registration_indexes
 
 Tracks the highest `registration_index` seen for each domain. Used to sequence registrations.
 
@@ -285,7 +285,7 @@ Tracks the highest `registration_index` seen for each domain. Used to sequence r
 
 **Primary key:** `domain_id`.
 
-## `renewals`
+## renewals
 
 A renewal is keyed by `id` and belongs to a specific registration.
 
@@ -305,7 +305,7 @@ A renewal is keyed by `id` and belongs to a specific registration.
 
 **Relations:** belongs to one `registrations` record via `(domain_id, registration_index)`, has one `events` record via `(event_id)`.
 
-## `latest_renewal_indexes`
+## latest_renewal_indexes
 
 Tracks the highest `renewal_index` seen for each registration. Used to sequence renewals.
 
@@ -317,7 +317,7 @@ Tracks the highest `renewal_index` seen for each registration. Used to sequence 
 
 **Primary key:** `(domain_id, registration_index)`.
 
-## `permissions`
+## permissions
 
 An ENSv2 permissions contract instance.
 
@@ -331,7 +331,7 @@ An ENSv2 permissions contract instance.
 
 **Relations:** has many `permissions_resources`, has many `permissions_users`.
 
-## `permissions_resources`
+## permissions_resources
 
 A resource managed by a `permissions` contract.
 
@@ -346,7 +346,7 @@ A resource managed by a `permissions` contract.
 
 **Relations:** belongs to one `permissions` via `(chain_id, address)`.
 
-## `permissions_users`
+## permissions_users
 
 A user's role bitmap for a specific resource within a `permissions` contract.
 

--- a/docs/ensnode.io/src/content/docs/docs/services/ensdb/concepts/database-schemas.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/services/ensdb/concepts/database-schemas.mdx
@@ -65,7 +65,7 @@ Defined in [`protocol-acceleration.schema.ts`](https://github.com/namehash/ensno
 
 Provides accelerated lookups for the Resolution API. Rather than traversing the full namegraph at query time for common operations, this database sub-schema materializes the minimal state needed to answer resolution queries efficiently.
 
-#### `reverse_name_records`
+#### reverse_name_records
 
 Tracks an Account's ENSIP-19 Reverse Name Records by CoinType.
 
@@ -87,7 +87,7 @@ These records **cannot** be queried directly and used as a source of truth — y
 
 **Primary key:** `(address, coin_type)`.
 
-#### `domain_resolver_relations`
+#### domain_resolver_relations
 
 Tracks Domain-Resolver relationships. This powers: (1) Domain-Resolver relationships within the GraphQL API, and (2) accelerated lookups of a Domain's Resolver within the Resolution API.
 
@@ -106,7 +106,7 @@ It is keyed by `(chain_id, address, domain_id)` to match the on-chain data model
 
 **Relations:** has one `resolver` via `(chain_id, resolver)`.
 
-#### `resolvers`
+#### resolvers
 
 Represents an individual `IResolver` contract that has emitted at least one event. Note that Resolver contracts can exist on-chain but not emit any events and still function properly, so checks against a Resolver's existence and metadata must be done at runtime.
 
@@ -120,7 +120,7 @@ Represents an individual `IResolver` contract that has emitted at least one even
 
 **Relations:** has many `resolver_records`.
 
-#### `resolver_records`
+#### resolver_records
 
 Tracks a set of records for a specified `node` within a `resolver` contract on `chain_id`.
 
@@ -147,7 +147,7 @@ These record values do **not** allow the caller to confidently resolve records f
 
 **Relations:** belongs to one `resolvers` record via `(chain_id, address)`, has many `resolver_address_records`, has many `resolver_text_records`.
 
-#### `resolver_address_records`
+#### resolver_address_records
 
 Tracks address records for a `node` by `coin_type` within a `resolver` on `chain_id`.
 
@@ -165,7 +165,7 @@ Keyed by `(chain_id, resolver, node, coin_type)`, where the composite key segmen
 
 **Relations:** belongs to one `resolver_records` record via `(chain_id, address, node)`.
 
-#### `resolver_text_records`
+#### resolver_text_records
 
 Tracks text records for a `node` by `key` within a `resolver` on `chain_id`.
 
@@ -183,7 +183,7 @@ Keyed by `(chain_id, resolver, node, key)`, where the composite key segment `(ch
 
 **Relations:** belongs to one `resolver_records` record via `(chain_id, address, node)`.
 
-#### `migrated_nodes_by_parent`
+#### migrated_nodes_by_parent
 
 Tracks the migration status of a node, keyed by `(parent_node, label_hash)`. Due to a security issue, ENS migrated from the `RegistryOld` contract to a new Registry contract. When indexing events, the indexer must ignore any events on `RegistryOld` for domains that have since been migrated to the new Registry.
 
@@ -202,7 +202,7 @@ The composite key is chosen so that Ponder's profile-pattern matcher can decompo
 
 **Primary key:** `(parent_node, label_hash)`.
 
-#### `migrated_nodes_by_node`
+#### migrated_nodes_by_node
 
 Sibling lookup-by-namehash table for `migrated_nodes_by_parent`, keyed by `node`. The three `RegistryOld` handlers (`Transfer` / `NewTTL` / `NewResolver`) emit only the post-namehash `node` and cannot reconstruct the `(parent_node, label_hash)` pair without an unprofileable reverse lookup. Existence in this table is equivalent to existence in `migrated_nodes_by_parent`; both rows are written together by the migration helper. See [`protocol-acceleration/migrated-node-db-helpers.ts`](https://github.com/namehash/ensnode/blob/main/apps/ensindexer/src/lib/protocol-acceleration/migrated-node-db-helpers.ts) for the full rationale.
 
@@ -229,7 +229,7 @@ Models the lifecycle of ENS name registrations and renewals as logical actions, 
 | `registration` |
 | `renewal`      |
 
-#### `subregistries`
+#### subregistries
 
 A "subregistry" represents a smart contract that manages the subnames of a given parent name.
 
@@ -249,7 +249,7 @@ These assumptions hold for the current scope of indexing logic but may not hold 
 
 **Relations:** has many `registration_lifecycles`.
 
-#### `registration_lifecycles`
+#### registration_lifecycles
 
 A "registration lifecycle" represents a single cycle of a name being registered once, followed by renewals (expiry date extensions) any number of times.
 
@@ -267,7 +267,7 @@ This data model only tracks the **most recently created** registration lifecycle
 
 **Relations:** belongs to one `subregistries` record, has many `registrar_actions` records.
 
-#### `registrar_actions`
+#### registrar_actions
 
 Models "logical actions" rather than "events" because a single logical action, such as a single registration or renewal, may emit multiple on-chain events from multiple contracts where each individual event may only provide a subset of the data about the full logical action. Each logical action in this table is associated with a single transaction. A single transaction may perform any number of logical actions.
 
@@ -300,7 +300,7 @@ The state from both events is aggregated into a single logical registrar action.
 
 **Relations:** belongs to one `registration_lifecycles` record via `node`.
 
-##### `id` format
+##### id format
 
 The `id` value is a Ponder checkpoint string — a fixed-length decimal string encoding the following fields (left to right, most to least significant):
 
@@ -315,7 +315,7 @@ The `id` value is a Ponder checkpoint string — a fixed-length decimal string e
 
 All fields are zero-padded to their fixed widths, so the string has constant length and lexicographic order equals chronological order. Because all registrar actions originate from Ponder log (smart-contract event) handlers, every `id` shares the same `event_type` digit (`5`), making direct lexicographic or bigint comparison safe for establishing total chronological order.
 
-##### `incremental_duration` semantics
+##### incremental_duration semantics
 
 If `type` is `registration`: represents the duration between `block_timestamp` and the initial `expires_at` value that the associated registration lifecycle will be initialized with.
 
@@ -328,7 +328,7 @@ If `type` is `renewal`: represents the incremental increase in duration made to 
 
 After the grace period expires entirely, the name is considered "released" and can no longer be renewed — it must be registered again, starting a new lifecycle.
 
-#### `_ensindexer_registrar_action_metadata`
+#### \_ensindexer_registrar_action_metadata
 
 :::caution[Internal implementation detail]
 This table is an **internal implementation detail of ENSIndexer** and should not be queried outside of ENSIndexer. It is used to temporarily store data during event handler execution to correlate multiple on-chain events into a single `registrar_actions` record.
@@ -356,7 +356,7 @@ Defined in [`subgraph.schema.ts`](https://github.com/namehash/ensnode/blob/main/
 
 A complete re-implementation of the legacy ENS Subgraph data model. When the `subgraph_` prefix is stripped and the resulting database schema is paired with `@ensnode/ponder-subgraph`, the resulting GraphQL API is fully compatible with the legacy ENS Subgraph.
 
-#### `subgraph_domains`
+#### subgraph_domains
 
 | Column                | Type          | Nullable | Description                                                                                                                                                                                                                                                                                                                  |
 | --------------------- | ------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -384,7 +384,7 @@ A complete re-implementation of the legacy ENS Subgraph data model. When the `su
 
 **Relations:** has one `subgraph_accounts` record (resolved_address), has one `subgraph_accounts` record (owner), has one `subgraph_accounts` record (registrant), has one `subgraph_accounts` record (wrapped_owner), has one `subgraph_resolvers` record, has one `subgraph_domains` record (parent), has many `subgraph_domains` records (subdomains), has one `subgraph_wrapped_domains` record, has one `subgraph_registrations` record, has many domain event tables.
 
-#### `subgraph_accounts`
+#### subgraph_accounts
 
 | Column | Type   | Nullable |
 | ------ | ------ | -------- |
@@ -392,7 +392,7 @@ A complete re-implementation of the legacy ENS Subgraph data model. When the `su
 
 **Relations:** has many `subgraph_domains` records, has many `subgraph_wrapped_domains` records, has many `subgraph_registrations` records.
 
-#### `subgraph_resolvers`
+#### subgraph_resolvers
 
 | Column         | Type            | Nullable | Description                                                                                                             |
 | -------------- | --------------- | -------- | ----------------------------------------------------------------------------------------------------------------------- |
@@ -408,7 +408,7 @@ A complete re-implementation of the legacy ENS Subgraph data model. When the `su
 
 **Relations:** has one `subgraph_accounts` record (addr), has one `subgraph_domains` record, has many resolver event tables.
 
-#### `subgraph_registrations`
+#### subgraph_registrations
 
 | Column              | Type          | Nullable | Description                                                                                                                                                                                                                                                                                                                                                                                        |
 | ------------------- | ------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -424,7 +424,7 @@ A complete re-implementation of the legacy ENS Subgraph data model. When the `su
 
 **Relations:** has one `subgraph_domains` record, has one `subgraph_accounts` record (registrant), has many registration event tables.
 
-#### `subgraph_wrapped_domains`
+#### subgraph_wrapped_domains
 
 | Column        | Type          | Nullable | Description                                                                                                                                                                                                                                                                                                                                                                            |
 | ------------- | ------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -488,7 +488,7 @@ Defined in [`tokenscope.schema.ts`](https://github.com/namehash/ensnode/blob/mai
 
 Tracks ENS-related NFT token ownership and secondary market sales via the Seaport protocol.
 
-#### `name_sales`
+#### name_sales
 
 | Column             | Type          | Nullable | Description                                                                                                                                                                          |
 | ------------------ | ------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -511,7 +511,7 @@ Tracks ENS-related NFT token ownership and secondary market sales via the Seapor
 
 **Indexes:** `domain_id`, `asset_id`, `buyer`, `seller`, `timestamp`.
 
-#### `name_tokens`
+#### name_tokens
 
 After an NFT is indexed, it is never deleted from the index. When an indexed NFT is burned on-chain, its record is retained and its `mint_status` is updated to `burned`. If the NFT is minted again after being burned, `mint_status` is updated back to `minted`.
 

--- a/docs/ensnode.io/src/content/docs/docs/services/ensrainbow/concepts/typescript-interfaces.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/services/ensrainbow/concepts/typescript-interfaces.mdx
@@ -11,7 +11,7 @@ ENSRainbow's TypeScript APIs expose two companion interfaces that describe **whi
 
 ## Server Label Set
 
-### `EnsRainbowServerLabelSet`
+### EnsRainbowServerLabelSet
 
 Returned by `GET /version` and stored in database metadata:
 
@@ -29,7 +29,7 @@ interface EnsRainbowServerLabelSet {
 
 ## Client Label Set
 
-### `EnsRainbowClientLabelSet`
+### EnsRainbowClientLabelSet
 
 Provided when constructing `new EnsRainbowApiClient({ clientLabelSet: … })` to pin client expectations:
 

--- a/docs/ensnode.io/src/content/docs/docs/services/ensrainbow/concepts/versioning.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/services/ensrainbow/concepts/versioning.mdx
@@ -15,7 +15,7 @@ The semantic version of the Node.js application itself (e.g. `0.4.2`).
 - Bumped when new features, fixes, or breaking changes are released.
 - Shown in `/v1/config` under the `version` field.
 
-## 2. Database Schema Version (`DB_SCHEMA_VERSION`)
+## 2. Database Schema Version (DB_SCHEMA_VERSION)
 
 Specifies the expected on-disk structure of the LevelDB database as well as the expected format of the downloadable pre-built LevelDB databases.
 
@@ -25,7 +25,7 @@ Specifies the expected on-disk structure of the LevelDB database as well as the 
 The API server will refuse to start if the on-disk database schema is different than the running software's expected schema.
 :::
 
-## 3. Label-set Version (`LABEL_SET_VERSION`)
+## 3. Label-set Version (LABEL_SET_VERSION)
 
 Identifies incremental sets of rainbow records for a given label-set (`LABEL_SET_ID`).
 

--- a/docs/ensnode.io/src/content/docs/docs/services/ensrainbow/contributing/building.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/services/ensrainbow/contributing/building.mdx
@@ -43,7 +43,7 @@ You can pull this image using:
 docker pull ghcr.io/namehash/ensnode/ensrainbow:latest
 ```
 
-## Runtime Data Provisioning via `entrypoint.sh`
+## Runtime Data Provisioning via entrypoint.sh
 
 The ENSRainbow application image (whether self-built or pulled from GHCR) uses the `entrypoint.sh` script to manage the LevelDB data at runtime.
 

--- a/docs/ensnode.io/src/content/docs/docs/services/ensrainbow/contributing/index.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/services/ensrainbow/contributing/index.mdx
@@ -61,7 +61,7 @@ Follow these steps to start contributing to ENSRainbow:
 - **Running into issues?** → [Troubleshooting](/docs/services/ensrainbow/usage/troubleshooting)
 - **Want to understand the data flow?** → [Data Model](/docs/services/ensrainbow/concepts/data-model)
 
-### Data Ingestion (`ingest-ensrainbow`)
+### Data Ingestion (ingest-ensrainbow)
 
 Ingests data from `.ensrainbow` files into the LevelDB database.
 
@@ -72,7 +72,7 @@ pnpm run ingest-ensrainbow --input-file <path/to/LABEL_SET_ID-LABEL_SET_VERSION.
 - `--input-file`: Path to the `.ensrainbow` file. Adheres to [ingestion rules](#ingest-rainbow-tables).
 - `--data-dir`: Directory for the LevelDB database (default: `data/`). The database stores `LABEL_SET_ID` and `HIGHEST_LABEL_SET_VERSION` metadata.
 
-### Database Validation (`validate`)
+### Database Validation (validate)
 
 ```bash
 pnpm run validate [--data-dir path/to/db] [--lite]
@@ -96,7 +96,7 @@ The process will exit with:
 - Code 0: Validation successful
 - Code 1: Validation failed or errors encountered
 
-### Database Purge (`purge`)
+### Database Purge (purge)
 
 ```bash
 pnpm run purge [--data-dir path/to/db]
@@ -109,7 +109,7 @@ The process will exit with:
 - Code 0: Successful purge
 - Code 1: Error during purge operation
 
-### API Server (`serve`)
+### API Server (serve)
 
 ```bash
 pnpm run serve [--port 3223] [--data-dir path/to/db]
@@ -290,7 +290,7 @@ Using a volume ensures that your downloaded and ingested data is not lost when t
 These steps are typically performed by project maintainers for releasing official pre-built ENSRainbow database archives. Assumes `rclone` is configured with a remote named `ENSRAINBOWR2`.
 :::
 
-### 1. Prepare `.ensrainbow` Files
+### 1. Prepare .ensrainbow Files
 
 This section covers the conversion of source data (like CSV data or empty files for initial datasets) into the `.ensrainbow` format. For detailed conversion instructions and examples, see the [Creating ENSRainbow Files](/docs/services/ensrainbow/concepts/creating-files) guide.
 
@@ -318,7 +318,7 @@ This converts a test dataset CSV file into an `.ensrainbow` file for version 0 o
 time pnpm run convert --input-file test/fixtures/ens_test_env_names.csv --output-file ens-test-env_0.ensrainbow --label-set-id ens-test-env
 ```
 
-### 2. Upload `.ensrainbow` Files to R2 Storage
+### 2. Upload .ensrainbow Files to R2 Storage
 
 After generation, these `.ensrainbow` files are uploaded to the designated cloud storage (e.g., R2 via rclone).
 
@@ -328,7 +328,7 @@ rclone copy ./discovery-a_0.ensrainbow ENSRAINBOWR2:ensrainbow/labelsets/
 rclone copy ./ens-test-env_0.ensrainbow ENSRAINBOWR2:ensrainbow/labelsets/
 ```
 
-### 3. Calculate and Upload Checksums for `.ensrainbow` Files
+### 3. Calculate and Upload Checksums for .ensrainbow Files
 
 SHA256 checksums are generated for each `.ensrainbow` file to ensure data integrity. These checksum files are then uploaded.
 
@@ -344,7 +344,7 @@ rclone copy ./discovery-a_0.ensrainbow.sha256sum ENSRAINBOWR2:ensrainbow/labelse
 rclone copy ./ens-test-env_0.ensrainbow.sha256sum ENSRAINBOWR2:ensrainbow/labelsets/
 ```
 
-### 4. Ingest `.ensrainbow` Files into LevelDB Databases
+### 4. Ingest .ensrainbow Files into LevelDB Databases
 
 The `.ensrainbow` files are ingested into local LevelDB instances to create the actual databases.
 

--- a/docs/ensnode.io/src/content/docs/docs/services/ensrainbow/contributing/local-development.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/services/ensrainbow/contributing/local-development.mdx
@@ -13,7 +13,7 @@ import { LinkCard } from "@astrojs/starlight/components";
 1. Clone the monorepo and install dependencies (see the main ENSNode [Contribution Guide](/docs/reference/contributing)).
 2. Make sure `pnpm`, `Node.js >= 18`, and Docker (optional) are installed.
 
-## 1 Download a `.ensrainbow` file
+## 1 Download a .ensrainbow file
 
 ENSRainbow stores label-hash-to-label pairs in compressed snapshots with the file extension `.ensrainbow`.
 Use the helper script located in `apps/ensrainbow/scripts/`:

--- a/docs/ensnode.io/src/content/docs/docs/services/ensrainbow/usage/available-label-sets.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/services/ensrainbow/usage/available-label-sets.mdx
@@ -31,7 +31,7 @@ The information below reflects actual availability as of the last check.
 
 ### Currently Available
 
-#### `subgraph`
+#### subgraph
 
 **Source**: The Graph's official ENS Subgraph  
 **Description**: Main production dataset containing labelhash-to-label mappings from The Graph's ENS subgraph.
@@ -40,7 +40,7 @@ The information below reflects actual availability as of the last check.
 | ------- | ------------ | -------------------------- |
 | `0`     | ✅ Available | Initial production dataset |
 
-#### `ens-test-env`
+#### ens-test-env
 
 **Source**: [ens-test-env](https://github.com/ensdomains/ens-test-env) project  
 **Description**: Small, curated test dataset perfectly aligned with the ens-test-env labels for development and testing.
@@ -49,7 +49,7 @@ The information below reflects actual availability as of the last check.
 | ------- | ------------ | ---------------------------------- |
 | `0`     | ✅ Available | Test dataset for local development |
 
-#### `discovery-a`
+#### discovery-a
 
 **Source**: Dynamic discovery pipeline  
 **Description**: Dataset for dynamically discovered labels, initially empty but grows over time.
@@ -58,7 +58,7 @@ The information below reflects actual availability as of the last check.
 | ------- | ------------ | --------------------------------------------- |
 | `0`     | ✅ Available | Initial empty dataset for dynamic discoveries |
 
-#### `searchlight`
+#### searchlight
 
 **Source**: Extended discovery mechanisms  
 **Description**: Enhanced dataset with additional label discoveries beyond the subgraph, providing maximum healing coverage.


### PR DESCRIPTION
# Lite PR

[Tip: Review docs on the ENSNode PR process](https://ensnode.io/docs/contributing/prs)

## Summary

- Removes inline code from headings on the ensnode.io docs site
- This doesn't touch READMEs of packages, or apps like ensrainbow which still use inline code in headings

---

## Why

- Make docs great again

---

## Testing

- How this was tested.
- If you didn't test it, say why.

---

## Notes for Reviewer (Optional)

- Anything non-obvious or worth a heads-up.

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)
