### PR TITLE
chore(docs): New batch of UI refinements to ensnode.io docs 

### DIFF
--- a/docs/ensnode.io/src/components/atoms/ENSAdminCTAButton.astro
+++ b/docs/ensnode.io/src/components/atoms/ENSAdminCTAButton.astro
@@ -3,7 +3,7 @@ import ENSAdminLogoDark from "@components/atoms/logos/astro/ENSAdminLogoDark.ast
 import cc from "classcat";
 
 interface ENSAdminCTAButtonProps {
-  ensAdminHref?: string;
+  ensAdminHref: string;
   text: string;
 }
 

--- a/docs/ensnode.io/src/components/atoms/ENSAdminCTAButton.astro
+++ b/docs/ensnode.io/src/components/atoms/ENSAdminCTAButton.astro
@@ -1,0 +1,23 @@
+---
+import ENSAdminLogoDark from "@components/atoms/logos/astro/ENSAdminLogoDark.astro";
+import cc from "classcat";
+
+interface ENSAdminCTAButtonProps {
+  ensAdminHref?: string;
+  text: string;
+}
+
+const { ensAdminHref, text } = Astro.props as ENSAdminCTAButtonProps;
+
+const styles =
+  "w-fit inline-flex shrink-0 cursor-pointer items-center gap-2 rounded-lg bg-[var(--sl-color-text-accent)] p-1.5 pr-2 text-sm font-medium text-[var(--sl-color-black)] transition-colors hover:bg-[var(--sl-color-accent-high)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--sl-color-text-accent)]";
+---
+
+<a
+  class={cc([styles, "no-underline"])}
+  href={ensAdminHref}
+  target="_blank"
+  rel="noopener noreferrer">
+  <ENSAdminLogoDark className="h-5 w-auto shrink-0" />
+  {text}
+</a>

--- a/docs/ensnode.io/src/components/molecules/HostedEnsNodeInstance.astro
+++ b/docs/ensnode.io/src/components/molecules/HostedEnsNodeInstance.astro
@@ -18,14 +18,13 @@ const hostedEnsNodeVersion = ACTIVE_OMNIGRAPH_VERSION;
           href={instanceURL}>{instanceURL}</a
         >
         <a
-          class="not-content w-fit open-in-ensadmin flex flex-row flex-nowrap justify-start items-center gap-1 min-[400px]:gap-2 transition-colors button-as-child bg-[var(--sl-color-accent)]
+          class="not-content w-fit open-in-ensadmin flex flex-row flex-nowrap justify-start items-center gap-2 transition-colors button-as-child bg-[var(--sl-color-accent)]
                 hover:bg-[var(--sl-color-accent-high)] p-1.5 pr-2 rounded-lg"
           target="_blank"
           rel="noopener noreferrer"
           href={connectWithENSAdminURL}>
           <ENSAdminLogoDark className="h-5 w-auto shrink-0" />
-          <p
-            class="text-[var(--sl-color-black)] text-xs min-[400px]:text-sm font-medium text-nowrap">
+          <p class="text-[var(--sl-color-black)] text-sm font-medium text-nowrap">
             Connect with ENSAdmin
           </p>
         </a>

--- a/docs/ensnode.io/src/components/molecules/HostedEnsNodeInstance.astro
+++ b/docs/ensnode.io/src/components/molecules/HostedEnsNodeInstance.astro
@@ -1,5 +1,5 @@
 ---
-import ENSAdminLogoDark from "@components/atoms/logos/astro/ENSAdminLogoDark.astro";
+import ENSAdminCTAButton from "@components/atoms/ENSAdminCTAButton.astro";
 import { ACTIVE_OMNIGRAPH_VERSION } from "@data/omnigraph-examples/active";
 
 const { instanceURL, connectWithENSAdminURL, namespace, ensVersions, plugins } = Astro.props;
@@ -17,17 +17,9 @@ const hostedEnsNodeVersion = ACTIVE_OMNIGRAPH_VERSION;
           class="sl-markdown-content underline underline-offset-4 hover:underline-offset-2 transition-[text-underline-offset] duration-200"
           href={instanceURL}>{instanceURL}</a
         >
-        <a
-          class="not-content w-fit open-in-ensadmin flex flex-row flex-nowrap justify-start items-center gap-2 transition-colors button-as-child bg-[var(--sl-color-accent)]
-                hover:bg-[var(--sl-color-accent-high)] p-1.5 pr-2 rounded-lg"
-          target="_blank"
-          rel="noopener noreferrer"
-          href={connectWithENSAdminURL}>
-          <ENSAdminLogoDark className="h-5 w-auto shrink-0" />
-          <p class="text-[var(--sl-color-black)] text-sm font-medium text-nowrap">
-            Connect with ENSAdmin
-          </p>
-        </a>
+        <div class="not-content">
+          <ENSAdminCTAButton ensAdminHref={connectWithENSAdminURL} text="Connect with ENSAdmin" />
+        </div>
       </td>
     </tr>
     <tr>

--- a/docs/ensnode.io/src/components/molecules/HostedEnsNodeInstance.astro
+++ b/docs/ensnode.io/src/components/molecules/HostedEnsNodeInstance.astro
@@ -18,13 +18,14 @@ const hostedEnsNodeVersion = ACTIVE_OMNIGRAPH_VERSION;
           href={instanceURL}>{instanceURL}</a
         >
         <a
-          class="not-content w-fit open-in-ensadmin flex flex-row flex-nowrap justify-start items-center gap-1 min-[400px]:gap-2 transition-all button-as-child bg-[var(--sl-color-accent)]
+          class="not-content w-fit open-in-ensadmin flex flex-row flex-nowrap justify-start items-center gap-1 min-[400px]:gap-2 transition-colors button-as-child bg-[var(--sl-color-accent)]
                 hover:bg-[var(--sl-color-accent-high)] pl-1 pr-2 py-1 min-[400px]:pl-2 min-[400px]:pr-3 min-[400px]:py-2 rounded-lg"
           target="_blank"
           rel="noopener noreferrer"
           href={connectWithENSAdminURL}>
           <ENSAdminLogoDark className="h-6.5 w-auto shrink-0" />
-          <p class="text-[var(--sl-color-black)] text-xs min-[400px]:text-base font-normal">
+          <p
+            class="text-[var(--sl-color-black)] text-xs min-[400px]:text-base font-normal text-nowrap">
             Connect with ENSAdmin
           </p>
         </a>

--- a/docs/ensnode.io/src/components/molecules/HostedEnsNodeInstance.astro
+++ b/docs/ensnode.io/src/components/molecules/HostedEnsNodeInstance.astro
@@ -19,13 +19,13 @@ const hostedEnsNodeVersion = ACTIVE_OMNIGRAPH_VERSION;
         >
         <a
           class="not-content w-fit open-in-ensadmin flex flex-row flex-nowrap justify-start items-center gap-1 min-[400px]:gap-2 transition-colors button-as-child bg-[var(--sl-color-accent)]
-                hover:bg-[var(--sl-color-accent-high)] pl-1 pr-2 py-1 min-[400px]:pl-2 min-[400px]:pr-3 min-[400px]:py-2 rounded-lg"
+                hover:bg-[var(--sl-color-accent-high)] p-1.5 pr-2 rounded-lg"
           target="_blank"
           rel="noopener noreferrer"
           href={connectWithENSAdminURL}>
-          <ENSAdminLogoDark className="h-6.5 w-auto shrink-0" />
+          <ENSAdminLogoDark className="h-5 w-auto shrink-0" />
           <p
-            class="text-[var(--sl-color-black)] text-xs min-[400px]:text-base font-normal text-nowrap">
+            class="text-[var(--sl-color-black)] text-xs min-[400px]:text-sm font-medium text-nowrap">
             Connect with ENSAdmin
           </p>
         </a>

--- a/docs/ensnode.io/src/components/molecules/omnigraph-static-example/StaticExampleActionBar.astro
+++ b/docs/ensnode.io/src/components/molecules/omnigraph-static-example/StaticExampleActionBar.astro
@@ -20,7 +20,7 @@ const { variant, adminUrl, hostedInstanceDocUrl, hostedInstanceNamespace, static
 const actionBarClass =
   "flex flex-wrap items-center gap-3 border-b border-black/[0.06] bg-[var(--sl-color-gray-6)] px-4 py-4 dark:border-white/[0.08] dark:bg-[var(--sl-color-gray-7)] md:px-5";
 const actionButtonClass =
-  "inline-flex shrink-0 cursor-pointer items-center gap-2 rounded-lg bg-[var(--sl-color-text-accent)] p-1.5 pr-2 text-sm font-semibold text-[var(--sl-color-black)] transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--sl-color-text-accent)]";
+  "inline-flex shrink-0 cursor-pointer items-center gap-2 rounded-lg bg-[var(--sl-color-text-accent)] p-1.5 pr-2 text-sm font-semibold text-[var(--sl-color-black)] transition-colors hover:bg-[var(--sl-color-accent-high)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--sl-color-text-accent)]";
 ---
 
 <div class={actionBarClass}>

--- a/docs/ensnode.io/src/components/molecules/omnigraph-static-example/StaticExampleActionBar.astro
+++ b/docs/ensnode.io/src/components/molecules/omnigraph-static-example/StaticExampleActionBar.astro
@@ -26,7 +26,7 @@ const actionButtonClass =
 <div class={actionBarClass}>
   {
     variant === "ensadmin" ? (
-      <ENSAdminCTAButton ensAdminHref={adminUrl} text="Run in ENSAdmin" />
+      adminUrl && <ENSAdminCTAButton ensAdminHref={adminUrl} text="Run in ENSAdmin" />
     ) : (
       <button type="button" class={actionButtonClass} data-static-example-id={staticExampleId}>
         <StackBlitzLogo className="h-5 w-auto shrink-0" />

--- a/docs/ensnode.io/src/components/molecules/omnigraph-static-example/StaticExampleActionBar.astro
+++ b/docs/ensnode.io/src/components/molecules/omnigraph-static-example/StaticExampleActionBar.astro
@@ -1,7 +1,7 @@
 ---
 import type { ENSNamespaceId } from "@ensnode/ensnode-sdk";
 
-import ENSAdminLogoDark from "@components/atoms/logos/astro/ENSAdminLogoDark.astro";
+import ENSAdminCTAButton from "@components/atoms/ENSAdminCTAButton.astro";
 import StackBlitzLogo from "@components/atoms/logos/astro/StackBlitzLogo.astro";
 
 import StaticExamplePlaygroundHint from "./StaticExamplePlaygroundHint.astro";
@@ -26,14 +26,7 @@ const actionButtonClass =
 <div class={actionBarClass}>
   {
     variant === "ensadmin" ? (
-      <a
-        class={`${actionButtonClass} no-underline`}
-        href={adminUrl}
-        target="_blank"
-        rel="noopener noreferrer">
-        <ENSAdminLogoDark className="h-5 w-auto shrink-0" />
-        Run in ENSAdmin
-      </a>
+      <ENSAdminCTAButton ensAdminHref={adminUrl} text="Run in ENSAdmin" />
     ) : (
       <button type="button" class={actionButtonClass} data-static-example-id={staticExampleId}>
         <StackBlitzLogo className="h-5 w-auto shrink-0" />

--- a/docs/ensnode.io/src/components/molecules/omnigraph-static-example/StaticExampleActionBar.astro
+++ b/docs/ensnode.io/src/components/molecules/omnigraph-static-example/StaticExampleActionBar.astro
@@ -20,7 +20,7 @@ const { variant, adminUrl, hostedInstanceDocUrl, hostedInstanceNamespace, static
 const actionBarClass =
   "flex flex-wrap items-center gap-3 border-b border-black/[0.06] bg-[var(--sl-color-gray-6)] px-4 py-4 dark:border-white/[0.08] dark:bg-[var(--sl-color-gray-7)] md:px-5";
 const actionButtonClass =
-  "inline-flex shrink-0 cursor-pointer items-center gap-2 rounded-lg bg-[var(--sl-color-text-accent)] p-1.5 pr-2 text-sm font-semibold text-[var(--sl-color-black)] transition-colors hover:bg-[var(--sl-color-accent-high)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--sl-color-text-accent)]";
+  "inline-flex shrink-0 cursor-pointer items-center gap-2 rounded-lg bg-[var(--sl-color-text-accent)] p-1.5 pr-2 text-sm font-medium text-[var(--sl-color-black)] transition-colors hover:bg-[var(--sl-color-accent-high)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--sl-color-text-accent)]";
 ---
 
 <div class={actionBarClass}>

--- a/docs/ensnode.io/src/components/molecules/omnigraph-static-example/StaticExamplePlaygroundHint.astro
+++ b/docs/ensnode.io/src/components/molecules/omnigraph-static-example/StaticExamplePlaygroundHint.astro
@@ -10,7 +10,7 @@ interface Props {
 const { variant, hostedInstanceDocUrl, hostedInstanceNamespace } = Astro.props;
 
 const hostedInstanceLinkClass =
-  "text-sm font-semibold text-[var(--sl-color-accent)] underline underline-offset-4 hover:underline-offset-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 transition-underline duration-200";
+  "text-sm font-semibold text-[var(--sl-color-accent)] underline underline-offset-4 hover:underline-offset-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--sl-color-text-accent)] transition-[text-underline-offset] duration-200";
 ---
 
 <span class="hidden text-xs leading-snug text-[var(--sl-color-gray-3)] sm:block">

--- a/docs/ensnode.io/src/components/molecules/omnigraph-static-example/StaticExamplePlaygroundHint.astro
+++ b/docs/ensnode.io/src/components/molecules/omnigraph-static-example/StaticExamplePlaygroundHint.astro
@@ -10,7 +10,7 @@ interface Props {
 const { variant, hostedInstanceDocUrl, hostedInstanceNamespace } = Astro.props;
 
 const hostedInstanceLinkClass =
-  "text-sm font-semibold text-[var(--sl-color-gray-1)] underline decoration-[var(--sl-color-gray-4)] underline-offset-2 transition-colors hover:text-[var(--sl-color-text-accent)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--sl-color-text-accent)]";
+  "text-sm font-semibold text-[var(--sl-color-accent)] underline underline-offset-4 hover:underline-offset-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 transition-underline duration-200";
 ---
 
 <span class="hidden text-xs leading-snug text-[var(--sl-color-gray-3)] sm:block">

--- a/docs/ensnode.io/src/styles/starlight.css
+++ b/docs/ensnode.io/src/styles/starlight.css
@@ -337,12 +337,6 @@ starlight-toc a:hover {
   }
 }
 
-.open-in-ensadmin {
-  @media screen and (max-width: 400px) {
-    font-size: 14px;
-  }
-}
-
 /* Enhance hover and selected states for sidebar items */
 #starlight__sidebar a {
   transition:

--- a/docs/ensnode.io/src/styles/starlight.css
+++ b/docs/ensnode.io/src/styles/starlight.css
@@ -482,6 +482,10 @@ starlight-tabs ul[role="tablist"] {
 
   & a {
     color: var(--aside-text-color, var(--aside-color));
+
+    &:hover {
+      color: var(--aside-text-color, var(--aside-color));
+    }
   }
 
   & code {


### PR DESCRIPTION
# Lite PR &rarr; New batch of refinements to ensnode.io docs 

## Summary

- Applied feedback items 1,6,7 from the related Google Doc spec
- Extracted the `ENSAdmin CTA` button to a separate component to avoid code duplication
- Fixed the link hover color bug of the `<Aside/>` components, where the links would change the color to blue when hovered.

---


## Why

- Requested by @lightwalker-eth [here](https://namehash.slack.com/archives/C086Z6FNBHN/p1779872976107029)

---

## Testing

- Ran `lint` command locally to ensure that the migration didn't break anything, and later confirmed that in our CI workflow
- Verified the UI after introducing changes using a local and Vercel (build) previews

---

## Notes for Reviewer (Optional)

- Pure UI/UX changes, so I don't think that the changeset log is required

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)
