### PR TITLE
fix: add multicall batching to viem client

### DIFF
--- a/apps/ensapi/src/di.ts
+++ b/apps/ensapi/src/di.ts
@@ -18,7 +18,7 @@ import { buildConfigFromEnvironment, buildRootChainRpcConfig } from "@/config/co
 import { buildEnsDbConfigFromEnvironment } from "@/config/ensdb-config";
 import type { EnsApiEnvironment } from "@/config/environment";
 import { makeLogger } from "@/lib/logger";
-import { buildPublicClient } from "@/lib/public-client";
+import { buildRootChainPublicClient } from "@/lib/public-client";
 
 const logger = makeLogger("di");
 
@@ -153,7 +153,7 @@ export function buildEnsApiDiContext(ensApiEnvironment: EnsApiEnvironment): EnsA
 
     get rootChainPublicClient(): PublicClient {
       if (instances.rootChainPublicClient === undefined) {
-        instances.rootChainPublicClient = buildPublicClient(
+        instances.rootChainPublicClient = buildRootChainPublicClient(
           context.rootChainRpcConfig,
           context.namespace,
         );

--- a/apps/ensapi/src/di.ts
+++ b/apps/ensapi/src/di.ts
@@ -1,5 +1,5 @@
 import type { ChainId } from "enssdk";
-import { createPublicClient, fallback, http, type PublicClient } from "viem";
+import type { PublicClient } from "viem";
 
 import { type ENSNamespaceId, getENSRootChainId } from "@ensnode/datasources";
 import { type EnsDbConfig, EnsDbReader } from "@ensnode/ensdb-sdk";
@@ -18,6 +18,7 @@ import { buildConfigFromEnvironment, buildRootChainRpcConfig } from "@/config/co
 import { buildEnsDbConfigFromEnvironment } from "@/config/ensdb-config";
 import type { EnsApiEnvironment } from "@/config/environment";
 import { makeLogger } from "@/lib/logger";
+import { buildPublicClient } from "@/lib/public-client";
 
 const logger = makeLogger("di");
 
@@ -152,12 +153,10 @@ export function buildEnsApiDiContext(ensApiEnvironment: EnsApiEnvironment): EnsA
 
     get rootChainPublicClient(): PublicClient {
       if (instances.rootChainPublicClient === undefined) {
-        // Create an viem#PublicClient that uses a fallback() transport with all specified HTTP RPCs
-        instances.rootChainPublicClient = createPublicClient({
-          transport: fallback(
-            context.rootChainRpcConfig.httpRPCs.map((url) => http(url.toString())),
-          ),
-        });
+        instances.rootChainPublicClient = buildPublicClient(
+          context.rootChainRpcConfig,
+          context.namespace,
+        );
       }
 
       return instances.rootChainPublicClient;

--- a/apps/ensapi/src/lib/public-client.ts
+++ b/apps/ensapi/src/lib/public-client.ts
@@ -6,7 +6,7 @@ import type { RpcConfig } from "@ensnode/ensnode-sdk/internal";
 /**
  * Builds a viem {@link PublicClient} for the ENS root chain with a fallback transport over all HTTP RPCs.
  */
-export function buildPublicClient(
+export function buildRootChainPublicClient(
   rootChainRpcConfig: RpcConfig,
   namespace: ENSNamespaceId,
 ): PublicClient {

--- a/apps/ensapi/src/lib/public-client.ts
+++ b/apps/ensapi/src/lib/public-client.ts
@@ -1,0 +1,22 @@
+import { createPublicClient, fallback, http, type PublicClient } from "viem";
+
+import { type ENSNamespaceId, getENSRootChain } from "@ensnode/datasources";
+import type { RpcConfig } from "@ensnode/ensnode-sdk/internal";
+
+/**
+ * Builds a viem {@link PublicClient} for the ENS root chain with a fallback transport over all HTTP RPCs.
+ */
+export function buildPublicClient(
+  rootChainRpcConfig: RpcConfig,
+  namespace: ENSNamespaceId,
+): PublicClient {
+  return createPublicClient({
+    chain: getENSRootChain(namespace),
+    batch: {
+      multicall: {
+        batchSize: 2048,
+      },
+    },
+    transport: fallback(rootChainRpcConfig.httpRPCs.map((url) => http(url.toString()))),
+  });
+}

--- a/apps/ensapi/src/lib/public-client.ts
+++ b/apps/ensapi/src/lib/public-client.ts
@@ -14,6 +14,7 @@ export function buildPublicClient(
     chain: getENSRootChain(namespace),
     batch: {
       multicall: {
+        // bytes per batch; default is 1024
         batchSize: 2048,
       },
     },


### PR DESCRIPTION
closes https://github.com/namehash/ensnode/issues/2237

## Summary

Enabling multicall batchin in viem: https://viem.sh/docs/clients/public#batchmulticall-optional

## Why

Viem doesnt support `eth_call` batching by default!

---

## Testing

- How this was tested.
- If you didn't test it, say why.

---

## Notes for Reviewer (Optional)

- Anything non-obvious or worth a heads-up.

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)
