### PR TITLE
fix(docs): round code block frames and remove drop shadow

### DIFF
--- a/docs/ensnode.io/src/styles/starlight.css
+++ b/docs/ensnode.io/src/styles/starlight.css
@@ -668,7 +668,7 @@ starlight-tabs ul[role="tablist"] {
 
 /* Radius + overflow live on the figure so the horizontal scrollbar inside
    <pre> gets clipped by the rounded shape instead of overlapping it. */
-.sl-markdown-content .expressive-code .frame:not(.not-content) {
+.sl-markdown-content .expressive-code .frame {
   border-radius: 12px;
   overflow: hidden;
   box-shadow: none;

--- a/docs/ensnode.io/src/styles/starlight.css
+++ b/docs/ensnode.io/src/styles/starlight.css
@@ -671,6 +671,7 @@ starlight-tabs ul[role="tablist"] {
 .sl-markdown-content .expressive-code .frame:not(.not-content) {
   border-radius: 12px;
   overflow: hidden;
+  box-shadow: none;
   border-color: color-mix(in srgb, var(--sl-color-gray-5), transparent 25%);
 }
 


### PR DESCRIPTION
# Lite PR

[Tip: Review docs on the ENSNode PR process](https://ensnode.io/docs/contributing/prs)

## Summary

There was a shadow on expressive code that meant we seen the lack of border radius. The shadow also made the box look blurry.

Before

<img width="1530" height="234" alt="CleanShot 2026-06-03 at 08 57 37@2x" src="https://github.com/user-attachments/assets/8ca685ee-d6a7-47b6-b802-d621db2137da" />

After

<img width="1518" height="280" alt="CleanShot 2026-06-03 at 08 57 31@2x" src="https://github.com/user-attachments/assets/2ab946cf-6425-4de5-be55-3fb4b549e9a5" />
<img width="1516" height="146" alt="CleanShot 2026-06-03 at 08 57 06@2x" src="https://github.com/user-attachments/assets/830f153b-7de7-44fb-82a4-b2449cb60a65" />


---

## Why

- Why this change exists. Link to related GitHub issues where relevant.

---

## Testing

- How this was tested.
- If you didn't test it, say why.

---

## Notes for Reviewer (Optional)

- Anything non-obvious or worth a heads-up.

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)
