### PR TITLE
fix(ensapi): correct ensv2 fallback behavior

### DIFF
--- a/.changeset/walk-namegraph-no-ensv1-fallback.md
+++ b/.changeset/walk-namegraph-no-ensv1-fallback.md
@@ -1,0 +1,5 @@
+---
+"ensapi": patch
+---
+
+The Omnigraph namegraph walk (`domain(by: name)` and related Name→Domain lookups) no longer falls back to the ENSv1 disjoint namegraph when the ENSv2 Root walk fails to exact-match. UniversalResolverV2 has no registry-level ENSv1 fallback — its only ENSv1 fallback is the `ENSV1Resolver` (a mirror Resolver) set within the ENSv2 namegraph on reserved entries, which the walk already follows. A name present only in ENSv1 and not reserved in ENSv2 is therefore not resolvable under UR2, so the walk no longer addresses it as vestigial ENSv1 state.

--- a/.changeset/walk-namegraph-no-ensv1-fallback.md
+++ b/.changeset/walk-namegraph-no-ensv1-fallback.md
@@ -1,5 +1,0 @@
----
-"ensapi": patch
----
-
-The Omnigraph namegraph walk (`domain(by: name)` and related Name→Domain lookups) no longer falls back to the ENSv1 disjoint namegraph when the ENSv2 Root walk fails to exact-match. UniversalResolverV2 has no registry-level ENSv1 fallback — its only ENSv1 fallback is the `ENSV1Resolver` (a mirror Resolver) set within the ENSv2 namegraph on reserved entries, which the walk already follows. A name present only in ENSv1 and not reserved in ENSv2 is therefore not resolvable under UR2, so the walk no longer addresses it as vestigial ENSv1 state.

--- a/apps/ensapi/src/omnigraph-api/lib/get-domain-by-interpreted-name.ts
+++ b/apps/ensapi/src/omnigraph-api/lib/get-domain-by-interpreted-name.ts
@@ -14,7 +14,6 @@ import {
   getENSv2RootRegistryId,
   getRootRegistryId,
   makeContractMatcher,
-  maybeGetENSv2RootRegistryId,
 } from "@ensnode/ensnode-sdk";
 import { isBridgedResolver } from "@ensnode/ensnode-sdk/internal";
 
@@ -57,10 +56,8 @@ export interface NamegraphWalkResult {
  * Walks the namegraph for an Interpreted Name and returns the {@link NamegraphWalkResult}.
  *
  * Walks resolution from the primary Root Registry (ENSv2 Root when defined, otherwise the ENSv1 Root),
- * following Bridged Resolvers as necessary. When ENSv2 is defined but the initial walk does not
- * exact-match (e.g. a name registered only in ENSv1, not reserved in ENSv2), falls back to the ENSv1
- * disjoint namegraph unless an ancestor already has an ENSIP-10 wildcard Resolver. We only operate over
- * indexed data which is fully available for the ENS Root Chain.
+ * following Bridged Resolvers as necessary. We only operate over indexed data which is fully available
+ * for the ENS Root Chain.
  *
  * Unlike Forward Resolution, this walk does not check registration expiry, so callers can address
  * Domains regardless of expiry status. This means that a Domain identified by this walk may not be
@@ -168,23 +165,6 @@ async function walkNamegraphFromRegistry(
         depth + 1,
       );
     }
-  }
-
-  // ENSv1-only fallback: when the preferred ENSv2 Root walk does not exact-match and no ENSv1Resolver
-  // hop applied (e.g. a .eth 2LD registered only in ENSv1, not reserved in ENSv2), walk the ENSv1
-  // disjoint namegraph. Skip when an ancestor already has an ENSIP-10 wildcard Resolver — resolution
-  // stays in the ENSv2 path (UnindexedDomain), not vestigial ENSv1 state.
-  const ensv2RootId = maybeGetENSv2RootRegistryId(di.context.namespace);
-  const triedOnlyENSv2Registry = ensv2RootId && registryId === ensv2RootId;
-  const deepestResolverIsExtended = deepestResolver?.extended ?? false;
-  const firstHop = depth === 0;
-  if (!exact && triedOnlyENSv2Registry && firstHop && !deepestResolverIsExtended) {
-    const v1Result = await walkNamegraphFromRegistry(
-      getENSv1RootRegistryId(di.context.namespace),
-      path,
-      depth + 1,
-    );
-    if (v1Result.exact) return v1Result;
   }
 
   // finally, return the terminal path; the caller interprets `exact` (indexed leaf) vs a deepest

--- a/apps/ensapi/src/omnigraph-api/schema/query.integration.test.ts
+++ b/apps/ensapi/src/omnigraph-api/schema/query.integration.test.ts
@@ -1,14 +1,9 @@
 import {
   asInterpretedLabel,
-  asInterpretedName,
-  asLiteralLabel,
   type DomainId,
   ETH_NODE,
-  encodeLabelHash,
   type InterpretedLabel,
-  type InterpretedName,
   labelhashInterpretedLabel,
-  labelhashLiteralLabel,
   makeENSv1DomainId,
   makeENSv1RegistryId,
   makeENSv2DomainId,
@@ -17,7 +12,6 @@ import {
   type Node,
   type NormalizedAddress,
 } from "enssdk";
-import { namehash } from "viem";
 import { describe, expect, it } from "vitest";
 
 import { DatasourceNames } from "@ensnode/datasources";
@@ -48,6 +42,7 @@ const V2_ROOT_REGISTRY = getDatasourceContract(
 
 const V1_ROOT_REGISTRY = getDatasourceContract(namespace, DatasourceNames.ENSRoot, "ENSv1Registry");
 
+const V2_ETH_REGISTRY = getDatasourceContract(namespace, DatasourceNames.ENSv2Root, "ETHRegistry");
 const V1_ETH_DOMAIN_ID = makeENSv1DomainId(V1_ROOT_REGISTRY, ETH_NODE);
 const V2_ETH_STORAGE_ID = makeStorageId(labelhashInterpretedLabel(asInterpretedLabel("eth")));
 const V2_ETH_DOMAIN_ID = makeENSv2DomainId(V2_ROOT_REGISTRY, V2_ETH_STORAGE_ID);
@@ -304,39 +299,25 @@ describe("Query.domain", () => {
     }
   `;
 
-  const ensv1RootRegistry = () =>
-    getDatasourceContract("ens-test-env", DatasourceNames.ENSRoot, "ENSv1Registry");
-
-  const unhealedCanonicalEthName = (label: string): InterpretedName =>
-    asInterpretedName(
-      `${asInterpretedLabel(encodeLabelHash(labelhashLiteralLabel(asLiteralLabel(label))))}.eth`,
-    );
-
   it.each(DEVNET_NAMES)("resolves $name", async ({ name, canonical }) => {
     await expect(request(DomainByName, { name })).resolves.toMatchObject({
       domain: { canonical: { name: { interpreted: canonical } } },
     });
   });
 
-  it.each(DEVNET_ENSV1_NAMES.filter((entry) => entry.wrapped))(
-    "resolves healed ENSv1 name $name via domain(by: name)",
-    async ({ name, canonical }) => {
-      const id = makeENSv1DomainId(ensv1RootRegistry(), namehash(name));
+  // ENSv1-only names are reserved in the ENSv2 ETHRegistry (resolver = ENSV1Resolver), mirroring the
+  // migration. The walk prefers the ENSv2 Domain, and the ENSv2 registration emits the literal label,
+  // so each name resolves to an ENSv2 Domain whose canonical is the full literal name — including the
+  // legacy-unwrapped name whose ENSv1 canonical is an Encoded LabelHash.
+  it.each(DEVNET_ENSV1_NAMES)(
+    "resolves ENSv1-only name $name to its reserved ENSv2 Domain via domain(by: name)",
+    async ({ name, label, canonical }) => {
+      const id = makeENSv2DomainId(
+        V2_ETH_REGISTRY,
+        makeStorageId(labelhashInterpretedLabel(asInterpretedLabel(label))),
+      );
       await expect(request(DomainByName, { name })).resolves.toMatchObject({
         domain: { id, canonical: { name: { interpreted: canonical } } },
-      });
-    },
-  );
-
-  it.each(DEVNET_ENSV1_NAMES.filter((entry) => !entry.wrapped))(
-    "resolves unhealed ENSv1 name $name via domain(by: name)",
-    async ({ name, label }) => {
-      const id = makeENSv1DomainId(ensv1RootRegistry(), namehash(name));
-      await expect(request(DomainByName, { name })).resolves.toMatchObject({
-        domain: {
-          id,
-          canonical: { name: { interpreted: unhealedCanonicalEthName(label) } },
-        },
       });
     },
   );

--- a/apps/ensapi/src/test/integration/devnet-names.ts
+++ b/apps/ensapi/src/test/integration/devnet-names.ts
@@ -37,7 +37,8 @@ const SEEDED_ENSV2_NAMES = additionallyRegisteredNames
     })),
   ]);
 
-// ENSv1 names are seeded on-chain but live outside the ENSv2 nametree; use for targeted ENSv1 tests.
+// ENSv1 names: registered in ENSv1 and reserved in the ENSv2 ETHRegistry (resolver = ENSV1Resolver),
+// mirroring migration. Used for targeted ENSv1 tests and the reserved-entry walk tests.
 export const DEVNET_ENSV1_NAMES = additionallyRegisteredNames
   .filter((entry) => entry.type === "ENSv1")
   .map((entry) => ({

--- a/packages/integration-test-env/src/seed/registered-names.ts
+++ b/packages/integration-test-env/src/seed/registered-names.ts
@@ -47,6 +47,16 @@ async function seedEnsV1Name(
   if (entry.records) {
     await seedNameRecords(client, resolver, namehash(entry.name) as Hex, entry.records);
   }
+
+  // Mirror the ENSv2 migration's reserved-entry state: also register the name in the ENSv2
+  // ETHRegistry pointing at the ENSV1Resolver (the v1 mirror resolver). This is how a name that
+  // still lives in ENSv1 stays resolvable under UR2, and makes the preferred ENSv2 Domain the one
+  // returned by the namegraph walk — matching mainnet, where every v1 name is reserved in v2.
+  await registerEthName(client, {
+    label: entry.label,
+    resolver: contracts.ENSV1Resolver,
+    subregistry: zeroAddress,
+  });
 }
 
 async function seedEnsV2Name(
@@ -101,7 +111,8 @@ async function seedEnsV2Name(
  * Seed custom registered names into the devnet.
  *
  * ENSv1 names are registered via WrappedETHRegistrarController (healed, default) or
- * LegacyETHRegistrarController (unhealed).
+ * LegacyETHRegistrarController (unhealed), then reserved in the ENSv2 ETHRegistry pointing at the
+ * ENSV1Resolver (mirroring migration, so they resolve under UR2 as the preferred ENSv2 Domain).
  * ENSv2 names without subnames are registered directly with a zero subregistry (no UserRegistry).
  * ENSv2 names with subnames get a dedicated UserRegistry deployed first.
  */


### PR DESCRIPTION
## What

The namegraph walk (`domain(by: name)` and related Name→Domain lookups) fell back to the ENSv1 disjoint namegraph whenever the ENSv2 Root walk didn't exact-match (added in #2286). **UniversalResolverV2 has no registry-level ENSv1 fallback.** Its only ENSv1 fallback is the `ENSV1Resolver` (a mirror Resolver) set within the ENSv2 namegraph on reserved entries — which the walk already follows via its existing `ENSv1Resolver` hop. I confirmed this against `contracts-v2` (`LibRegistry.findResolver` walks only the ENSv2 registry tree; the overview docs describe the `ENSV1Resolver` reserved-entry mechanism).

So a name present only in ENSv1 and not reserved in ENSv2 is simply not resolvable under UR2 — the fallback fabricated resolution the protocol doesn't have.

## Changes

- **Revert the fallback** in `get-domain-by-interpreted-name.ts` (file is byte-identical to its pre-#2286 state) so the walk faithfully models UR2.
- **Faithful devnet seed:** reserve the ENSv1 fixtures in the ENSv2 ETHRegistry (`resolver = ENSV1Resolver`), mirroring migration. `domain(by: name)` now returns the preferred ENSv2 Domain.
- **Tests:** the `domain(by: name)` ENSv1 blocks (which only passed via the fallback) now assert the reserved **ENSv2** Domain id + literal canonical name. The `domains(where: name eq)` direct-lookup and ENSv1 virtual-registry tests are untouched.

## Notes

- The devnet reservation goes through the normal `ETHRegistrar` commit-reveal (owner = seed account) rather than a migration-controller `owner=0` reserved registration. Indistinguishable to the walk/indexer (what matters is the ENSv2 entry with `resolver = ENSV1Resolver`), but a simplification of the true reserved-entry shape.
- The changed integration tests run only against a live devnet (`test:integration:ci`) — not exercised locally.

## Verify

`pnpm -F ensapi typecheck` ✓ · `pnpm -F @ensnode/integration-test-env typecheck` ✓ · `pnpm lint` ✓ · `pnpm test --project ensapi` → 293 passed