### PR TITLE
fix(ensrainbow): decouple Docker build from dev-only skills tooling

### DIFF
--- a/apps/ensrainbow/Dockerfile
+++ b/apps/ensrainbow/Dockerfile
@@ -15,15 +15,16 @@ RUN corepack enable
 WORKDIR /app
 
 # Copy package files for dependency installation
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml skills-npm.config.ts ./
-COPY .agents/ .agents/
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY packages/ packages/
 COPY patches/ patches/
-COPY scripts/ scripts/
 COPY apps/ensrainbow/package.json apps/ensrainbow/
 
-# Install dependencies
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
+# Install dependencies. --ignore-scripts skips the root `prepare` lifecycle (dev-only skill
+# symlinking via skills-npm + scripts/link-local-skills.mjs), which is irrelevant to a runtime
+# image and would otherwise force copying skills-npm.config.ts, .agents/ and scripts/ into the
+# build context. The lockfile pins no built dependencies, so nothing else relies on scripts here.
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --ignore-scripts
 
 # Copy the application source and scripts
 COPY apps/ensrainbow/src/ apps/ensrainbow/src/


### PR DESCRIPTION
The ENSRainbow image copied `skills-npm.config.ts`, `.agents/`, and `scripts/` solely so the root `prepare` lifecycle (dev-only skill symlinking via skills-npm + `scripts/link-local-skills.mjs`) would not fail during `pnpm install`. That coupling is exactly what broke the build in #2302 — every change to the skills tooling risks silently breaking the ENSRainbow image.

This skips the irrelevant `prepare` with `--ignore-scripts` and drops those three copies. The lockfile pins no built dependencies (`pnpm.onlyBuiltDependencies` is empty), so nothing else depends on install scripts here.

## Validation
- Builds clean and boots: `/health` returns `{"status":"ok"}`, the entrypoint binds the HTTP server and starts the database download.
- Image size unchanged: **921MB** (vs 922MB on `main`).
- No changeset, matching the precedent set by #2302 (Dockerfile-only build change).

## Scope
Intentionally narrow — this de-fragilizes the existing selective-copy build. It does **not** switch ENSRainbow to the other apps' `COPY . .` pattern (that nearly doubles the image to ~1.79GB) nor to a `pnpm deploy --prod` bundle (blocked by the apps running TypeScript from source and importing workspace packages' source at runtime; tracked separately as a larger "run built JS in production images" initiative).