### PR TITLE
docs: fix 404 on Offchain Name omnigraph example page

### DIFF
--- a/docs/ensnode.io/scripts/fetch-omnigraph-example-responses.mts
+++ b/docs/ensnode.io/scripts/fetch-omnigraph-example-responses.mts
@@ -24,12 +24,27 @@ function logError(message: string, id?: string) {
 const TIMEOUT_MS = 120_000;
 const WARN_THRESHOLD_MS = 5_000;
 
-const dataDir = join(dirname(fileURLToPath(import.meta.url)), "../src/data/omnigraph-examples");
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const dataDir = join(scriptDir, "../src/data/omnigraph-examples");
 const examplesPath = join(dataDir, "examples.json");
 const outputPath = join(dataDir, "responses.json");
+const contentExamplesDir = join(scriptDir, "../src/content/docs/docs/integrate/omnigraph/examples");
 
 if (!existsSync(examplesPath)) {
   logError(`No examples snapshot at ${examplesPath}. Run pnpm omnigraph:snapshot <version> first.`);
+  process.exit(1);
+}
+
+// Every separate-page example must have a content page, or its sidebar/index link 404s.
+const missingPages = OMNIGRAPH_EXAMPLES_CONFIG.filter((config) => config.hostSeparatePage)
+  .map((config) => config.id)
+  .filter((id) => !existsSync(join(contentExamplesDir, `${id}.mdx`)));
+
+if (missingPages.length > 0) {
+  logError(
+    `Missing content page(s) for separate-page example(s): ${missingPages.join(", ")}. ` +
+      `Create src/content/docs/docs/integrate/omnigraph/examples/<id>.mdx for each.`,
+  );
   process.exit(1);
 }
 

--- a/docs/ensnode.io/src/content/docs/docs/integrate/omnigraph/examples/offchain-name.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/integrate/omnigraph/examples/offchain-name.mdx
@@ -1,0 +1,10 @@
+---
+title: Offchain Name
+description: Resolve an offchain (CCIP-Read) name, surfaced as an UnindexedDomain.
+sidebar:
+  order: 4.5
+---
+
+import OmnigraphStaticExampleSet from "@components/organisms/OmnigraphStaticExampleSet.astro";
+
+<OmnigraphStaticExampleSet id="offchain-name" />


### PR DESCRIPTION
## Problem

`/docs/integrate/omnigraph/examples/offchain-name` 404s.

The `offchain-name` example was added to `OMNIGRAPH_EXAMPLES_CONFIG` with `hostSeparatePage: true` (plus its query in `examples.json` and response in `responses.json`), so it gets a sidebar entry and an index-page `LinkCard` — but the content page `offchain-name.mdx` was never created. Both links resolve to a route with no page.

## Fix

- Add `src/content/docs/docs/integrate/omnigraph/examples/offchain-name.mdx`, mirroring the other example pages (renders `<OmnigraphStaticExampleSet id="offchain-name" />`, whose response already exists in `responses.json`).
- Harden `scripts/fetch-omnigraph-example-responses.mts` to **fail fast** when any `hostSeparatePage` example is missing its `<id>.mdx` content page — catching this class of bug at refresh time instead of in production.

## Verification

- Page returns `200` locally.
- `pnpm lint` clean; `pnpm -F @docs/ensnode test` passes (72 tests).
- Confirmed all 19 separate-page examples now have content pages.