### PR TITLE
Update lockfile after auto-bumping package version with changesets

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "changeset:next": "changeset version --snapshot next && pnpm release:postversion",
     "changeset:publish": "changeset publish",
     "changeset:publish:next": "changeset publish --no-git-tag --tag next",
-    "release:postversion": "pnpm docker:version:sync && pnpm generate:openapi",
+    "release:postversion": "pnpm install --no-frozen-lockfile && pnpm docker:version:sync && pnpm generate:openapi",
     "packages:prepublish": "pnpm -r prepublish",
     "devnet": "docker compose -f docker/services/devnet.yml up",
     "docker:build:ensnode": "pnpm run -w --parallel \"/^docker:build:.*/\"",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "changeset:next": "changeset version --snapshot next && pnpm release:postversion",
     "changeset:publish": "changeset publish",
     "changeset:publish:next": "changeset publish --no-git-tag --tag next",
-    "release:postversion": "pnpm install --no-frozen-lockfile && pnpm docker:version:sync && pnpm generate:openapi",
+    "release:postversion": "pnpm install --lockfile-only && pnpm docker:version:sync && pnpm generate:openapi",
     "packages:prepublish": "pnpm -r prepublish",
     "devnet": "docker compose -f docker/services/devnet.yml up",
     "docker:build:ensnode": "pnpm run -w --parallel \"/^docker:build:.*/\"",


### PR DESCRIPTION
# Lite PR

[Tip: Review docs on the ENSNode PR process](https://ensnode.io/docs/contributing/prs)

## Summary

- The lockfile is set to be re-generated after `changeset version` command is executed.

---

## Why

- Several packages in the monorepo must use fixed version numbers to reference other monorepo packages. This creates a problem of the lockfile getting out-of-sync after running `changeset version` command. There would be no issue if the fixed version numbers were replaced with `workspace:*`. Then, Changeset CLI would figure all required updates out. But we cannot go with `workspace:*` version reference with the `examples/*` packages (for practical reasons).

---

## Testing

- Will test it out on the Changesets PR CI actions after this PR is merged.

---

## Notes for Reviewer (Optional)

- Issue and the solve was discussed by team in [this thread](https://namehash.slack.com/archives/C086Z6FNBHN/p1781790810987969)

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)
