### PR TITLE
Fix published module metadata

### DIFF
--- a/.changeset/quiet-maps-join.md
+++ b/.changeset/quiet-maps-join.md
@@ -1,0 +1,8 @@
+---
+"@ensnode/datasources": patch
+"@ensnode/ensrainbow-sdk": patch
+"@ensnode/ponder-subgraph": patch
+"@namehash/namehash-ui": patch
+---
+
+Fix published package `module` entries to point at emitted `dist/index.js` files.

--- a/packages/datasources/package.json
+++ b/packages/datasources/package.json
@@ -35,7 +35,7 @@
       }
     },
     "main": "./dist/index.js",
-    "module": "./dist/index.mjs",
+    "module": "./dist/index.js",
     "types": "./dist/index.d.ts"
   },
   "scripts": {

--- a/packages/ensrainbow-sdk/package.json
+++ b/packages/ensrainbow-sdk/package.json
@@ -40,7 +40,7 @@
       }
     },
     "main": "./dist/index.js",
-    "module": "./dist/index.mjs",
+    "module": "./dist/index.js",
     "types": "./dist/index.d.ts"
   },
   "scripts": {

--- a/packages/namehash-ui/package.json
+++ b/packages/namehash-ui/package.json
@@ -41,7 +41,7 @@
       }
     },
     "main": "./dist/index.js",
-    "module": "./dist/index.mjs",
+    "module": "./dist/index.js",
     "types": "./dist/index.d.ts",
     "styles": "./dist/index.css"
   },

--- a/packages/ponder-subgraph/package.json
+++ b/packages/ponder-subgraph/package.json
@@ -29,7 +29,7 @@
       }
     },
     "main": "./dist/index.js",
-    "module": "./dist/index.mjs",
+    "module": "./dist/index.js",
     "types": "./dist/index.d.ts"
   },
   "scripts": {


### PR DESCRIPTION
## Summary

- point the published `module` entries for four packages at `./dist/index.js`
- keep `main`, `types`, and exports aligned with the files emitted in published tarballs
- add a changeset for the affected public packages

## Verification

- `npm pack @ensnode/ensrainbow-sdk@1.15.2`, `@ensnode/datasources@1.15.2`, `@namehash/namehash-ui@1.15.2`, and `@ensnode/ponder-subgraph@1.15.2`
- confirmed each tarball contains `package/dist/index.js` and `package/dist/index.d.ts`, but not `package/dist/index.mjs`
- node assertion that all four `publishConfig.module` values are now `./dist/index.js`
- `git diff --check`