### PR TITLE
Update the yellow env config

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -58,7 +58,7 @@ locals {
       ensnode_indexer_type         = "v2-sepolia"
       ensnode_environment_name     = var.render_environment
       ensindexer_schema_name       = "v2SepoliaSchema-${var.ensnode_version}"
-      plugins                      = "unigraph,protocol-acceleration"
+      plugins                      = "subgraph,unigraph,protocol-acceleration"
       namespace                    = "sepolia"
       render_instance_plan         = "starter"
       subgraph_compat              = false
@@ -120,7 +120,7 @@ module "ensdb" {
 
   render_environment_id = render_project.ensnode.environments["default"].id
   render_region         = local.render_region
-  disk_size_gb          = 500
+  disk_size_gb          = 750
 }
 
 module "ensrainbow" {


### PR DESCRIPTION
# Lite PR

[Tip: Review docs on the ENSNode PR process](https://ensnode.io/docs/contributing/prs)

## Summary

- Updated ENSDb Server volume limit to 750GB.
- Activated the `subgraph` plugin for the ENSIndexer V2 Sepolia instance.

---

## Why

- We need the yellow env to have config aligned with the blue/green env config

---

## Testing

- Will be tested with the ENSNode v1.16.0 deployment to the yellow env.
---

## Notes for Reviewer (Optional)

- N/A

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)
