### PR TITLE
chore(docs): Refine the X icon for `NotENSv2Ready` badge

### DIFF
--- a/docs/ensnode.io/src/components/atoms/NotENSv2ReadyBadge.tsx
+++ b/docs/ensnode.io/src/components/atoms/NotENSv2ReadyBadge.tsx
@@ -1,9 +1,9 @@
 import type React from "react";
 import { CheckSolidIcon } from "@components/atoms/icons/CheckSolidIcon";
 import { SkullIcon } from "@components/atoms/icons/SkullIcon";
-import { XMarkIcon } from "@components/atoms/icons/XMarkIcon";
 import { Tooltip } from "@namehash/namehash-ui/legacy";
 import { useIsMobile } from "@namehash/namehash-ui";
+import { useId } from "react";
 
 export interface ENSSubgraphDependentApplicationTransitionStages {
   toENSNodeSubgraphCompatibleEndpoint: boolean;
@@ -81,29 +81,34 @@ const NotENSv2ReadyInfoIcon = (props: React.SVGProps<SVGSVGElement>) => (
   </svg>
 );
 
-// for the same reason here is the X icon, unique to this badge
-const NotENSv2ReadyXIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    width="12"
-    height="12"
-    viewBox="0 0 12 12"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-    xmlnsXlink="http://www.w3.org/1999/xlink"
-    {...props}
-  >
-    <rect width="12" height="12" fill="url(#pattern0_2984_387)" />
-    <defs>
-      <pattern id="pattern0_2984_387" patternContentUnits="objectBoundingBox" width="1" height="1">
-        <use xlinkHref="#image0_2984_387" transform="scale(0.0227273)" />
-      </pattern>
-      <image
-        id="image0_2984_387"
-        width="44"
-        height="44"
-        preserveAspectRatio="none"
-        href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAsCAYAAAAehFoBAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAALKADAAQAAAABAAAALAAAAAD8buejAAAGeklEQVRYCbWZPW8cVRSGb/wRhISFUmVJEYkKggiKZJokQjJKikjUKEKh2AIJRaLjD+wfoKOBCgoEoQ12FREJQgEEEoSEoKDgM5vEH3i98cfOZob3Oblncj1e767t3ZGO79l7zznvM3fu3NlZh5AcRaMxwceiKA51ZmevZOfOnbbPc3NTSdhY3CJqoIk2DKYdmXaIOiwDWydOXO1MThado0eXty5dOmmJY4R2WLTQRBsGh0zZrC/tUOD8FgkhbMiKrVqtNU7oFNa00ET7EfT8DugK7MKmAjdD6MhoM9pxQVdhU035HVg0gQs7oOlgZgnYeAybewH1FZu12uooZzqFpbZpxAmSrmkbS2Wm7QZb13rZiLAkRsvVYnzOaFV4JMujAttKNeSnujaBsMFoN+Lvx49/vjU1Vaxr3cho82hVP2N844DQKSy1oqbV7qO9ASOsoRHCmZ9CWMkE80AzKauCpidg4w9YHhcvvshScgD8QYfHkkuNqLUrLOMwwQZjQ6ym8VYIL90OocVAO0IrMI9GUuo/ht7DllfCKsdhgZFV65dasMAEG4wG+0EI0zj1EE4y0FHAmgIVDHwererb+PqQyyOFJSfW7qsBAywwwQajs4brIdiTjIFbCmD/JUFGm0er+jbeBqDPTDssMcTGmgNrwwCLwzoj4HZ4Rz1Cs6W1BC2jzaNVfRtf03rsBZ3CEhNrDayJdl/YyLxtpn/Q2bHdrA4PvW3Lc1j2bsG2hoFFC020mTi4fCKdcUfrAXUlOPR/KqRiwOfRqr6Nt5LlQWFmnb6Y27cGGsPA2jeiKjXQr4bQBfqdEL55IYQZ3QBdxbHWixhPburb+ESt9iCcPz9rMdeu3cybzafkD8w9rNq/hLD2fghnPwrhZ2ewOsP8IYG4uqBv6hKx/axoFmSFZiOPVvVtfPXYsSYWYzPFVuMsn3FqUhsNtNB0bfw9HZ5YV6HvVZDtaDlCSyiPhmjqd/WZPsz9dLz0qUVNaqMBnGvi7+vwAnUV/C5CL0lIYsDn0ar+Q/Vj1f4ynhrAUpPawLkW/oEOL1SP0OylCMpo82j4/SyNs314LLB+plVotqnF7dD9YP3ELIfcscL2gv5WuxY3k6C7MtphrEsOuVwt6vpEuMbIWxfQtvfcrYkJ2wnua73KclmxizH2kBuRHHL3C2tvyXs5q7m5OQv/8vLl8MyRI7bBDpvPZkwOuRxeyz6M448/bpf1BLtfq60xm/e0JGS0w1jXrkCt1qYGjF5z5LxemMetYFt3pSXLYpvHlr7dzGMshxq9vjCNBNxhmZV7EmruhHWY3WDpJ8bjMmpQa+QzXYFdRUhmgmrzaPSV/h3dYJj6tvWnMfIdenVk0CnsXc2GIPrCMi57tE6jH3PKk6lCM07tA0P3glXxDAFZHq3qZ+zHN0JoYvjD5FDzQNAlrN5uVWj1XxWUZbHN1WL0GXj0Hbb9uvZZTNBtoDVuuZwkOTE+9W0creW9vo2XsLrBBsEm4g7buhSfYNzt+IJupdAxpz/0sFteCtvUuvpHsyPLYpurxehL/Yy99WuBOSxPQ38i0scYMcobWIv6aA9c071gNRs9lwGzFMF7wvpe2g+630wPhE5h72gdOUxs09ks/b91MjzdqjPrsN5Wockht19tjdk4LDtmupidnaY4AwpoqZgVjG2uFqMv9YeCHQTdo+42DcZhKqEja2gmsH52asvZdD8KGOxXlTXrcLu16UyT6zNNTa+vtupnDg0jtQ+tX7hweu327fms2Tyi12B7uy2UyCsx4+6rpat7WDfUr3q71c9GZz/Z49st0Ppq2eVGfFtv488nb+MqXkgDEXRSv6v+qelabWXm1KnXJl9ZWnrv6cXFl58IYfNhCIdJVIIlyjFwtRQx2N/2CUvNj3XVrkv8XT1U9LPBF8+G8ObREJ6ULhM1iQjianHtT67+abFttNszPy4tzVj/ZyFc/UOx2tg7f6nl0uhS2JJIl8GgG4xiwxxAE+dbXnV5RO0CFphgg1EpdiKmoY75P2NAhPabbV9r1or2+ZNC91rTDgsTbGWpRggT/kEDCym0znRPu4HXGbZNobl6PtMV2AWv13DW0tEIZ8MlaOpfCHwZp1D6BPPkUbVVaDTRjsugnNmU0bTTjk+1XpjpG/qZ/o34y7cXHhVoWsdro4Um2jB4TMrmfdYmA4c+DOGKPp9hwAvij+twjYY00ZaO3WD6XC5ZtP8HZkBqyykb7AUAAAAASUVORK5CYII="
-      />
-    </defs>
-  </svg>
-);
+// Same reason as above: this X icon is unique to this badge
+const NotENSv2ReadyXIcon = (props: React.SVGProps<SVGSVGElement>) => {
+  const id = useId();
+  const patternId = `pattern0_${id}`;
+  const imageId = `image0_${id}`;
+
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <rect width="12" height="12" fill={`url(#${patternId})`} />
+      <defs>
+        <pattern id={patternId} patternContentUnits="objectBoundingBox" width="1" height="1">
+          <use href={`#${imageId}`} transform="scale(0.0227273)" />
+        </pattern>
+        <image
+          id={imageId}
+          width="44"
+          height="44"
+          preserveAspectRatio="none"
+          href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAsCAYAAAAehFoBAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAALKADAAQAAAABAAAALAAAAAD8buejAAAGeklEQVRYCbWZPW8cVRSGb/wRhISFUmVJEYkKggiKZJokQjJKikjUKEKh2AIJRaLjD+wfoKOBCgoEoQ12FREJQgEEEoSEoKDgM5vEH3i98cfOZob3Oblncj1e767t3ZGO79l7zznvM3fu3NlZh5AcRaMxwceiKA51ZmevZOfOnbbPc3NTSdhY3CJqoIk2DKYdmXaIOiwDWydOXO1MThado0eXty5dOmmJY4R2WLTQRBsGh0zZrC/tUOD8FgkhbMiKrVqtNU7oFNa00ET7EfT8DugK7MKmAjdD6MhoM9pxQVdhU035HVg0gQs7oOlgZgnYeAybewH1FZu12uooZzqFpbZpxAmSrmkbS2Wm7QZb13rZiLAkRsvVYnzOaFV4JMujAttKNeSnujaBsMFoN+Lvx49/vjU1Vaxr3cho82hVP2N844DQKSy1oqbV7qO9ASOsoRHCmZ9CWMkE80AzKauCpidg4w9YHhcvvshScgD8QYfHkkuNqLUrLOMwwQZjQ6ym8VYIL90OocVAO0IrMI9GUuo/ht7DllfCKsdhgZFV65dasMAEG4wG+0EI0zj1EE4y0FHAmgIVDHwererb+PqQyyOFJSfW7qsBAywwwQajs4brIdiTjIFbCmD/JUFGm0er+jbeBqDPTDssMcTGmgNrwwCLwzoj4HZ4Rz1Cs6W1BC2jzaNVfRtf03rsBZ3CEhNrDayJdl/YyLxtpn/Q2bHdrA4PvW3Lc1j2bsG2hoFFC020mTi4fCKdcUfrAXUlOPR/KqRiwOfRqr6Nt5LlQWFmnb6Y27cGGsPA2jeiKjXQr4bQBfqdEL55IYQZ3QBdxbHWixhPburb+ESt9iCcPz9rMdeu3cybzafkD8w9rNq/hLD2fghnPwrhZ2ewOsP8IYG4uqBv6hKx/axoFmSFZiOPVvVtfPXYsSYWYzPFVuMsn3FqUhsNtNB0bfw9HZ5YV6HvVZDtaDlCSyiPhmjqd/WZPsz9dLz0qUVNaqMBnGvi7+vwAnUV/C5CL0lIYsDn0ar+Q/Vj1f4ynhrAUpPawLkW/oEOL1SP0OylCMpo82j4/SyNs314LLB+plVotqnF7dD9YP3ELIfcscL2gv5WuxY3k6C7MtphrEsOuVwt6vpEuMbIWxfQtvfcrYkJ2wnua73KclmxizH2kBuRHHL3C2tvyXs5q7m5OQv/8vLl8MyRI7bBDpvPZkwOuRxeyz6M448/bpf1BLtfq60xm/e0JGS0w1jXrkCt1qYGjF5z5LxemMetYFt3pSXLYpvHlr7dzGMshxq9vjCNBNxhmZV7EmruhHWY3WDpJ8bjMmpQa+QzXYFdRUhmgmrzaPSV/h3dYJj6tvWnMfIdenVk0CnsXc2GIPrCMi57tE6jH3PKk6lCM07tA0P3glXxDAFZHq3qZ+zHN0JoYvjD5FDzQNAlrN5uVWj1XxWUZbHN1WL0GXj0Hbb9uvZZTNBtoDVuuZwkOTE+9W0creW9vo2XsLrBBsEm4g7buhSfYNzt+IJupdAxpz/0sFteCtvUuvpHsyPLYpurxehL/Yy99WuBOSxPQ38i0scYMcobWIv6aA9c071gNRs9lwGzFMF7wvpe2g+630wPhE5h72gdOUxs09ks/b91MjzdqjPrsN5Wockht19tjdk4LDtmupidnaY4AwpoqZgVjG2uFqMv9YeCHQTdo+42DcZhKqEja2gmsH52asvZdD8KGOxXlTXrcLu16UyT6zNNTa+vtupnDg0jtQ+tX7hweu327fms2Tyi12B7uy2UyCsx4+6rpat7WDfUr3q71c9GZz/Z49st0Ppq2eVGfFtv488nb+MqXkgDEXRSv6v+qelabWXm1KnXJl9ZWnrv6cXFl58IYfNhCIdJVIIlyjFwtRQx2N/2CUvNj3XVrkv8XT1U9LPBF8+G8ObREJ6ULhM1iQjianHtT67+abFttNszPy4tzVj/ZyFc/UOx2tg7f6nl0uhS2JJIl8GgG4xiwxxAE+dbXnV5RO0CFphgg1EpdiKmoY75P2NAhPabbV9r1or2+ZNC91rTDgsTbGWpRggT/kEDCym0znRPu4HXGbZNobl6PtMV2AWv13DW0tEIZ8MlaOpfCHwZp1D6BPPkUbVVaDTRjsugnNmU0bTTjk+1XpjpG/qZ/o34y7cXHhVoWsdro4Um2jB4TMrmfdYmA4c+DOGKPp9hwAvij+twjYY00ZaO3WD6XC5ZtP8HZkBqyykb7AUAAAAASUVORK5CYII="
+        />
+      </defs>
+    </svg>
+  );
+};

--- a/docs/ensnode.io/src/components/atoms/NotENSv2ReadyBadge.tsx
+++ b/docs/ensnode.io/src/components/atoms/NotENSv2ReadyBadge.tsx
@@ -38,23 +38,23 @@ export const NotENSv2ReadyBadge = ({ transitionStages }: NotENSv2ReadyBadgeProps
 };
 
 const ENSv2NotReadyTooltipContent = ({ transitionStages }: NotENSv2ReadyBadgeProps) => {
-  const transitionInfoStyles = "flex flex-row flex-nowrap justify-start items-start gap-1.5";
+  const transitionInfoStyles = "flex flex-row flex-nowrap justify-start items-start gap-2";
 
   return (
     <div className="h-fit flex flex-col justify-start items-start gap-2 cursor-default -mx-1 py-1">
       <div className={transitionInfoStyles}>
         {transitionStages.toENSNodeSubgraphCompatibleEndpoint ? (
-          <CheckSolidIcon className="w-5 h-5 shrink-0 pt-1" />
+          <CheckSolidIcon className="w-4 h-4 shrink-0 pt-1 box-content" />
         ) : (
-          <XMarkIcon className="w-5 h-5 shrink-0 stroke-red-500 stroke-2 pt-0.5" />
+          <NotENSv2ReadyXIcon className="w-4 h-4 shrink-0 pt-1 box-content" />
         )}
         <p className="text-xs leading-5">Transitioned from The Graph to ENSNode</p>
       </div>
       <div className={transitionInfoStyles}>
         {transitionStages.toOmnigraphAPI ? (
-          <CheckSolidIcon className="w-5 h-5 shrink-0 pt-1" />
+          <CheckSolidIcon className="w-4 h-4 shrink-0 pt-1 box-content" />
         ) : (
-          <XMarkIcon className="w-5 h-5 shrink-0 stroke-red-500 stroke-2 pt-0.5" />
+          <NotENSv2ReadyXIcon className="w-4 h-4 shrink-0 pt-1 box-content" />
         )}
         <p className="text-xs leading-5">Transitioned from the Subgraph API to the Omnigraph API</p>
       </div>
@@ -78,5 +78,32 @@ const NotENSv2ReadyInfoIcon = (props: React.SVGProps<SVGSVGElement>) => (
       d="M6 0C9.31371 0 12 2.68629 12 6C12 9.31371 9.31371 12 6 12C2.68629 12 0 9.31371 0 6C0 2.68629 2.68629 0 6 0ZM5 5C4.58579 5 4.25 5.33579 4.25 5.75C4.25 6.16421 4.58579 6.5 5 6.5H5.25293C5.41287 6.5 5.53176 6.64856 5.49707 6.80469L5.25293 8C5.01013 9.09286 5.84239 10.1299 6.96191 10.1299H7.21484C7.62897 10.1299 7.96471 9.79398 7.96484 9.37988C7.96484 8.96567 7.62906 8.62988 7.21484 8.62988H6.96191C6.80198 8.62988 6.68308 8.48132 6.71777 8.3252L6.96191 7.12988C7.20478 6.03698 6.37249 5 5.25293 5H5ZM6 2C5.44771 2 5 2.44772 5 3C5 3.55228 5.44771 4 6 4C6.55228 4 7 3.55228 7 3C7 2.44772 6.55228 2 6 2Z"
       fill="currentColor"
     />
+  </svg>
+);
+
+// for the same reason here is the X icon, unique to this badge
+const NotENSv2ReadyXIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    width="12"
+    height="12"
+    viewBox="0 0 12 12"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlnsXlink="http://www.w3.org/1999/xlink"
+    {...props}
+  >
+    <rect width="12" height="12" fill="url(#pattern0_2984_387)" />
+    <defs>
+      <pattern id="pattern0_2984_387" patternContentUnits="objectBoundingBox" width="1" height="1">
+        <use xlinkHref="#image0_2984_387" transform="scale(0.0227273)" />
+      </pattern>
+      <image
+        id="image0_2984_387"
+        width="44"
+        height="44"
+        preserveAspectRatio="none"
+        href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAsCAYAAAAehFoBAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAALKADAAQAAAABAAAALAAAAAD8buejAAAGeklEQVRYCbWZPW8cVRSGb/wRhISFUmVJEYkKggiKZJokQjJKikjUKEKh2AIJRaLjD+wfoKOBCgoEoQ12FREJQgEEEoSEoKDgM5vEH3i98cfOZob3Oblncj1e767t3ZGO79l7zznvM3fu3NlZh5AcRaMxwceiKA51ZmevZOfOnbbPc3NTSdhY3CJqoIk2DKYdmXaIOiwDWydOXO1MThado0eXty5dOmmJY4R2WLTQRBsGh0zZrC/tUOD8FgkhbMiKrVqtNU7oFNa00ET7EfT8DugK7MKmAjdD6MhoM9pxQVdhU035HVg0gQs7oOlgZgnYeAybewH1FZu12uooZzqFpbZpxAmSrmkbS2Wm7QZb13rZiLAkRsvVYnzOaFV4JMujAttKNeSnujaBsMFoN+Lvx49/vjU1Vaxr3cho82hVP2N844DQKSy1oqbV7qO9ASOsoRHCmZ9CWMkE80AzKauCpidg4w9YHhcvvshScgD8QYfHkkuNqLUrLOMwwQZjQ6ym8VYIL90OocVAO0IrMI9GUuo/ht7DllfCKsdhgZFV65dasMAEG4wG+0EI0zj1EE4y0FHAmgIVDHwererb+PqQyyOFJSfW7qsBAywwwQajs4brIdiTjIFbCmD/JUFGm0er+jbeBqDPTDssMcTGmgNrwwCLwzoj4HZ4Rz1Cs6W1BC2jzaNVfRtf03rsBZ3CEhNrDayJdl/YyLxtpn/Q2bHdrA4PvW3Lc1j2bsG2hoFFC020mTi4fCKdcUfrAXUlOPR/KqRiwOfRqr6Nt5LlQWFmnb6Y27cGGsPA2jeiKjXQr4bQBfqdEL55IYQZ3QBdxbHWixhPburb+ESt9iCcPz9rMdeu3cybzafkD8w9rNq/hLD2fghnPwrhZ2ewOsP8IYG4uqBv6hKx/axoFmSFZiOPVvVtfPXYsSYWYzPFVuMsn3FqUhsNtNB0bfw9HZ5YV6HvVZDtaDlCSyiPhmjqd/WZPsz9dLz0qUVNaqMBnGvi7+vwAnUV/C5CL0lIYsDn0ar+Q/Vj1f4ynhrAUpPawLkW/oEOL1SP0OylCMpo82j4/SyNs314LLB+plVotqnF7dD9YP3ELIfcscL2gv5WuxY3k6C7MtphrEsOuVwt6vpEuMbIWxfQtvfcrYkJ2wnua73KclmxizH2kBuRHHL3C2tvyXs5q7m5OQv/8vLl8MyRI7bBDpvPZkwOuRxeyz6M448/bpf1BLtfq60xm/e0JGS0w1jXrkCt1qYGjF5z5LxemMetYFt3pSXLYpvHlr7dzGMshxq9vjCNBNxhmZV7EmruhHWY3WDpJ8bjMmpQa+QzXYFdRUhmgmrzaPSV/h3dYJj6tvWnMfIdenVk0CnsXc2GIPrCMi57tE6jH3PKk6lCM07tA0P3glXxDAFZHq3qZ+zHN0JoYvjD5FDzQNAlrN5uVWj1XxWUZbHN1WL0GXj0Hbb9uvZZTNBtoDVuuZwkOTE+9W0creW9vo2XsLrBBsEm4g7buhSfYNzt+IJupdAxpz/0sFteCtvUuvpHsyPLYpurxehL/Yy99WuBOSxPQ38i0scYMcobWIv6aA9c071gNRs9lwGzFMF7wvpe2g+630wPhE5h72gdOUxs09ks/b91MjzdqjPrsN5Wockht19tjdk4LDtmupidnaY4AwpoqZgVjG2uFqMv9YeCHQTdo+42DcZhKqEja2gmsH52asvZdD8KGOxXlTXrcLu16UyT6zNNTa+vtupnDg0jtQ+tX7hweu327fms2Tyi12B7uy2UyCsx4+6rpat7WDfUr3q71c9GZz/Z49st0Ppq2eVGfFtv488nb+MqXkgDEXRSv6v+qelabWXm1KnXJl9ZWnrv6cXFl58IYfNhCIdJVIIlyjFwtRQx2N/2CUvNj3XVrkv8XT1U9LPBF8+G8ObREJ6ULhM1iQjianHtT67+abFttNszPy4tzVj/ZyFc/UOx2tg7f6nl0uhS2JJIl8GgG4xiwxxAE+dbXnV5RO0CFphgg1EpdiKmoY75P2NAhPabbV9r1or2+ZNC91rTDgsTbGWpRggT/kEDCym0znRPu4HXGbZNobl6PtMV2AWv13DW0tEIZ8MlaOpfCHwZp1D6BPPkUbVVaDTRjsugnNmU0bTTjk+1XpjpG/qZ/o34y7cXHhVoWsdro4Um2jB4TMrmfdYmA4c+DOGKPp9hwAvij+twjYY00ZaO3WD6XC5ZtP8HZkBqyykb7AUAAAAASUVORK5CYII="
+      />
+    </defs>
   </svg>
 );

--- a/docs/ensnode.io/src/components/atoms/icons/CheckSolidIcon.tsx
+++ b/docs/ensnode.io/src/components/atoms/icons/CheckSolidIcon.tsx
@@ -1,27 +1,33 @@
 import type React from "react";
+import { useId } from "react";
 
-export const CheckSolidIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    width="12"
-    height="12"
-    viewBox="0 0 12 12"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-    xmlnsXlink="http://www.w3.org/1999/xlink"
-    {...props}
-  >
-    <rect width="12" height="12" fill="url(#pattern0_2974_708)" />
-    <defs>
-      <pattern id="pattern0_2974_708" patternContentUnits="objectBoundingBox" width="1" height="1">
-        <use xlinkHref="#image0_2974_708" transform="scale(0.0227273)" />
-      </pattern>
-      <image
-        id="image0_2974_708"
-        width="44"
-        height="44"
-        preserveAspectRatio="none"
-        xlinkHref="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAsCAYAAAAehFoBAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAALKADAAQAAAABAAAALAAAAAD8buejAAAJ60lEQVRYCb1ZW2wU1xn+zuzMLr5gahuLNOA0Ntcgol6UUomqFIumuFVL8kKF1LwFnKRCbQnIJm6kLpaaREEFk4c+JS9V1UKf+5CQBmRVbR/Sqq0gQMCYgCEkLL5718zuzpx+/5mZ9Xp9W4q3v707M2fOOf93/vP9l5lViCQJC0n45rK7fouViO9VMavNt/z1GjoOFXWs0FGDKlTW8q2r2vPP+W72FF4buWC0FWELYPwRMfwIHn7SVIsvolclYs9rJw84WSBBrLYtk8mMlRGC1Zpm8ajTpc4cdeZsaNd7B3fwc/wmNYkQo6JVA8smG9YgYZ9DjbUOta5uang0v23VU9ba5S1WnVMbAAZnXnLUwZyEi/HcJK5NXPf/9vk//NTwpzYmEwppvx9uvg3J4VuCNbBZkpatwr9QR7D1nruz+dvx9tU7VY1TrfPaI0/8Stl2xo5ZsLStYkjnMurd2x/oDwb7shiJJTBO0FP4KpKpSduMWKZ7URdbh8a82/7404m2R76px/xxPZwbUUIFxe//h5AWSiwdQ0x/t3kHHMdJvPvJ+y5gryNfeolhHylRv0U1OOf1yrx+Ys0T+MHqpzHhp2FZArOyQIlulmiqFNC+r/VyqwZ/uv0+Lt26BHXPVrTgkzY5u1dXa1jLl+U3rGhxbufukASeUl5lwdJzIPYsFgEK+h2pIaDVuDeuiUl9PHY952dyDlxrr63iaNNVHhpqGq2s5ep0PlNxy5qNz/hwXEYCghbT0KBwLBuxahtpNVUA7Vgx3VBTZ92ruguVVm22trEecQ3btqwhb5gL9IoXveTnYr0pfwpH/J9iW9NWc258hFyI2RY60z34PHcXy1RCnB1cgsEmGOmR63ntx9mGLFwM0clIB3GzJQcqE9KZMKbGsTP3LTz35b1gZJohbw/9Dn+5+3c02g1I67ThMscoYhNP5AR+3GYkIWkUpvR9EK1ZVaUAi0P5roeDq18yYHNMFBKAbFLhxv1BdPf3kBo+RvKjBqxw2uwIsfGEHzJBIEJbcH0Xeck07FQJsalqSg/hReclbH3sKe6jR6AxcxR9r9xIIuXeRJXTiAwpMy0Knk9LkuOClYCDE1/nGEoIuAJskB3LqQwasqvQvfFlmpRqmIs8bqmtbJwZ+TP+8NlvWQLUkdOZaaxyJvAMWHPCoeYivCF3pX2JxaIaLz+Jrrokmh9tRl7nyUw6E8EKBQ4NHKFGLotYGIFnazeYBFuBEmJWfioClttOR9vsfwUHWsldijifgHaUg2O3juPC+D9hx+uR93Pm/pxfoZVDCwv6CnBBNItXZfNIrupGdX21ASqO5FgObt6/iZ4br3EFy8hTVmnzWaxgYcMmcTrpu/QW5qbD0xPYZX8fe1r2cLNNnWAcTUB3DryCTHYENqtBsfi8YvAZ1MLhiDMlgHmpGD1miyTNYPDse0UtNIBnZaHcOHpafglU0ya+1H3koTja8Bmc/uz3sOwqghXrlsgsFWzgfxjW2HlGBwHvBcAEc3SPzXKufK6z0FiiKLw01s1n0VH9IrZ+aWtgVWWZyk+K9UP9h8OeErIWya6iP8RAwEWdpVE4xwmrWSmtcVdj3J2gR0sxEhQlGYan4ZohWl/NC1pxuz3LZbXaiF9s7A7CGPsXHG3wGB3tPB3NpqPNYd1wKXMdxFQzxXgjMOVlcHztceyo2oFRZh4JQzEG+tGJUbQPtmPAGWDiscjLiFLT07AyhUeH76zvLIQxicWRox29flRCRZAQpoctfkasAWABHX14atGivufj8NBhXPz6RdTwL5ImNOFE9gSeufMMdIKDSvCKM0kW26w348DaA2aYhDFpE+ns76SjZehotO5CjmZ6h18RNh4DrypqEOA+ncPmg+fl4cs4+PFBMyrrZU17nvXc7k27sS+xD3x+MjG1sFiZR3jOXU4+kiyEMZOGxdGG6Gh3TjOjkR6SVUv0LnrNqQNyCiQZXCQyoXIUTt48ib6RPsRjcXq4Dz6G82kaeGPTG2jJtRjLiVVFxJKyM7ucXdjTKmGM/fknUUEc7eWrTMsU4f8DSYSNx2kLywwlK46qto5LHcgxC4lisaBsZeOqRvSuPsnHcg6TIlzCGGsDlVPoeawnDGOacTigwrEbx/DR6Edm5yQdl+pa8DrCxmMAuKhBTiORie2YjStjV9B5tdM0C4CIk7s3/RD7q/YbasT56CKPNy/UvoCtjwdhTBZnHG3qJo4OHDXRwlRekYJyj5GF2T+gRNRQYmFZdUSN3k960TfcZwAIJ6XaEmq8vul1tOZbaWgXTfkmdLcyjDECyP0oVstiMy4dLaTGgtacA4NZV9g+DXiujmFbgRoXO5Bl3BTF8lgTUeOt5reACeDwysOFMGYeb9jvzD062qenYTnW/+ZoJbhi+B6OMGotA3eU9qbZZos4jFAjlU5h0p9Ee1O7ARtxekP9BqwY/gKe2/hj1FbVGn5KzJZxz/77WaSyqUKGmz17GS3iBszyyMBlGMAoQ+sKLOdGLfLKTyytPY2+b/Rhe8P2ALSE8tDpZLkC0mQ0VmNvDryJrotdsBMPEHPnwp8ltgnOnsLYtNNJxxLzl15H1Nh/YX8haphMx3ES8gSs/ImjDU4N4ui1IkdbZO5SXTOuixYRAJZsVcaEJqHwgfHK6BV0Xe4y00jUMO+IwtgaperOy3S0+w/haKV4wowqxcC0lHYqvWZP2W4VVzgxcAJ9Q0HUMJFE6geCF16/l3oPp26fmnY00VA614NcRwiJNbBwNDi6Md8x7BdRo+N8mFBodROzeRRaHLp0aOYMMu5hpAjfzNQc3VjkGNUaJqFcChKKvCYQOXaNGW0kzGisSR7KssU4ZHJeK/wad7GScaKOl0wElDlDm7lT/MVeJmqwADq77SzaVrbheuY6tvRt4XuFzMOFsWI9AlOeTcep7h5SYuGrpvKT52tZUbkiqw0dreM/HWbUq5dfnelo5c61UL/Ayn6I8SpJh3OsAbaZ0ip4gyVdyrKyqcZiFvrT/dj+1+34cOxDk65N6bgQiPLvSZRUBhtfZQhWhV9hC9PGeTTwUl7OyUu3AG5ZoEV3lFCMC5c9SkYuKEEpIllO3lwNU80YnozhLDn8HTRT2deY6bI8yk9GkUyfRS3zHOUpJdAwT4cHaw7I6RNJnpgmiSmDd9CFt4OwNs6flqbQz8YEueKa2By8Zw4YVIayKGGU0XWhLoG+gAbyfOwaTIJNMFIsJM1nkjfauJJ+5uyEPOKwM98Omj95bgtcsvJH0SUOljMYBItgEmxJnhFrsOXRD4tJ1DLA9ZIaz7OrKbiLOC0LrKyIfYWz8hJIwnqWNEjRsgK28MMi240Elg4S9Uk6Yhx7afs2smg9j1J8Rs5oTpf0K2CsWFfqMgmzZ2nj0/gZZv10+1+Ya1Tz2ThBaAAAAABJRU5ErkJggg=="
-      />
-    </defs>
-  </svg>
-);
+export const CheckSolidIcon = (props: React.SVGProps<SVGSVGElement>) => {
+  const id = useId();
+  const patternId = `pattern0_${id}`;
+  const imageId = `image0_${id}`;
+
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <rect width="12" height="12" fill={`url(#${patternId})`} />
+      <defs>
+        <pattern id={patternId} patternContentUnits="objectBoundingBox" width="1" height="1">
+          <use href={`#${imageId}`} transform="scale(0.0227273)" />
+        </pattern>
+        <image
+          id={imageId}
+          width="44"
+          height="44"
+          preserveAspectRatio="none"
+          href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAsCAYAAAAehFoBAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAALKADAAQAAAABAAAALAAAAAD8buejAAAJ60lEQVRYCb1ZW2wU1xn+zuzMLr5gahuLNOA0Ntcgol6UUomqFIumuFVL8kKF1LwFnKRCbQnIJm6kLpaaREEFk4c+JS9V1UKf+5CQBmRVbR/Sqq0gQMCYgCEkLL5718zuzpx+/5mZ9Xp9W4q3v707M2fOOf93/vP9l5lViCQJC0n45rK7fouViO9VMavNt/z1GjoOFXWs0FGDKlTW8q2r2vPP+W72FF4buWC0FWELYPwRMfwIHn7SVIsvolclYs9rJw84WSBBrLYtk8mMlRGC1Zpm8ajTpc4cdeZsaNd7B3fwc/wmNYkQo6JVA8smG9YgYZ9DjbUOta5uang0v23VU9ba5S1WnVMbAAZnXnLUwZyEi/HcJK5NXPf/9vk//NTwpzYmEwppvx9uvg3J4VuCNbBZkpatwr9QR7D1nruz+dvx9tU7VY1TrfPaI0/8Stl2xo5ZsLStYkjnMurd2x/oDwb7shiJJTBO0FP4KpKpSduMWKZ7URdbh8a82/7404m2R76px/xxPZwbUUIFxe//h5AWSiwdQ0x/t3kHHMdJvPvJ+y5gryNfeolhHylRv0U1OOf1yrx+Ys0T+MHqpzHhp2FZArOyQIlulmiqFNC+r/VyqwZ/uv0+Lt26BHXPVrTgkzY5u1dXa1jLl+U3rGhxbufukASeUl5lwdJzIPYsFgEK+h2pIaDVuDeuiUl9PHY952dyDlxrr63iaNNVHhpqGq2s5ep0PlNxy5qNz/hwXEYCghbT0KBwLBuxahtpNVUA7Vgx3VBTZ92ruguVVm22trEecQ3btqwhb5gL9IoXveTnYr0pfwpH/J9iW9NWc258hFyI2RY60z34PHcXy1RCnB1cgsEmGOmR63ntx9mGLFwM0clIB3GzJQcqE9KZMKbGsTP3LTz35b1gZJohbw/9Dn+5+3c02g1I67ThMscoYhNP5AR+3GYkIWkUpvR9EK1ZVaUAi0P5roeDq18yYHNMFBKAbFLhxv1BdPf3kBo+RvKjBqxw2uwIsfGEHzJBIEJbcH0Xeck07FQJsalqSg/hReclbH3sKe6jR6AxcxR9r9xIIuXeRJXTiAwpMy0Knk9LkuOClYCDE1/nGEoIuAJskB3LqQwasqvQvfFlmpRqmIs8bqmtbJwZ+TP+8NlvWQLUkdOZaaxyJvAMWHPCoeYivCF3pX2JxaIaLz+Jrrokmh9tRl7nyUw6E8EKBQ4NHKFGLotYGIFnazeYBFuBEmJWfioClttOR9vsfwUHWsldijifgHaUg2O3juPC+D9hx+uR93Pm/pxfoZVDCwv6CnBBNItXZfNIrupGdX21ASqO5FgObt6/iZ4br3EFy8hTVmnzWaxgYcMmcTrpu/QW5qbD0xPYZX8fe1r2cLNNnWAcTUB3DryCTHYENqtBsfi8YvAZ1MLhiDMlgHmpGD1miyTNYPDse0UtNIBnZaHcOHpafglU0ya+1H3koTja8Bmc/uz3sOwqghXrlsgsFWzgfxjW2HlGBwHvBcAEc3SPzXKufK6z0FiiKLw01s1n0VH9IrZ+aWtgVWWZyk+K9UP9h8OeErIWya6iP8RAwEWdpVE4xwmrWSmtcVdj3J2gR0sxEhQlGYan4ZohWl/NC1pxuz3LZbXaiF9s7A7CGPsXHG3wGB3tPB3NpqPNYd1wKXMdxFQzxXgjMOVlcHztceyo2oFRZh4JQzEG+tGJUbQPtmPAGWDiscjLiFLT07AyhUeH76zvLIQxicWRox29flRCRZAQpoctfkasAWABHX14atGivufj8NBhXPz6RdTwL5ImNOFE9gSeufMMdIKDSvCKM0kW26w348DaA2aYhDFpE+ns76SjZehotO5CjmZ6h18RNh4DrypqEOA+ncPmg+fl4cs4+PFBMyrrZU17nvXc7k27sS+xD3x+MjG1sFiZR3jOXU4+kiyEMZOGxdGG6Gh3TjOjkR6SVUv0LnrNqQNyCiQZXCQyoXIUTt48ib6RPsRjcXq4Dz6G82kaeGPTG2jJtRjLiVVFxJKyM7ucXdjTKmGM/fknUUEc7eWrTMsU4f8DSYSNx2kLywwlK46qto5LHcgxC4lisaBsZeOqRvSuPsnHcg6TIlzCGGsDlVPoeawnDGOacTigwrEbx/DR6Edm5yQdl+pa8DrCxmMAuKhBTiORie2YjStjV9B5tdM0C4CIk7s3/RD7q/YbasT56CKPNy/UvoCtjwdhTBZnHG3qJo4OHDXRwlRekYJyj5GF2T+gRNRQYmFZdUSN3k960TfcZwAIJ6XaEmq8vul1tOZbaWgXTfkmdLcyjDECyP0oVstiMy4dLaTGgtacA4NZV9g+DXiujmFbgRoXO5Bl3BTF8lgTUeOt5reACeDwysOFMGYeb9jvzD062qenYTnW/+ZoJbhi+B6OMGotA3eU9qbZZos4jFAjlU5h0p9Ee1O7ARtxekP9BqwY/gKe2/hj1FbVGn5KzJZxz/77WaSyqUKGmz17GS3iBszyyMBlGMAoQ+sKLOdGLfLKTyytPY2+b/Rhe8P2ALSE8tDpZLkC0mQ0VmNvDryJrotdsBMPEHPnwp8ltgnOnsLYtNNJxxLzl15H1Nh/YX8haphMx3ES8gSs/ImjDU4N4ui1IkdbZO5SXTOuixYRAJZsVcaEJqHwgfHK6BV0Xe4y00jUMO+IwtgaperOy3S0+w/haKV4wowqxcC0lHYqvWZP2W4VVzgxcAJ9Q0HUMJFE6geCF16/l3oPp26fmnY00VA614NcRwiJNbBwNDi6Md8x7BdRo+N8mFBodROzeRRaHLp0aOYMMu5hpAjfzNQc3VjkGNUaJqFcChKKvCYQOXaNGW0kzGisSR7KssU4ZHJeK/wad7GScaKOl0wElDlDm7lT/MVeJmqwADq77SzaVrbheuY6tvRt4XuFzMOFsWI9AlOeTcep7h5SYuGrpvKT52tZUbkiqw0dreM/HWbUq5dfnelo5c61UL/Ayn6I8SpJh3OsAbaZ0ip4gyVdyrKyqcZiFvrT/dj+1+34cOxDk65N6bgQiPLvSZRUBhtfZQhWhV9hC9PGeTTwUl7OyUu3AG5ZoEV3lFCMC5c9SkYuKEEpIllO3lwNU80YnozhLDn8HTRT2deY6bI8yk9GkUyfRS3zHOUpJdAwT4cHaw7I6RNJnpgmiSmDd9CFt4OwNs6flqbQz8YEueKa2By8Zw4YVIayKGGU0XWhLoG+gAbyfOwaTIJNMFIsJM1nkjfauJJ+5uyEPOKwM98Omj95bgtcsvJH0SUOljMYBItgEmxJnhFrsOXRD4tJ1DLA9ZIaz7OrKbiLOC0LrKyIfYWz8hJIwnqWNEjRsgK28MMi240Elg4S9Uk6Yhx7afs2smg9j1J8Rs5oTpf0K2CsWFfqMgmzZ2nj0/gZZv10+1+Ya1Tz2ThBaAAAAABJRU5ErkJggg=="
+        />
+      </defs>
+    </svg>
+  );
+};


### PR DESCRIPTION
# Lite PR &rarr; Refine the X icon for `NotENSv2Ready` badge

## Summary

- Adapted the X icon in the tooltip of `NotENSv2Ready` badge accordingly to @sskvts's instructions

### BEFORE

<img width="999" height="291" alt="image" src="https://github.com/user-attachments/assets/6b156a52-caa2-480e-b8dc-d2720433f523" />

### AFTER

<img width="1008" height="276" alt="image" src="https://github.com/user-attachments/assets/e6c0616b-951c-4d45-86ed-8c08aa52818a" />

---

## Why

- Requested by @lightwalker-eth [here](https://namehash.slack.com/archives/C086Z6FNBHN/p1780482556188169).

---

## Testing

- Ran `lint` command locally to ensure that the migration didn't break anything, and later confirmed that in our CI workflow
- Verified the UI after introducing changes using a local and Vercel (build) previews

---

## Notes for Reviewer (Optional)

- Pure UI/UX changes, so I don't think that the changeset log is required

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)

