### PR TITLE
chore: consolidate prettier invocation to monorepo root

### DIFF
--- a/docs/ensnode.io/package.json
+++ b/docs/ensnode.io/package.json
@@ -13,8 +13,6 @@
     "astro": "astro",
     "lint": "biome check --write",
     "lint:ci": "biome ci",
-    "lint:prettier": "prettier --write \"**/*.astro\"",
-    "lint:prettier:ci": "prettier --check \"**/*.astro\"",
     "omnigraph-examples:refresh-responses": "tsx --tsconfig tsconfig.json scripts/fetch-omnigraph-example-responses.mts",
     "omnigraph:snapshot": "tsx --tsconfig tsconfig.json scripts/snapshot-omnigraph-version.mts",
     "test": "vitest",
@@ -61,8 +59,6 @@
     "@types/react-dom": "catalog:",
     "enssdk": "workspace:*",
     "enskit": "workspace:*",
-    "prettier": "catalog:",
-    "prettier-plugin-astro": "catalog:",
     "tsx": "^4.19.3",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/docs/ensrainbow.io/package.json
+++ b/docs/ensrainbow.io/package.json
@@ -12,9 +12,7 @@
     "preview": "astro preview",
     "astro": "astro",
     "lint": "biome check --write .",
-    "lint:ci": "biome ci",
-    "lint:prettier": "prettier --write \"**/*.astro\"",
-    "lint:prettier:ci": "prettier --check \"**/*.astro\""
+    "lint:ci": "biome ci"
   },
   "dependencies": {
     "@astrojs/react": "catalog:",
@@ -32,8 +30,6 @@
   },
   "devDependencies": {
     "@types/react": "catalog:",
-    "@types/react-dom": "catalog:",
-    "prettier": "catalog:",
-    "prettier-plugin-astro": "catalog:"
+    "@types/react-dom": "catalog:"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "lint": "pnpm run lint:biome && pnpm run lint:prettier",
     "lint:ci": "pnpm run lint:biome:ci && pnpm run lint:prettier:ci",
-    "lint:prettier": "pnpm exec prettier --write \"**/*.{md,mdx}\" && pnpm -r lint:prettier",
-    "lint:prettier:ci": "pnpm exec prettier --check \"**/*.{md,mdx}\" && pnpm -r lint:prettier:ci",
+    "lint:prettier": "pnpm exec prettier --write \"**/*.{md,mdx,astro}\"",
+    "lint:prettier:ci": "pnpm exec prettier --check \"**/*.{md,mdx,astro}\"",
     "lint:biome": "biome check --write .",
     "lint:biome:ci": "biome ci",
     "test": "vitest --silent passed-only",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -806,12 +806,6 @@ importers:
       enssdk:
         specifier: workspace:*
         version: link:../../packages/enssdk
-      prettier:
-        specifier: 'catalog:'
-        version: 3.6.2
-      prettier-plugin-astro:
-        specifier: 'catalog:'
-        version: 0.14.1
       tsx:
         specifier: ^4.19.3
         version: 4.21.0
@@ -867,12 +861,6 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.7)
-      prettier:
-        specifier: 'catalog:'
-        version: 3.6.2
-      prettier-plugin-astro:
-        specifier: 'catalog:'
-        version: 0.14.1
 
   examples/enskit-react-example:
     dependencies:


### PR DESCRIPTION
simplifies the prettier hookup by just including astro files at the root