### PR TITLE
fix(docs): remove horizontal shift on sidebar link hover

### DIFF
--- a/docs/ensnode.io/src/styles/starlight.css
+++ b/docs/ensnode.io/src/styles/starlight.css
@@ -340,7 +340,6 @@ starlight-toc a:hover {
 #starlight__sidebar details details > summary:hover,
 #starlight__sidebar details > summary:hover {
   background-color: rgba(128, 128, 128, 0.1);
-  transform: translateX(2px);
   border-radius: 6px;
 }
 


### PR DESCRIPTION
# Lite PR

[Tip: Review docs on the ENSNode PR process](https://ensnode.io/docs/contributing/prs)

## Summary

- Drop the translateX(2px) transform from the sidebar hover rule


<img width="396" height="800" alt="CleanShot 2026-05-27 at 18 57 49" src="https://github.com/user-attachments/assets/a56eb8d9-efdd-455a-a0f2-1506c6a6bd81" />

---

## Why

- Requested by @lightwalker-eth 

---

## Testing

- Viewed in browser locally, see GIF

---

## Notes for Reviewer (Optional)

- Anything non-obvious or worth a heads-up.

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)
