### PR TITLE
Index ResolverAddressRecord for nameReferences keyset order

### DIFF
--- a/packages/ensdb-sdk/src/ensindexer-abstract/protocol-acceleration.schema.ts
+++ b/packages/ensdb-sdk/src/ensindexer-abstract/protocol-acceleration.schema.ts
@@ -218,8 +218,10 @@ export const resolverAddressRecord = onchainTable(
   (t) => ({
     pk: primaryKey({ columns: [t.chainId, t.address, t.node, t.coinType] }),
     // supports the reverse lookup powering `Account.nameReferences`:
-    // `WHERE value = <address> [AND coin_type = <coinType>]`
-    byValueAndCoinType: index().on(t.value, t.coinType),
+    // `WHERE value = <address> [AND coin_type = <coinType>] ORDER BY (node, coinType, chainId, address)`.
+    // The `value` prefix seeks the filter; the remaining columns match the keyset ORDER BY tuple so
+    // rows are yielded already sorted, letting pagination range-scan to the cursor instead of sorting.
+    byValueKeyset: index().on(t.value, t.node, t.coinType, t.chainId, t.address),
   }),
 );
 


### PR DESCRIPTION
## Summary

`Account.nameReferences` reads `resolver_address_records` with `WHERE value = <account> [AND coin_type = <coinType>]` and paginates via a keyset `ORDER BY (node, coinType, chainId, address)` (see `resolveAccountNameReferences`).

The existing index `(value, coinType)` could seek the `value = account` filter but yielded rows in the wrong order, so Postgres added a `Sort` over the full matching set on every page — negating keyset pagination's seek-to-cursor benefit and scaling poorly for addresses with many records.

This extends the index to `(value, node, coinType, chainId, address)`:

- `value` leading → equality seek for the filter.
- The trailing columns match the keyset `ORDER BY` tuple exactly (a full PK permutation, so the order is total), so rows come out already sorted. Pagination range-scans to the cursor and stops at `LIMIT` — no `Sort`.

Renamed `byValueAndCoinType` → `byValueKeyset` to reflect the new role.

## Notes

- The `coinType`-filtered path still preserves order (no sort); `coinType` is applied inline rather than as a tight range, which is an acceptable trade given the unfiltered case is primary and benefits unconditionally.
- Wider index (5 cols) means existing deployments need an index build / reindex.

## Verification

- `pnpm -F @ensnode/ensdb-sdk typecheck` passes.