### PR TITLE
Address OSV Scanner findings & revert PR 2313

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "changeset:next": "changeset version --snapshot next && pnpm release:postversion",
     "changeset:publish": "changeset publish",
     "changeset:publish:next": "changeset publish --no-git-tag --tag next",
-    "release:postversion": "pnpm install --lockfile-only && pnpm docker:version:sync && pnpm generate:openapi",
+    "release:postversion": "pnpm docker:version:sync && pnpm generate:openapi",
     "packages:prepublish": "pnpm -r prepublish",
     "devnet": "docker compose -f docker/services/devnet.yml up",
     "docker:build:ensnode": "pnpm run -w --parallel \"/^docker:build:.*/\"",
@@ -75,10 +75,11 @@
       "ponder>vite": "^6.4.3",
       "vite-node>vite": "^6.4.3",
       "vite@>=7.0.0 <=7.3.4": "^7.3.5",
-      "dompurify@<3.4.9": "^3.4.9",
+      "dompurify@<3.4.11": "^3.4.11",
       "protobufjs@>=7.0.0 <7.6.3": "^7.6.3",
       "protobufjs@>=8.0.0 <8.6.0": "^8.6.0",
       "postcss@>=8.0.0 <8.5.12": "^8.5.12",
+      "undici@<7.28.0": "^7.28.0",
       "ws@>=8.0.0 <8.21.0": "^8.21.0"
     },
     "peerDependencyRules": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,10 +129,11 @@ overrides:
   ponder>vite: ^6.4.3
   vite-node>vite: ^6.4.3
   vite@>=7.0.0 <=7.3.4: ^7.3.5
-  dompurify@<3.4.9: ^3.4.9
+  dompurify@<3.4.11: ^3.4.11
   protobufjs@>=7.0.0 <7.6.3: ^7.6.3
   protobufjs@>=8.0.0 <8.6.0: ^8.6.0
   postcss@>=8.0.0 <8.5.12: ^8.5.12
+  undici@<7.28.0: ^7.28.0
   ws@>=8.0.0 <8.21.0: ^8.21.0
 
 patchedDependencies:
@@ -6227,8 +6228,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.10:
-    resolution: {integrity: sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==}
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -9474,12 +9475,8 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@6.24.0:
-    resolution: {integrity: sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==}
-    engines: {node: '>=18.17'}
-
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unhead@2.1.13:
@@ -15543,7 +15540,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 6.24.0
+      undici: 7.28.0
       whatwg-mimetype: 4.0.0
 
   chokidar@3.6.0:
@@ -16111,7 +16108,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.10:
+  dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -17703,7 +17700,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
-      dompurify: 3.4.10
+      dompurify: 3.4.11
       es-toolkit: 1.46.1
       katex: 0.16.25
       khroma: 2.1.0
@@ -18053,7 +18050,7 @@ snapshots:
 
   monaco-editor@0.55.1:
     dependencies:
-      dompurify: 3.4.10
+      dompurify: 3.4.11
       marked: 14.0.0
 
   monaco-graphql@1.7.2(graphql@16.11.0)(monaco-editor@0.52.2)(prettier@3.6.2):
@@ -19750,7 +19747,7 @@ snapshots:
       ssh-remote-port-forward: 1.0.4
       tar-fs: 3.1.2
       tmp: 0.2.7
-      undici: 7.25.0
+      undici: 7.28.0
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -19962,9 +19959,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@6.24.0: {}
-
-  undici@7.25.0: {}
+  undici@7.28.0: {}
 
   unhead@2.1.13:
     dependencies:


### PR DESCRIPTION
This PR reverts the update from PR #2313 as it didn't improve the original issue it was meant to address. This PR also applies version upgrades accordingly to the OSV Scanner findings.