### PR TITLE
docs: hosted instance link hover

### DIFF
--- a/.changeset/upset-kids-drop.md
+++ b/.changeset/upset-kids-drop.md
@@ -1,0 +1,6 @@
+---
+"@namehash/namehash-ui": patch
+"ensadmin": patch
+---
+
+Eliminate the `@ensnode/ensnode-react` package; its provider, context, hooks, and query utilities are now exported from `@namehash/namehash-ui`.

--- a/.changeset/upset-kids-drop.md
+++ b/.changeset/upset-kids-drop.md
@@ -1,6 +1,0 @@
----
-"@namehash/namehash-ui": patch
-"ensadmin": patch
----
-
-Eliminate the `@ensnode/ensnode-react` package; its provider, context, hooks, and query utilities are now exported from `@namehash/namehash-ui`.

--- a/docs/ensnode.io/src/components/molecules/HostedEnsNodeInstance.astro
+++ b/docs/ensnode.io/src/components/molecules/HostedEnsNodeInstance.astro
@@ -14,7 +14,7 @@ const hostedEnsNodeVersion = ACTIVE_OMNIGRAPH_VERSION;
         style={{ marginTop: "20px" }}
         class="flex flex-col xl:flex-row justify-start xl:items-center gap-4">
         <a
-          class="sl-markdown-content underline underline-offset-4 hover:underline-offset-2 hover:text-[var(--sl-color-accent-high)] transition-all duration-200"
+          class="sl-markdown-content underline underline-offset-4 hover:underline-offset-2 transition-all duration-200"
           href={instanceURL}>{instanceURL}</a
         >
         <a

--- a/docs/ensnode.io/src/components/molecules/HostedEnsNodeInstance.astro
+++ b/docs/ensnode.io/src/components/molecules/HostedEnsNodeInstance.astro
@@ -14,7 +14,7 @@ const hostedEnsNodeVersion = ACTIVE_OMNIGRAPH_VERSION;
         style={{ marginTop: "20px" }}
         class="flex flex-col xl:flex-row justify-start xl:items-center gap-4">
         <a
-          class="sl-markdown-content underline underline-offset-4 hover:underline-offset-2 transition-all duration-200"
+          class="sl-markdown-content underline underline-offset-4 hover:underline-offset-2 transition-[text-underline-offset] duration-200"
           href={instanceURL}>{instanceURL}</a
         >
         <a

--- a/docs/ensnode.io/src/components/organisms/OmnigraphStaticExampleSet.astro
+++ b/docs/ensnode.io/src/components/organisms/OmnigraphStaticExampleSet.astro
@@ -130,7 +130,7 @@ const data = resolveOmnigraphStaticExample(id);
         name="left-arrow"
         class="h-5 w-5 text-[var(--sl-color-accent)] group-hover:text-[var(--sl-color-white)] transition-colors duration-200"
       />
-      <p class="not-content m-0 underline underline-offset-4 group-hover:underline-offset-2 transition-all duration-200">
+      <p class="not-content m-0 underline underline-offset-4 group-hover:underline-offset-2 transition-[text-underline-offset] duration-200">
         Back to Examples{" "}
       </p>
     </a>

--- a/docs/ensnode.io/src/components/organisms/OmnigraphStaticExampleSet.astro
+++ b/docs/ensnode.io/src/components/organisms/OmnigraphStaticExampleSet.astro
@@ -128,7 +128,7 @@ const data = resolveOmnigraphStaticExample(id);
       href="/docs/integrate/omnigraph/examples">
       <Icon
         name="left-arrow"
-        class="h-5 w-5 text-[var(--sl-color-accent)] group-hover:text-[var(--sl-color-white)] transition-colors duration-200"
+        class="h-5 w-5 text-[var(--sl-color-accent)]"
       />
       <p class="not-content m-0 underline underline-offset-4 group-hover:underline-offset-2 transition-[text-underline-offset] duration-200">
         Back to Examples{" "}

--- a/docs/ensnode.io/src/content/docs/docs/integrate/integration-options/enskit/example.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/integrate/integration-options/enskit/example.mdx
@@ -30,9 +30,9 @@ The embedded StackBlitz editor runs entirely in your browser. Downloading and in
 >
   <Icon
     name="left-arrow"
-    class="h-5 w-5 text-[var(--sl-color-accent)] group-hover:text-[var(--sl-color-accent-high)] transition-colors duration-200"
+    class="h-5 w-5 text-[var(--sl-color-accent)] transition-colors duration-200"
   />
-  <div class="not-content m-0 underline underline-offset-4 group-hover:underline-offset-2 group-hover:text-[var(--sl-color-accent-high)] transition-all duration-200">
+  <div class="not-content m-0 underline underline-offset-4 group-hover:underline-offset-2 transition-all duration-200">
     Back to enskit overview
   </div>
 </a>

--- a/docs/ensnode.io/src/content/docs/docs/integrate/integration-options/enskit/example.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/integrate/integration-options/enskit/example.mdx
@@ -32,7 +32,7 @@ The embedded StackBlitz editor runs entirely in your browser. Downloading and in
     name="left-arrow"
     class="h-5 w-5 text-[var(--sl-color-accent)] transition-colors duration-200"
   />
-  <div class="not-content m-0 underline underline-offset-4 group-hover:underline-offset-2 transition-all duration-200">
+  <div class="not-content m-0 underline underline-offset-4 group-hover:underline-offset-2 transition-[text-underline-offset] duration-200">
     Back to enskit overview
   </div>
 </a>

--- a/docs/ensnode.io/src/content/docs/docs/integrate/integration-options/enskit/example.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/integrate/integration-options/enskit/example.mdx
@@ -30,7 +30,7 @@ The embedded StackBlitz editor runs entirely in your browser. Downloading and in
 >
   <Icon
     name="left-arrow"
-    class="h-5 w-5 text-[var(--sl-color-accent)] transition-colors duration-200"
+    class="h-5 w-5 text-[var(--sl-color-accent)]"
   />
   <div class="not-content m-0 underline underline-offset-4 group-hover:underline-offset-2 transition-[text-underline-offset] duration-200">
     Back to enskit overview

--- a/docs/ensnode.io/src/content/docs/docs/integrate/integration-options/enssdk/example.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/integrate/integration-options/enssdk/example.mdx
@@ -34,7 +34,7 @@ You can edit the script and re-execute **`npm start`** in the terminal to run it
     name="left-arrow"
     class="h-5 w-5 text-[var(--sl-color-accent)] transition-colors duration-200"
   />
-  <div class="not-content m-0 underline underline-offset-4 group-hover:underline-offset-2 transition-all duration-200">
+  <div class="not-content m-0 underline underline-offset-4 group-hover:underline-offset-2 transition-[text-underline-offset] duration-200">
     Back to enssdk overview
   </div>
 </a>

--- a/docs/ensnode.io/src/content/docs/docs/integrate/integration-options/enssdk/example.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/integrate/integration-options/enssdk/example.mdx
@@ -32,7 +32,7 @@ You can edit the script and re-execute **`npm start`** in the terminal to run it
 >
   <Icon
     name="left-arrow"
-    class="h-5 w-5 text-[var(--sl-color-accent)] transition-colors duration-200"
+    class="h-5 w-5 text-[var(--sl-color-accent)]"
   />
   <div class="not-content m-0 underline underline-offset-4 group-hover:underline-offset-2 transition-[text-underline-offset] duration-200">
     Back to enssdk overview

--- a/docs/ensnode.io/src/content/docs/docs/integrate/integration-options/enssdk/example.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/integrate/integration-options/enssdk/example.mdx
@@ -32,9 +32,9 @@ You can edit the script and re-execute **`npm start`** in the terminal to run it
 >
   <Icon
     name="left-arrow"
-    class="h-5 w-5 text-[var(--sl-color-accent)] group-hover:text-[var(--sl-color-accent-high)] transition-colors duration-200"
+    class="h-5 w-5 text-[var(--sl-color-accent)] transition-colors duration-200"
   />
-  <div class="not-content m-0 underline underline-offset-4 group-hover:underline-offset-2 group-hover:text-[var(--sl-color-accent-high)] transition-all duration-200">
+  <div class="not-content m-0 underline underline-offset-4 group-hover:underline-offset-2 transition-all duration-200">
     Back to enssdk overview
   </div>
 </a>

--- a/docs/ensnode.io/src/styles/starlight.css
+++ b/docs/ensnode.io/src/styles/starlight.css
@@ -207,8 +207,12 @@ a[rel="prev"]:hover {
   color: var(--sl-color-white);
 }
 
+/* Override Starlight's default markdown link hover (which switches to
+   --sl-color-white): keep links their base color on hover so only the
+   underline-offset animates. */
+.sl-markdown-content a:hover:not(:where(.not-content *)),
 .sl-markdown-content a:hover:not(:where(.not-content *)) > span {
-  color: var(--sl-color-accent);
+  color: var(--sl-color-text-accent);
 }
 
 .sl-markdown-content > p a:not(:has(code), [role="tab"]),
@@ -217,17 +221,13 @@ a[rel="prev"]:hover {
   text-decoration: underline;
   text-underline-offset: 4px;
 
-  transition:
-    color 0.2s ease-in-out,
-    text-underline-offset 0.2s ease-in-out;
+  transition: text-underline-offset 0.2s ease-in-out;
 
   &:hover {
     text-underline-offset: 2px;
   }
 }
 
-.sl-markdown-content > p a:not([role="tab"]):hover,
-.sl-markdown-content :is(ul, ol) > li a:not([role="tab"]):hover,
 starlight-toc a:hover {
   color: var(--sl-color-accent-high);
 }

--- a/docs/ensnode.io/src/styles/starlight.css
+++ b/docs/ensnode.io/src/styles/starlight.css
@@ -238,9 +238,13 @@ starlight-toc a:hover {
   text-decoration: none;
 
   &:hover {
-    color: var(--sl-color-white);
     text-decoration: underline;
   }
+}
+
+.sl-markdown-content :is(h1, h2, h3, h4, h5, h6) > a:hover,
+.sl-markdown-content :is(h1, h2, h3, h4, h5, h6) > a:hover > span {
+  color: var(--sl-color-white);
 }
 
 .sl-markdown-content :global(.anchor-link) {
@@ -333,8 +337,8 @@ starlight-toc a:hover {
   font-weight: 500;
 }
 
-/* Only apply hover effects to: 
-* * non-selected items 
+/* Only apply hover effects to:
+* * non-selected items
 * * expandable items (in all states), including nested ones
 */
 #starlight__sidebar a:not([aria-current="page"]):hover,
@@ -388,7 +392,7 @@ a.starlight-sidebar-topics-current .starlight-sidebar-topics-icon {
 
 /* Make sure that all non-top-level sidebar items are:
  * * not enlarged
- * * not bolded 
+ * * not bolded
  * * the same color as the rest of the sidebar text
  */
 ul.top-level details details > summary .group-label span {
@@ -433,7 +437,7 @@ ul.top-level details details > summary .group-label span {
   transform: none !important;
 }
 
-/* Align "tablist" component to the left 
+/* Align "tablist" component to the left
  * and remove the default full-width underline
  */
 starlight-tabs ul[role="tablist"] {
@@ -604,7 +608,7 @@ starlight-tabs ul[role="tablist"] {
   }
 }
 
-/* Custom icon logic for specific sidebar items based on URL - 
+/* Custom icon logic for specific sidebar items based on URL -
  * hack since Starlight doesn't allow overriding icons directly. */
 
 .starlight-sidebar-topics-icon svg {

--- a/docs/ensnode.io/src/styles/starlight.css
+++ b/docs/ensnode.io/src/styles/starlight.css
@@ -238,6 +238,7 @@ starlight-toc a:hover {
   text-decoration: none;
 
   &:hover {
+    color: var(--sl-color-white);
     text-decoration: underline;
   }
 }


### PR DESCRIPTION
# Lite PR

[Tip: Review docs on the ENSNode PR process](https://ensnode.io/docs/contributing/prs)

## Summary

- Keep only the underline-offset transition on the "Hosted at" link (drop the hover text color shift)

---

## Why

- Requested by @lightwalker-eth 

---

## Testing

- Checked a few of the regular blue links in docs

---

## Notes for Reviewer (Optional)

spotted this:

<img width="2474" height="834" alt="image" src="https://github.com/user-attachments/assets/c7aeb16a-e8bd-4eef-ad9c-05ca011cd06a" />

that we should get rid of, we don't typically have this kind of link with icon.

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)
