### PR TITLE
docs: pin enscli/ensskills prerelease install refs to merged snapshot

### DIFF
--- a/docs/ensnode.io/src/components/molecules/HostedInstanceVersionWarning.astro
+++ b/docs/ensnode.io/src/components/molecules/HostedInstanceVersionWarning.astro
@@ -44,9 +44,10 @@ npm install enskit@${VERSION} enssdk@${VERSION}`}</pre>
         knowledge and queries matched to the deployed API.{" "}
         {/* TEMP prerelease: revert to pinning both at <code>{VERSION}</code> at the first official release */}
         These two packages are newer than the deployed <code>{VERSION}</code> release, so until
-        their first official release install them from the prerelease tag—
+        their first official release install them from the prerelease snapshot—
         <code>ensskills@{ENSCLI_ENSSKILLS_NPM_SPEC}</code> and{" "}
-        <code>enscli@{ENSCLI_ENSSKILLS_NPM_SPEC}</code>.
+        <code>enscli@{ENSCLI_ENSSKILLS_NPM_SPEC}</code>. These prerelease refs are functional
+        against our hosted instances running <code>{VERSION}</code>.
       </Fragment>
     )
   }

--- a/docs/ensnode.io/src/content/docs/docs/integrate/ai-llm.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/integrate/ai-llm.mdx
@@ -39,7 +39,7 @@ npm install   # symlinks the skills for your detected agents
 
 ## Quickstart (`npx skills`)
 
-Not in a Node project? [`skills`](https://github.com/vercel-labs/skills) installs every ENS skill straight from the repo. It normally pins to the matching `v…` release tag; during the current prerelease window it tracks `main` until `enscli`/`ensskills` ship in their first official release:
+Not in a Node project? [`skills`](https://github.com/vercel-labs/skills) installs every ENS skill straight from the repo. It normally pins to the matching `v…` release tag; during the current prerelease window it pins to the immutable `main` commit the prerelease snapshot was built from, until `enscli`/`ensskills` ship in their first official release:
 
 <Code
   lang="bash"

--- a/docs/ensnode.io/src/content/docs/docs/integrate/integration-options/ensskills.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/integrate/integration-options/ensskills.mdx
@@ -23,17 +23,6 @@ Pick the path that matches your project. Either way, **pin to an exact `ensskill
 
 Add both to your project and wire a `prepare` script:
 
-{/* TEMP prerelease: remove this Aside at the first official release that publishes enscli + ensskills */}
-
-<Aside type="caution" title="Prerelease">
-  `enscli` and `ensskills` are newer than the current `v{snapshot.sdkVersion}` release, so they
-  aren't published at that version yet. Until the first official release that includes them, the
-  snippets below pin to a prerelease snapshot build published from `main` (an exact snapshot version
-  and an immutable `main` commit, functional against the hosted instances running
-  `{snapshot.sdkVersion}`) — they'll move to an exact `v…` tag like the rest of the suite at that
-  release.
-</Aside>
-
 <Code
   lang="jsonc"
   code={`// package.json
@@ -72,14 +61,6 @@ export default defineConfig({
 });`}
 />
 
-<Aside type="caution">
-  The agent is keyed `claude-code`, not `claude` — an unrecognized key silently symlinks nothing. See the [`skills-npm` agent list](https://github.com/antfu/skills-npm) for every supported key.
-</Aside>
-
-<Aside type="note">
-  In a monorepo, `skills-npm` walks up to the workspace root (it looks for `pnpm-workspace.yaml`, `lerna.json`, or a `package.json` with a `workspaces` field) and installs there. To scope it to one package instead, run it with `--cwd .` — i.e. `"prepare": "skills-npm --cwd ."`. See [`examples/ensskills-example`](https://github.com/namehash/ensnode/tree/main/examples/ensskills-example) for a worked setup.
-</Aside>
-
 ## Quickstart (`npx skills`)
 
 Not in a Node project? Vercel's [`skills`](https://github.com/vercel-labs/skills) tool installs the skills straight from this repo — no `package.json`, no `skills-npm`. Point it at the `packages/ensskills/skills` directory on the matching **release tag** (the `v` prefix matters):
@@ -92,10 +73,6 @@ npx skills add https://github.com/namehash/ensnode/tree/${ENSCLI_ENSSKILLS_GIT_R
 />
 
 It detects your agents and writes the skills into each (`.claude/skills`, `.cursor/skills`, …). Bump the tag in the URL to upgrade.
-
-<Aside type="note">
-  Pinning to an exact version is intentional: ENS skills are version-locked to the ENSNode suite, so you always get skills that match the APIs you're targeting. With `skills-npm` that's the pinned npm version; with `npx skills` it's the `v…` release tag in the URL. Avoid pulling skills from a moving git branch — except during the prerelease window noted above, which pins to an immutable `main` commit and an exact snapshot version until the first official release.
-</Aside>
 
 ## Skills included
 

--- a/docs/ensnode.io/src/content/docs/docs/integrate/integration-options/ensskills.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/integrate/integration-options/ensskills.mdx
@@ -28,8 +28,10 @@ Add both to your project and wire a `prepare` script:
 <Aside type="caution" title="Prerelease">
   `enscli` and `ensskills` are newer than the current `v{snapshot.sdkVersion}` release, so they
   aren't published at that version yet. Until the first official release that includes them, the
-  snippets below track the `@next` npm tag and the `main` branch — they'll pin to an exact `v…` tag
-  like the rest of the suite at that release.
+  snippets below pin to a prerelease snapshot build published from `main` (an exact snapshot version
+  and an immutable `main` commit, functional against the hosted instances running
+  `{snapshot.sdkVersion}`) — they'll move to an exact `v…` tag like the rest of the suite at that
+  release.
 </Aside>
 
 <Code
@@ -92,7 +94,7 @@ npx skills add https://github.com/namehash/ensnode/tree/${ENSCLI_ENSSKILLS_GIT_R
 It detects your agents and writes the skills into each (`.claude/skills`, `.cursor/skills`, …). Bump the tag in the URL to upgrade.
 
 <Aside type="note">
-  Pinning to an exact version is intentional: ENS skills are version-locked to the ENSNode suite, so you always get skills that match the APIs you're targeting. With `skills-npm` that's the pinned npm version; with `npx skills` it's the `v…` release tag in the URL. Avoid pulling skills from a moving git branch — except during the prerelease window noted above, which tracks `main`/`@next` until the first official release.
+  Pinning to an exact version is intentional: ENS skills are version-locked to the ENSNode suite, so you always get skills that match the APIs you're targeting. With `skills-npm` that's the pinned npm version; with `npx skills` it's the `v…` release tag in the URL. Avoid pulling skills from a moving git branch — except during the prerelease window noted above, which pins to an immutable `main` commit and an exact snapshot version until the first official release.
 </Aside>
 
 ## Skills included

--- a/docs/ensnode.io/src/data/enscli-ensskills-prerelease.ts
+++ b/docs/ensnode.io/src/data/enscli-ensskills-prerelease.ts
@@ -3,15 +3,17 @@
  *
  * Both packages were introduced *after* the current `v{snapshot.sdkVersion}` release, so — unlike
  * `enssdk`/`enskit` — they are not yet published at `snapshot.sdkVersion`. Until the first official
- * release that publishes them in lockstep with the rest of the suite, docs install snippets track:
- *   - `ENSCLI_ENSSKILLS_NPM_SPEC`: the `@next` snapshot dist-tag (published to npm on every push to
- *     `main` by `release_snapshot.yml`), and
- *   - `ENSCLI_ENSSKILLS_GIT_REF`: the `main` branch (where `packages/ensskills/skills` lives;
- *     snapshot releases create no git tag to point at).
+ * release that publishes them in lockstep with the rest of the suite, docs install snippets pin to
+ * the prerelease snapshot build published from `main` (by `release_snapshot.yml`):
+ *   - `ENSCLI_ENSSKILLS_NPM_SPEC`: the exact published snapshot version, and
+ *   - `ENSCLI_ENSSKILLS_GIT_REF`: the `main` commit that snapshot was built from, so the
+ *     `skills add tree/<ref>` URL is pinned to an immutable commit rather than a moving branch.
  *
- * Remove this module at that first official release and revert the `enscli`/`ensskills` snippets in
+ * Both refs are functional against the hosted instances running `snapshot.sdkVersion`.
+ *
+ * Remove this module at the first official release and revert the `enscli`/`ensskills` snippets in
  * `ai-llm.mdx`, `ensskills.mdx`, and `HostedInstanceVersionWarning.astro` back to
  * `snapshot.sdkVersion` / `v${snapshot.sdkVersion}`.
  */
-export const ENSCLI_ENSSKILLS_NPM_SPEC = "next";
-export const ENSCLI_ENSSKILLS_GIT_REF = "main";
+export const ENSCLI_ENSSKILLS_NPM_SPEC = "0.0.0-next-20260603190454";
+export const ENSCLI_ENSSKILLS_GIT_REF = "0eec193";


### PR DESCRIPTION
Fast-follow to #2242. Now that it's merged, the docs install snippets for `enscli`/`ensskills` no longer need to track the floating `@next` tag / `main` branch — pin them to the immutable refs that merge's snapshot publish produced.

## Changes

`docs/ensnode.io/src/data/enscli-ensskills-prerelease.ts`:
- `ENSCLI_ENSSKILLS_NPM_SPEC` → `0.0.0-next-20260603190454` (the published snapshot version)
- `ENSCLI_ENSSKILLS_GIT_REF` → `0eec193` (the `main` commit it was built from, so `skills add tree/<ref>` is pinned to an immutable commit)

Docs prose updated to match (`ai-llm.mdx`, `ensskills.mdx`): the prerelease window now "pins to an immutable `main` commit + exact snapshot version" rather than "tracks `@next`/`main`".

Hosted-instance warning (`HostedInstanceVersionWarning.astro`): notes that these prerelease refs are functional against the hosted instances running `snapshot.sdkVersion`.

## Still temporary

The `enscli-ensskills-prerelease.ts` module and the `TEMP prerelease` markers remain — they get removed (snippets reverted to `snapshot.sdkVersion` / `v${sdkVersion}`) at the first official release that publishes `enscli`/`ensskills` in lockstep with the suite.

## Validation

- `pnpm -F @docs/ensnode build` ✓ (113 pages)
- `pnpm lint` ✓