### PR TITLE
Allow `discovery-a` label set to be considered a subgraph compatible one

### DIFF
--- a/packages/ensnode-sdk/src/ensindexer/config/is-subgraph-compatible.ts
+++ b/packages/ensnode-sdk/src/ensindexer/config/is-subgraph-compatible.ts
@@ -19,13 +19,18 @@ export function isSubgraphCompatible(
   const isSubgraphLabelSet =
     config.clientLabelSet.labelSetId === "subgraph" && config.clientLabelSet.labelSetVersion === 0;
 
+  const isEmptyLabelSet = config.clientLabelSet.labelSetId === "discovery-a";
+
   const isEnsTestEnvLabelSet =
     config.clientLabelSet.labelSetId === "ens-test-env" &&
     config.clientLabelSet.labelSetVersion === 0;
 
-  // config should be considered subgraph-compatible if in ens-test-env namespace with ens-test-env labelset
   const labelSetIsSubgraphCompatible =
-    isSubgraphLabelSet || (config.namespace === ENSNamespaceIds.EnsTestEnv && isEnsTestEnvLabelSet);
+    isSubgraphLabelSet ||
+    // config should be considered subgraph-compatible if with `discovery-a` labelset
+    isEmptyLabelSet ||
+    // config should be considered subgraph-compatible if in ens-test-env namespace with ens-test-env labelset
+    (config.namespace === ENSNamespaceIds.EnsTestEnv && isEnsTestEnvLabelSet);
 
   return onlySubgraphPluginActivated && labelSetIsSubgraphCompatible;
 }


### PR DESCRIPTION
# Lite PR

[Tip: Review docs on the ENSNode PR process](https://ensnode.io/docs/contributing/prs)

## Summary

- What changed (1-3 bullets, no essays).

---

## Why

- Why this change exists. Link to related GitHub issues where relevant.

---

## Testing

- How this was tested.
- If you didn't test it, say why.

---

## Notes for Reviewer (Optional)

- Anything non-obvious or worth a heads-up.

---

## Pre-Review Checklist (Blocking)

- [ ] This PR does not introduce significant changes and is low-risk to review quickly.
- [ ] Relevant changesets are included (or are not required)
