### PR TITLE
Update sepolia-v2 namespace with latest deployment addresses

### DIFF
--- a/.changeset/sepolia-v2-latest-addresses.md
+++ b/.changeset/sepolia-v2-latest-addresses.md
@@ -1,0 +1,6 @@
+---
+"@ensnode/datasources": patch
+"ensindexer": patch
+---
+
+Updates the `sepolia-v2` ENS Namespace with the latest ENSv1+ENSv2 test deployment addresses on Sepolia (`RootRegistry`, `ETHRegistry`, `ETHRegistrar`, `UniversalResolver`, and the default `PublicResolverV2`), each with its on-chain deployment block as `startBlock`.

--- a/.changeset/sepolia-v2-latest-addresses.md
+++ b/.changeset/sepolia-v2-latest-addresses.md
@@ -3,4 +3,4 @@
 "ensindexer": patch
 ---
 
-Updates the `sepolia-v2` ENS Namespace with the latest ENSv1+ENSv2 test deployment addresses on Sepolia (`RootRegistry`, `ETHRegistry`, `ETHRegistrar`, `UniversalResolver`, and the default `PublicResolverV2`), each with its on-chain deployment block as `startBlock`.
+Updates the `sepolia-v2` ENS Namespace with the latest deployment addresses.

--- a/packages/datasources/src/sepolia-v2.ts
+++ b/packages/datasources/src/sepolia-v2.ts
@@ -31,12 +31,16 @@ import { DatasourceNames, type ENSNamespace } from "./lib/types";
 const SEPOLIA_ENSV1_DEPLOYMENT_BLOCK = 3702721;
 
 /**
- * The earliest deploy block of the Sepolia ENSv1+v2 test deployment.
+ * The earliest deploy block of the Sepolia ENSv1 test deployment.
  *
- * @dev this is the earliest block of _any_ Sepolia ENSv1+v2 test deployment, since the ENS Team
- * has shown in the past that a previous deployment's contracts may be used with a future deployment.
+ * @dev this is the earliest block of _any_ Sepolia ENSv1+v2 test deployment.
  */
-const SEPOLIA_ENSV2_DEPLOYMENT_BLOCK = 10400000;
+const SEPOLIA_V2_ENSV1_DEPLOYMENT_BLOCK = 10400000;
+
+/**
+ * The earliest deploy block of the Sepolia ENSv2 contracts.
+ */
+const SEPOLIA_V2_ENSV2_DEPLOYMENT_BLOCK = 10921916;
 
 /**
  * The Sepolia V2 ENSNamespace
@@ -58,13 +62,13 @@ export default {
       ENSv1RegistryOld: {
         abi: root_Registry, // Registry was redeployed, same abi
         address: zeroAddress,
-        startBlock: SEPOLIA_ENSV2_DEPLOYMENT_BLOCK,
+        startBlock: SEPOLIA_V2_ENSV1_DEPLOYMENT_BLOCK,
       },
       // NOTE: named ENSRegistry in deployment
       ENSv1Registry: {
         abi: root_Registry, // Registry was redeployed, same abi
         address: "0xb6fb46e1458915dd828633d91e1df8e4c3f2d4dd",
-        startBlock: SEPOLIA_ENSV2_DEPLOYMENT_BLOCK,
+        startBlock: SEPOLIA_V2_ENSV1_DEPLOYMENT_BLOCK,
       },
       Resolver: {
         abi: ResolverABI,
@@ -74,26 +78,24 @@ export default {
       BaseRegistrar: {
         abi: root_BaseRegistrar,
         address: "0xa51c9e6efe589407c72984e93b45e35a71a398ec",
-        startBlock: SEPOLIA_ENSV2_DEPLOYMENT_BLOCK,
+        startBlock: SEPOLIA_V2_ENSV1_DEPLOYMENT_BLOCK,
       },
       // NOTE: named ETHRegistrarController in deployment
       UnwrappedEthRegistrarController: {
         abi: root_UnwrappedEthRegistrarController,
         address: "0xb5778cf6cc9586d9ce740039c84dfb1802f307bc",
-        startBlock: SEPOLIA_ENSV2_DEPLOYMENT_BLOCK,
+        startBlock: SEPOLIA_V2_ENSV1_DEPLOYMENT_BLOCK,
       },
       NameWrapper: {
         abi: root_NameWrapper,
         address: "0x250a6c640297f605b63c6e91c7cd376f04b288da",
-        startBlock: SEPOLIA_ENSV2_DEPLOYMENT_BLOCK,
+        startBlock: SEPOLIA_V2_ENSV1_DEPLOYMENT_BLOCK,
       },
       // NOTE: named UpgradableUniversalResolverProxy in deployment
-      // The proxy itself was deployed at block 8928790 (reused cross-chain vanity address); index
-      // from the sepolia-v2 deployment block, since earlier blocks predate its use in this deployment.
       UniversalResolver: {
         abi: UniversalResolverABI,
         address: "0xeeeeeeee14d718c2b47d9923deab1335e144eeee",
-        startBlock: 10921916,
+        startBlock: SEPOLIA_V2_ENSV2_DEPLOYMENT_BLOCK,
       },
     },
   },
@@ -102,25 +104,25 @@ export default {
     chain: sepolia,
     contracts: {
       Resolver: { abi: ResolverABI, startBlock: SEPOLIA_ENSV1_DEPLOYMENT_BLOCK },
-      Registry: { abi: Registry, startBlock: SEPOLIA_ENSV2_DEPLOYMENT_BLOCK },
+      Registry: { abi: Registry, startBlock: SEPOLIA_V2_ENSV2_DEPLOYMENT_BLOCK },
       EnhancedAccessControl: {
         abi: EnhancedAccessControl,
-        startBlock: SEPOLIA_ENSV2_DEPLOYMENT_BLOCK,
+        startBlock: SEPOLIA_V2_ENSV2_DEPLOYMENT_BLOCK,
       },
       RootRegistry: {
         abi: Registry,
         address: "0xc960f7217d3643b525ef36bec8adf86953cd9ab8",
-        startBlock: 10921920,
+        startBlock: SEPOLIA_V2_ENSV2_DEPLOYMENT_BLOCK,
       },
       ETHRegistry: {
         abi: Registry,
         address: "0xdedb92913a25abe1f7bcdd85d8a344a43b398b67",
-        startBlock: 10921984,
+        startBlock: SEPOLIA_V2_ENSV2_DEPLOYMENT_BLOCK,
       },
       ETHRegistrar: {
         abi: ETHRegistrar,
         address: "0x8c2e866b439358c41ae05de9cbe8a00bfefaffca",
-        startBlock: 10921994,
+        startBlock: SEPOLIA_V2_ENSV2_DEPLOYMENT_BLOCK,
       },
     },
   },
@@ -131,40 +133,40 @@ export default {
       DefaultReverseRegistrar: {
         abi: StandaloneReverseRegistrar,
         address: "0x26997c9d0f3dcbae3f78c69e621a3926ee30bb98",
-        startBlock: SEPOLIA_ENSV2_DEPLOYMENT_BLOCK,
+        startBlock: SEPOLIA_V2_ENSV1_DEPLOYMENT_BLOCK,
       },
 
       // NOTE: named PublicResolverV2 in deployment
       DefaultPublicResolver5: {
         abi: ResolverABI,
         address: "0x5239a812ec9a62f46dbb5de8f346c8efe7553a9f",
-        startBlock: 10921998,
+        startBlock: SEPOLIA_V2_ENSV2_DEPLOYMENT_BLOCK,
       },
 
       BaseReverseResolver: {
         abi: ResolverABI,
         address: "0xaf3b3f636be80b6709f5bd3a374d6ac0d0a7c7aa",
-        startBlock: SEPOLIA_ENSV2_DEPLOYMENT_BLOCK,
+        startBlock: SEPOLIA_V2_ENSV1_DEPLOYMENT_BLOCK,
       },
       LineaReverseResolver: {
         abi: ResolverABI,
         address: "0x083da1dbc0f379ccda6ac81a934207c3d8a8a205",
-        startBlock: SEPOLIA_ENSV2_DEPLOYMENT_BLOCK,
+        startBlock: SEPOLIA_V2_ENSV1_DEPLOYMENT_BLOCK,
       },
       OptimismReverseResolver: {
         abi: ResolverABI,
         address: "0xc9ae189772bd48e01410ab3be933637ee9d3aa5f",
-        startBlock: SEPOLIA_ENSV2_DEPLOYMENT_BLOCK,
+        startBlock: SEPOLIA_V2_ENSV1_DEPLOYMENT_BLOCK,
       },
       ArbitrumReverseResolver: {
         abi: ResolverABI,
         address: "0x926f94d2adc77c86cb0050892097d49aadd02e8b",
-        startBlock: SEPOLIA_ENSV2_DEPLOYMENT_BLOCK,
+        startBlock: SEPOLIA_V2_ENSV1_DEPLOYMENT_BLOCK,
       },
       ScrollReverseResolver: {
         abi: ResolverABI,
         address: "0x9fa59673e43f15bdb8722fdaf5c2107574b99062",
-        startBlock: SEPOLIA_ENSV2_DEPLOYMENT_BLOCK,
+        startBlock: SEPOLIA_V2_ENSV1_DEPLOYMENT_BLOCK,
       },
     },
   },

--- a/packages/datasources/src/sepolia-v2.ts
+++ b/packages/datasources/src/sepolia-v2.ts
@@ -87,10 +87,13 @@ export default {
         address: "0x250a6c640297f605b63c6e91c7cd376f04b288da",
         startBlock: SEPOLIA_ENSV2_DEPLOYMENT_BLOCK,
       },
+      // NOTE: named UpgradableUniversalResolverProxy in deployment
+      // The proxy itself was deployed at block 8928790 (reused cross-chain vanity address); index
+      // from the sepolia-v2 deployment block, since earlier blocks predate its use in this deployment.
       UniversalResolver: {
         abi: UniversalResolverABI,
-        address: "0x651d670ce0d0f1ed0893f39d51fd0dbd4546c9ef",
-        startBlock: 10893223,
+        address: "0xeeeeeeee14d718c2b47d9923deab1335e144eeee",
+        startBlock: 10921916,
       },
     },
   },
@@ -106,18 +109,18 @@ export default {
       },
       RootRegistry: {
         abi: Registry,
-        address: "0x835f0b284e78cd3f358bcf6cba3b53809f09b79e",
-        startBlock: SEPOLIA_ENSV2_DEPLOYMENT_BLOCK,
+        address: "0xc960f7217d3643b525ef36bec8adf86953cd9ab8",
+        startBlock: 10921920,
       },
       ETHRegistry: {
         abi: Registry,
-        address: "0x64c81210d0e580cfc7746f3fb910bf0e8f6378e1",
-        startBlock: SEPOLIA_ENSV2_DEPLOYMENT_BLOCK,
+        address: "0xdedb92913a25abe1f7bcdd85d8a344a43b398b67",
+        startBlock: 10921984,
       },
       ETHRegistrar: {
         abi: ETHRegistrar,
-        address: "0xb68e594a47fe057bd31e7a8229ffcfd85b2e28af",
-        startBlock: SEPOLIA_ENSV2_DEPLOYMENT_BLOCK,
+        address: "0x8c2e866b439358c41ae05de9cbe8a00bfefaffca",
+        startBlock: 10921994,
       },
     },
   },
@@ -131,11 +134,11 @@ export default {
         startBlock: SEPOLIA_ENSV2_DEPLOYMENT_BLOCK,
       },
 
-      // NOTE: named PublicResolver in deployment
+      // NOTE: named PublicResolverV2 in deployment
       DefaultPublicResolver5: {
         abi: ResolverABI,
-        address: "0xb441cb480460eb8b2964dcb82b64a883b14abf3e",
-        startBlock: SEPOLIA_ENSV2_DEPLOYMENT_BLOCK,
+        address: "0x5239a812ec9a62f46dbb5de8f346c8efe7553a9f",
+        startBlock: 10921998,
       },
 
       BaseReverseResolver: {


### PR DESCRIPTION
Refreshes the `sepolia-v2` ENS Namespace to track the latest ENSv1+ENSv2 Sepolia test deployment (`contracts-v2` deployment `sepolia-official-v1-20260525-r2`).

## Updated entries

Each `startBlock` is the contract's on-chain deployment block, identified via `cast` (binary search over `eth_getCode`).

| Namespace entry | Deployment name | New address | startBlock |
|---|---|---|---|
| `ENSv2Root.RootRegistry` | RootRegistry | `0xc960f7217d3643b525ef36bec8adf86953cd9ab8` | 10921920 |
| `ENSv2Root.ETHRegistry` | ETHRegistry | `0xdedb92913a25abe1f7bcdd85d8a344a43b398b67` | 10921984 |
| `ENSv2Root.ETHRegistrar` | ETHRegistrar | `0x8c2e866b439358c41ae05de9cbe8a00bfefaffca` | 10921994 |
| `ENSRoot.UniversalResolver` | UpgradableUniversalResolverProxy | `0xeeeeeeee14d718c2b47d9923deab1335e144eeee` | 10921916 |
| `rrRoot.DefaultPublicResolver5` | PublicResolverV2 | `0x5239a812ec9a62f46dbb5de8f346c8efe7553a9f` | 10921998 |

## Notes

- **`UniversalResolver`** points at the `UpgradableUniversalResolverProxy` (reused cross-chain vanity address `0xeeee…eeee`, actually created at block 8928790). Its `startBlock` is set to the v2 deployment block `10921916` rather than the proxy's creation block, since earlier blocks predate its use in this deployment.
- **`DefaultPublicResolver5`** maps to `PublicResolverV2` — *"PublicResolver that respects the ENSv2 registry"*, the successor to the deployment's prior `PublicResolver`. (The separately-deployed `PublicResolverSet` is a `PermissionedAddressSet` allow-list of wrapper-aware resolver addresses, not a resolver, so it is not indexed.)
- The ENSv1 root contracts (`ENSv1Registry`, `BaseRegistrar`, `UnwrappedEthRegistrarController`, `NameWrapper`) and the reverse resolvers are unchanged — they are reused from the prior deployment and were not part of this address set.

## Validation

- `pnpm -F @ensnode/datasources typecheck` ✓
- `pnpm test packages/datasources` ✓ (8/8, incl. lowercase-address invariants)
- `biome check` ✓