### PR TITLE
Introduce `PONDER_STATEMENT_TIMEOUT` setting to `ponder` app

### DIFF
--- a/.changeset/moody-wasps-flow.md
+++ b/.changeset/moody-wasps-flow.md
@@ -1,0 +1,5 @@
+---
+"ensindexer": patch
+---
+
+Introduced `PONDER_STATEMENT_TIMEOUT` setting to manage database timeouts more granularly.

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
       "@opentelemetry/api": "patches/@opentelemetry__api.patch",
       "@opentelemetry/otlp-exporter-base": "patches/@opentelemetry__otlp-exporter-base.patch",
       "js-yaml@4.2.0": "patches/js-yaml@4.2.0.patch",
+      "ponder@0.16.6": "patches/ponder@0.16.6.patch",
       "starlight-llms-txt@0.10.0": "patches/starlight-llms-txt@0.10.0.patch"
     }
   }

--- a/patches/ponder@0.16.6.patch
+++ b/patches/ponder@0.16.6.patch
@@ -1,0 +1,30 @@
+diff --git a/dist/esm/utils/pg.js b/dist/esm/utils/pg.js
+index 0000000..0000000 100644
+--- a/dist/esm/utils/pg.js
++++ b/dist/esm/utils/pg.js
+@@ -62,9 +62,24 @@ export function createPool(config, logger) {
+             }
+         }
+     }
++    const rawStatementTimeout = process.env.PONDER_STATEMENT_TIMEOUT;
++    const statementTimeout = rawStatementTimeout === undefined || rawStatementTimeout.trim() === ""
++        ? 2 * 60 * 1000
++        : Number(rawStatementTimeout);
++    if (
++        !Number.isFinite(statementTimeout) ||
++        !Number.isInteger(statementTimeout) ||
++        statementTimeout < 0
++    ) {
++        throw new Error(`Invalid PONDER_STATEMENT_TIMEOUT: "${rawStatementTimeout}". It must be a non-negative integer (milliseconds).`);
++    }
++    logger.debug({
++        msg: "Postgres pool config",
++        statement_timeout: statementTimeout,
++    });
+     const pool = new pg.Pool({
+         // https://stackoverflow.com/questions/59155572/how-to-set-query-timeout-in-relation-to-statement-timeout
+-        statement_timeout: 2 * 60 * 1000,
++        statement_timeout: statementTimeout,
+         // @ts-expect-error: The custom Client is an undocumented option.
+         Client: Client,
+         ...config,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ patchedDependencies:
   js-yaml@4.2.0:
     hash: ac52f51689f99f5b6ae9e93670d300024c90ce32bf55ab2753541edc2775c69a
     path: patches/js-yaml@4.2.0.patch
+  ponder@0.16.6:
+    hash: 07ce9ff0276cbbcf8d5b7a93d4109d50575d5b305099e06eb2e0c19953f1eab9
+    path: patches/ponder@0.16.6.patch
   starlight-llms-txt@0.10.0:
     hash: b0be40873b81b978ff243b51b244d99ddad85f5b0ff444cc9890cb6a1566277a
     path: patches/starlight-llms-txt@0.10.0.patch
@@ -569,7 +572,7 @@ importers:
         version: 7.1.1
       ponder:
         specifier: 'catalog:'
-        version: 0.16.6(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))(@types/node@24.10.9)(@types/pg@8.16.0)(hono@4.12.25)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.3.6))(yaml@2.8.3)(zod@4.3.6)
+        version: 0.16.6(patch_hash=07ce9ff0276cbbcf8d5b7a93d4109d50575d5b305099e06eb2e0c19953f1eab9)(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))(@types/node@24.10.9)(@types/pg@8.16.0)(hono@4.12.25)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.3.6))(yaml@2.8.3)(zod@4.3.6)
       viem:
         specifier: 'catalog:'
         version: 2.50.3(typescript@5.9.3)(zod@4.3.6)
@@ -1078,7 +1081,7 @@ importers:
         version: 0.41.0(@electric-sql/pglite@0.2.13)(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))(@types/pg@8.16.0)(kysely@0.28.17)(pg@8.16.3)
       ponder:
         specifier: 'catalog:'
-        version: 0.16.6(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))(@types/node@24.10.9)(@types/pg@8.16.0)(hono@4.12.25)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.3.6))(yaml@2.8.3)(zod@4.3.6)
+        version: 0.16.6(patch_hash=07ce9ff0276cbbcf8d5b7a93d4109d50575d5b305099e06eb2e0c19953f1eab9)(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))(@types/node@24.10.9)(@types/pg@8.16.0)(hono@4.12.25)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.3.6))(yaml@2.8.3)(zod@4.3.6)
       tsup:
         specifier: 'catalog:'
         version: 8.5.0(jiti@2.6.1)(postcss@8.5.12)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.8.3)
@@ -18534,7 +18537,7 @@ snapshots:
       graphql: 16.11.0
       hono: 4.12.25
 
-  ponder@0.16.6(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))(@types/node@24.10.9)(@types/pg@8.16.0)(hono@4.12.25)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.3.6))(yaml@2.8.3)(zod@4.3.6):
+  ponder@0.16.6(patch_hash=07ce9ff0276cbbcf8d5b7a93d4109d50575d5b305099e06eb2e0c19953f1eab9)(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))(@types/node@24.10.9)(@types/pg@8.16.0)(hono@4.12.25)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.3.6))(yaml@2.8.3)(zod@4.3.6):
     dependencies:
       '@babel/code-frame': 7.29.0
       '@commander-js/extra-typings': 12.1.0(commander@12.1.0)


### PR DESCRIPTION
This aims to resolve the database performance issue where some important internal poder queries fail due to 2 minutes statement timeout. We need to try increasing the statement timeout for the PG Pool connections.

# Lite PR

[Tip: Review docs on the ENSNode PR process](https://ensnode.io/docs/contributing/prs)

## Summary

- There was a patch created for `ponder` dependency where the hardcoded SQL statement timeout got replace with the `PONDER_STATEMENT_TIMEOUT` env var read (optional, defaults to the previously hardcoded value of 2 minutes).

---

## Why

- ENSIndexer Alpha instances have displayed an issue across all environments where an SQL statement timeout makes the ENSIndexer instance to crash.
- Currently, the ENSIndexer Alpha in the yellow env suffers from this issue
    ```
    10:10:09.658 WARN  Failed database query query_id=bf6a582b retry_count=9 (2m 00s)
    error: canceling statement due to statement timeout
    ```

---

## Testing

- I tested the patch some weeks earlier and it worked just fine. More details [here](https://namehash.slack.com/archives/C086Z6FNBHN/p1780042943879369?thread_ts=1780028502.477809&cid=C086Z6FNBHN).

---

## Notes for Reviewer (Optional)

- This branch is aligned with the ENSNode v1.16.0 release, so that we can apply it dynamically to the yellow env.
  - The first commit fb3f45fb41b54b45aa14ffae25d1ec37f239094c after the ENSNode v1.16.0 was used for the base of this PR.

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)
