### PR TITLE
docs: reword Subgraph dependency framing on keep-ens-working

### DIFF
--- a/docs/ensnode.io/src/content/docs/docs/integrate/why-ensnode/keep-ens-working.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/integrate/why-ensnode/keep-ens-working.mdx
@@ -8,7 +8,7 @@ import UpgradeToOmnigraphRequiredTable from "@components/molecules/upgrade-to-om
 import ENSSubgraphDependentApp from "@components/molecules/upgrade-to-omnigraph-required-table/ENSSubgraphDependentApp.astro";
 
 :::danger[🚨 These apps go dark when ENSv2 launches]
-Hundreds of apps quietly read ENS data through the ENS Subgraph today. **The moment ENSv2 launches, the Subgraph stops being a reliable source of ENS data** — and every app that depends on it is at risk until it upgrades to the ENS Omnigraph API.
+Many of the most important ENS apps quietly read ENS data through the ENS Subgraph today. **The moment ENSv2 launches, the Subgraph stops being a reliable source of ENS data** — and every app that depends on it is at risk until it upgrades to the ENS Omnigraph API.
 
 <LinkCard
   title="Key Limitations of the ENS Subgraph 🚨"


### PR DESCRIPTION
Changes the wording on the "Keep ENS apps working" page from "Hundreds of apps" to "Many of the most important ENS apps".

🤖 Generated with [Claude Code](https://claude.com/claude-code)