### PR TITLE
fix(docs): match Card border radius to Aside component (12px)

### DIFF
--- a/docs/ensnode.io/src/styles/starlight.css
+++ b/docs/ensnode.io/src/styles/starlight.css
@@ -177,7 +177,7 @@
   box-shadow: var(--sl-shadow-sm);
 }
 
-.card {
+.sl-link-card.card {
   border-radius: 12px;
 }
 

--- a/docs/ensnode.io/src/styles/starlight.css
+++ b/docs/ensnode.io/src/styles/starlight.css
@@ -177,7 +177,6 @@
   box-shadow: var(--sl-shadow-sm);
 }
 
-/* Match Card borders to the rounded radius used by the Aside/Tip component (12px) */
 .card {
   border-radius: 12px;
 }
@@ -337,8 +336,8 @@ starlight-toc a:hover {
   font-weight: 500;
 }
 
-/* Only apply hover effects to: 
-* * non-selected items 
+/* Only apply hover effects to:
+* * non-selected items
 * * expandable items (in all states), including nested ones
 */
 #starlight__sidebar a:not([aria-current="page"]):hover,
@@ -392,7 +391,7 @@ a.starlight-sidebar-topics-current .starlight-sidebar-topics-icon {
 
 /* Make sure that all non-top-level sidebar items are:
  * * not enlarged
- * * not bolded 
+ * * not bolded
  * * the same color as the rest of the sidebar text
  */
 ul.top-level details details > summary .group-label span {
@@ -437,7 +436,7 @@ ul.top-level details details > summary .group-label span {
   transform: none !important;
 }
 
-/* Align "tablist" component to the left 
+/* Align "tablist" component to the left
  * and remove the default full-width underline
  */
 starlight-tabs ul[role="tablist"] {
@@ -608,7 +607,7 @@ starlight-tabs ul[role="tablist"] {
   }
 }
 
-/* Custom icon logic for specific sidebar items based on URL - 
+/* Custom icon logic for specific sidebar items based on URL -
  * hack since Starlight doesn't allow overriding icons directly. */
 
 .starlight-sidebar-topics-icon svg {

--- a/docs/ensnode.io/src/styles/starlight.css
+++ b/docs/ensnode.io/src/styles/starlight.css
@@ -177,6 +177,11 @@
   box-shadow: var(--sl-shadow-sm);
 }
 
+/* Match Card borders to the rounded radius used by the Aside/Tip component (12px) */
+.card {
+  border-radius: 12px;
+}
+
 .sl-link-card:hover,
 a[rel="next"]:hover,
 a[rel="prev"]:hover {

--- a/docs/ensnode.io/src/styles/starlight.css
+++ b/docs/ensnode.io/src/styles/starlight.css
@@ -177,7 +177,7 @@
   box-shadow: var(--sl-shadow-sm);
 }
 
-.sl-link-card.card {
+.card-grid .card {
   border-radius: 12px;
 }
 


### PR DESCRIPTION
# Lite PR

[Tip: Review docs on the ENSNode PR process](https://ensnode.io/docs/contributing/prs)

## Summary

<img width="1642" height="1580" alt="CleanShot 2026-05-27 at 18 45 34@2x" src="https://github.com/user-attachments/assets/d5ed6937-37f6-4050-8896-487acbf29587" />


---

## Why

- requested by @lightwalker-eth 

---

## Testing

- Checked docs

---

## Notes for Reviewer (Optional)

<img width="962" height="782" alt="CleanShot 2026-05-27 at 18 46 12@2x" src="https://github.com/user-attachments/assets/549daa18-6981-418d-b9d4-13377287bdeb" />

Maybe for a future update, but this didn't seem like our usual styling.

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)
