### PR TITLE
fix(ensindexer): demote expected EFP indexing conditions to debug

### DIFF
--- a/.changeset/efp-log-levels.md
+++ b/.changeset/efp-log-levels.md
@@ -1,5 +1,0 @@
----
-"ensindexer": patch
----
-
-Demote expected EFP indexing conditions from `warn` to `debug`: an `ADD_TAG`/`REMOVE_TAG` op referencing an absent list record, and an `UpdateListStorageLocation` with an undecodable payload (e.g. a list encoding a zero chainId). These reflect normal on-chain EFP data — EFP's own API resolves such lists to no records — and previously flooded the logs during EFP indexing.

--- a/.changeset/efp-log-levels.md
+++ b/.changeset/efp-log-levels.md
@@ -1,0 +1,5 @@
+---
+"ensindexer": patch
+---
+
+Demote expected EFP indexing conditions from `warn` to `debug`: an `ADD_TAG`/`REMOVE_TAG` op referencing an absent list record, and an `UpdateListStorageLocation` with an undecodable payload (e.g. a list encoding a zero chainId). These reflect normal on-chain EFP data — EFP's own API resolves such lists to no records — and previously flooded the logs during EFP indexing.

--- a/apps/ensindexer/src/plugins/efp/handlers/ListRecords.ts
+++ b/apps/ensindexer/src/plugins/efp/handlers/ListRecords.ts
@@ -67,10 +67,12 @@ export default function () {
           const record = await context.ensDb.find(ensIndexerSchema.efpListRecords, { id });
           // Ops for a (chain, contract, slot) are indexed in on-chain order, so a tag with no record
           // means the record is not in the list: removed earlier, or (anomalously) never added.
-          // Either way there is no row to tag; this is an expected on-chain condition (EFP's own
-          // indexer logs and skips such ops), so log at debug rather than flood warnings.
+          // Either way there is no row to tag; this is an expected on-chain condition, so debug
+          // log it just in case.
           if (!record) {
-            logger.debug({ msg: `EFP ADD_TAG references absent record ${id} (tag "${tagOp.tag}")` });
+            logger.debug({
+              msg: `EFP ADD_TAG references absent record ${id} (tag "${tagOp.tag}")`,
+            });
             return;
           }
           // A record's tags are a set, so skip a tag it already carries.
@@ -86,8 +88,7 @@ export default function () {
           if (!tagOp) return;
           const id = listRecordId(chainId, contractAddress, slot, tagOp.record);
           const record = await context.ensDb.find(ensIndexerSchema.efpListRecords, { id });
-          // As with ADD_TAG, an absent record is an expected on-chain condition (the record was
-          // removed earlier or never added); log at debug rather than flood warnings.
+          // As with ADD_TAG, this is an expected on-chain condition, so debug log it just in case.
           if (!record) {
             logger.debug({
               msg: `EFP REMOVE_TAG references absent record ${id} (tag "${tagOp.tag}")`,

--- a/apps/ensindexer/src/plugins/efp/handlers/ListRecords.ts
+++ b/apps/ensindexer/src/plugins/efp/handlers/ListRecords.ts
@@ -67,9 +67,10 @@ export default function () {
           const record = await context.ensDb.find(ensIndexerSchema.efpListRecords, { id });
           // Ops for a (chain, contract, slot) are indexed in on-chain order, so a tag with no record
           // means the record is not in the list: removed earlier, or (anomalously) never added.
-          // Either way there is no row to tag; warn rather than drop it silently.
+          // Either way there is no row to tag; this is an expected on-chain condition (EFP's own
+          // indexer logs and skips such ops), so log at debug rather than flood warnings.
           if (!record) {
-            logger.warn({ msg: `EFP ADD_TAG references absent record ${id} (tag "${tagOp.tag}")` });
+            logger.debug({ msg: `EFP ADD_TAG references absent record ${id} (tag "${tagOp.tag}")` });
             return;
           }
           // A record's tags are a set, so skip a tag it already carries.
@@ -85,8 +86,10 @@ export default function () {
           if (!tagOp) return;
           const id = listRecordId(chainId, contractAddress, slot, tagOp.record);
           const record = await context.ensDb.find(ensIndexerSchema.efpListRecords, { id });
+          // As with ADD_TAG, an absent record is an expected on-chain condition (the record was
+          // removed earlier or never added); log at debug rather than flood warnings.
           if (!record) {
-            logger.warn({
+            logger.debug({
               msg: `EFP REMOVE_TAG references absent record ${id} (tag "${tagOp.tag}")`,
             });
             return;

--- a/apps/ensindexer/src/plugins/efp/handlers/ListRegistry.ts
+++ b/apps/ensindexer/src/plugins/efp/handlers/ListRegistry.ts
@@ -127,9 +127,11 @@ export default function () {
       // An undecodable payload (future version, non-onchain location type, or malformed) replaces
       // the on-chain location with something this indexer can't represent. Drop the stale decoded
       // location, its reverse mapping, and its location-scoped roles rather than keep resolving the
-      // old slot; keep the raw payload for debugging.
+      // old slot; keep the raw payload for debugging. This is an expected on-chain condition (e.g.
+      // lists that encode a zero chainId, which EFP's own API also resolves to no records), so log
+      // at debug rather than flood warnings.
       if (!parsed) {
-        logger.warn({
+        logger.debug({
           msg: `EFP UpdateListStorageLocation(tokenId=${tokenId}) has an undecodable payload; clearing the list's location`,
         });
         if (oldLocationId !== null) {

--- a/apps/ensindexer/src/plugins/efp/handlers/ListRegistry.ts
+++ b/apps/ensindexer/src/plugins/efp/handlers/ListRegistry.ts
@@ -127,9 +127,8 @@ export default function () {
       // An undecodable payload (future version, non-onchain location type, or malformed) replaces
       // the on-chain location with something this indexer can't represent. Drop the stale decoded
       // location, its reverse mapping, and its location-scoped roles rather than keep resolving the
-      // old slot; keep the raw payload for debugging. This is an expected on-chain condition (e.g.
-      // lists that encode a zero chainId, which EFP's own API also resolves to no records), so log
-      // at debug rather than flood warnings.
+      // old slot; keep the raw payload for debugging. This is an expected on-chain condition, so
+      // debug log it just in case.
       if (!parsed) {
         logger.debug({
           msg: `EFP UpdateListStorageLocation(tokenId=${tokenId}) has an undecodable payload; clearing the list's location`,


### PR DESCRIPTION
## Summary

While indexing EFP on the mainnet namespace, three EFP handler paths log at `warn` for conditions that are normal on-chain data, flooding the logs. This demotes them to `debug`.

The affected paths:

- **`ADD_TAG` / `REMOVE_TAG` references absent record** (`ListRecords.ts`) — a tag op resolves to a `(chainId, contractAddress, slot, record)` row that isn't in the index because the record was removed earlier or was never added on-chain. The op is skipped, mirroring EFP's own api-v2 indexer ("log and skip bad ops").
- **`UpdateListStorageLocation` undecodable payload** (`ListRegistry.ts`) — a list whose storage location can't be represented. In practice these are well-formed 86-byte v1/type-1 payloads that encode a **zero chainId** (verified on-chain for several token ids, e.g. 43713/43715). EFP's own API resolves such lists to zero following records, so the indexer's "clear the location" behavior matches the canonical source — this is expected, not an anomaly.

No behavior change beyond log level; the indexed result is identical.

## Verification

- Read the raw `getListStorageLocation` payloads for the affected token ids on Base — confirmed 86-byte v1/type-1 with `chainId == 0`.
- Cross-checked EFP's public API (`api.ethfollow.xyz`): the same lists report `following_count: 0`, matching the indexer.
- `pnpm -F ensindexer typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)