### PR TITLE
Make ENSEngine to focus on live notifications

### DIFF
--- a/docs/ensnode.io/config/integrations/starlight/sidebar-topics/integrate.ts
+++ b/docs/ensnode.io/config/integrations/starlight/sidebar-topics/integrate.ts
@@ -196,7 +196,7 @@ export const integrateSidebarTopic = {
           link: "/docs/integrate/integration-options/ensdb-cli",
         },
         {
-          label: "ENSEngine (Webhooks)",
+          label: "ENSEngine (Push notifications)",
           link: "/docs/integrate/integration-options/ensengine",
         },
       ],

--- a/docs/ensnode.io/src/content/docs/docs/integrate/index.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/integrate/index.mdx
@@ -208,7 +208,7 @@ Beyond [`enssdk`](/docs/integrate/integration-options/enssdk), [`enskit`](/docs/
 - **[enscli (CLI)](/docs/integrate/integration-options/enscli)** — resolve names, look up records, and run ad-hoc Omnigraph queries from the terminal — built for humans and AI agents alike.
 - **[ensskills (AI agents)](/docs/integrate/integration-options/ensskills)** — a curated set of skills that gives AI coding agents a well-defined contract for working with ENS.
 - **[ensdb-cli (ENSDb Snapshots)](/docs/integrate/integration-options/ensdb-cli)** — bootstrap a fresh ENSDb in minutes from portable, versioned snapshots instead of waiting days on a full historical backfill.
-- **[ENSEngine (Webhooks)](/docs/integrate/integration-options/ensengine)** — subscribe to ENS-aware webhooks driven by changes in ENSDb, so your apps can stop polling and start reacting.
+- **[ENSEngine (Live push notifications)](/docs/integrate/integration-options/ensengine)** — subscribe to ENS-aware live notifications driven by changes in ENSDb, so your apps can stop polling and start reacting.
 
 <LinkCard
   title="See all Integration Options"

--- a/docs/ensnode.io/src/content/docs/docs/integrate/integration-options/ensengine.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/integrate/integration-options/ensengine.mdx
@@ -1,12 +1,12 @@
 ---
-title: ENSEngine (Webhooks)
-description: Coming soon - ENS-native webhooks and push-based events that fire when ENS state changes, so apps can stop polling and start reacting.
+title: ENSEngine (Live push notifications)
+description: Coming soon - ENS-native push-based events that fire when ENS state changes, so apps can stop polling and start reacting.
 ---
 
 import { LinkCard, Aside } from "@astrojs/starlight/components";
 
 <Aside type="caution" title="Coming soon">
-  ENS-native event-driven reactive development (such as webhooks) is coming soon with
+  ENS-native event-driven reactive development is coming soon with
   [ENSEngine](/docs/services/ensengine) that builds on top of [ENSDb](/docs/services/ensdb).
 </Aside>
 
@@ -19,16 +19,12 @@ Today, if you want your app to react to ENS state changes, you have two unappeal
 
 ## What we're building
 
-ENSEngine will be an **ENS-native event-driven reactive development service** (for webhooks and more) so your app can subscribe to ENS state changes in ENSDb the same way you'd subscribe to a Stripe or GitHub webhook - except the events speak the language of discrete meaningful ENS actions, not the language of bare-metal raw onchain event transaction logs.
+ENSEngine will be an **ENS-native event-driven reactive development service** (for live push notifications) so your app can subscribe to ENS state changes in ENSDb the same way you'd subscribe to updates from Stripe or GitHub - except the events speak the language of discrete meaningful ENS actions, not the language of bare-metal raw onchain event transaction logs.
 
-```http title="example-webhook.http"
-POST https://your-app.example.com/webhooks/ens
-Content-Type: application/json
-
+```json title="example-event.json"
 {
   "type": "domain.transferred",
-  "name": "vitalik.eth",
-  ...
+  "name": "vitalik.eth"
 }
 ```
 

--- a/docs/ensnode.io/src/content/docs/docs/services/ensengine/index.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/services/ensengine/index.mdx
@@ -49,7 +49,7 @@ The internal pipeline is intentionally simple to describe:
 - **Enrich** - attach ENS-level context to raw changes so consumers don't have to.
 - **Filter** - apply subscription rules so each sink only sees events it cares about.
 - **Transform** - shape events into the right payload for each sink type.
-- **Dispatch** - deliver to webhooks, cache-invalidation hooks, database sync targets, notification systems, and more.
+- **Route** - deliver to webhooks, cache-invalidation hooks, database sync targets, notification systems, and more.
 
 Implementation details behind the watch layer are intentionally not part of this teaser. Those will land in dedicated docs when the service ships.
 

--- a/docs/ensnode.io/src/content/docs/docs/services/ensengine/index.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/services/ensengine/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: ENSEngine
-description: Coming soon - the ENSNode service for push-based, reactive ENS functionality. Watches your ENSDb for changes and turns them into ENS-aware webhooks.
+description: Coming soon - the ENSNode service for push-based, reactive ENS functionality. Watches your ENSDb for changes and turns them into ENS-aware push notifications.
 sidebar:
   label: Overview
   order: 1
@@ -20,7 +20,7 @@ Today, building an app that reacts to ENS - when an avatar changes, when a name 
 
 ## What it is
 
-ENSEngine is the part of ENSNode that **watches your ENSDb for changes in real time and delivers ENS-aware events** - including webhooks - to any sink you configure.
+ENSEngine is the part of ENSNode that **watches your ENSDb for changes in real time and delivers ENS-aware events** to any sink you configure.
 
 It sits alongside [ENSIndexer](/docs/services/ensindexer), [ENSDb](/docs/services/ensdb), [ENSRainbow](/docs/services/ensrainbow), [ENSApi](/docs/services/ensapi), and [ENSAdmin](/docs/services/ensadmin) as the home for reactive / event-based functionality across the ENSNode stack.
 
@@ -49,7 +49,7 @@ The internal pipeline is intentionally simple to describe:
 - **Enrich** - attach ENS-level context to raw changes so consumers don't have to.
 - **Filter** - apply subscription rules so each sink only sees events it cares about.
 - **Transform** - shape events into the right payload for each sink type.
-- **Route** - deliver to webhooks, cache-invalidation hooks, database sync targets, notification systems, and more.
+- **Dispatch** - deliver to webhooks, cache-invalidation hooks, database sync targets, notification systems, and more.
 
 Implementation details behind the watch layer are intentionally not part of this teaser. Those will land in dedicated docs when the service ships.
 

--- a/docs/ensnode.io/src/content/docs/docs/services/ensengine/index.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/services/ensengine/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: ENSEngine
-description: Coming soon - the ENSNode service for push-based, reactive ENS functionality. Watches your ENSDb for changes and turns them into ENS-aware push notifications.
+description: Coming soon - the ENSNode service for push-based, reactive ENS functionality. Watches your ENSDb for changes and turns them into ENS-aware live push notifications.
 sidebar:
   label: Overview
   order: 1


### PR DESCRIPTION
Update the intro about ENSEngine to frame it as a "notifications service" which dispatches "live push notifications" without any details on a particular transport layer it will use.