### PR TITLE
docs: apply #2320 review follow-ups

### DIFF
--- a/.changeset/docs-pr-2320-review-followup.md
+++ b/.changeset/docs-pr-2320-review-followup.md
@@ -1,0 +1,5 @@
+---
+"@docs/ensnode": patch
+---
+
+Apply review follow-ups to the Integrate docs: refine Namegraph / Nametable / Unigraph wording in the Omnigraph and Unigraph concepts pages (the Unigraph models Namegraphs and Nametables rather than "constructs Namegraphs", an ENSv1 Root Registry roots a Nametable not a Namegraph, avoid singular "the namegraph" where multiple namegraphs are meant), singularize "primary name per chain" in ENS Resolution, and switch the Domain Resolver Omnigraph example to `jesse.base.eth` so the assigned vs. effective resolver actually differ.

--- a/.changeset/ensnode-sdk-domain-resolver-example.md
+++ b/.changeset/ensnode-sdk-domain-resolver-example.md
@@ -1,0 +1,5 @@
+---
+"@ensnode/ensnode-sdk": patch
+---
+
+Change the `domain-resolver` Omnigraph example query to target `jesse.base.eth` instead of `vitalik.eth`, so the assigned and effective Resolvers differ and better illustrate the distinction.

--- a/docs/ensnode.io/src/content/docs/docs/integrate/omnigraph/concepts.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/integrate/omnigraph/concepts.mdx
@@ -82,7 +82,7 @@ query Namegraph {
 
 The **Unigraph** is the entire collection of these disjoint ENSv2 Namegraphs and multiple ENSv1 Nametables, combined together into a single unified data model using ENS Resolution semantics. Navigating the Unigraph from `"eth"` down to `"vitalik.eth"` and beyond looks identical regardless of whether the underlying entities are ENSv1 or ENSv2.
 
-The `unigraph` [ENSNode plugin](/docs/integrate/integration-options/ensnode-plugins), implemented in [ENSIndexer](/docs/services/ensindexer), is what builds this unified model. The Unigraph constructs many Namegraphs — at minimum one rooted at the ENSv1 Root Registry and one rooted at the ENSv2 Root Registry. It also includes special support for unifying multiple ENSv1 Nametables across multiple chains into the Unigraph, including: Basenames (`.base.eth`), Lineanames (`.linea.eth`), and 3DNS names (`.box`).
+The `unigraph` [ENSNode plugin](/docs/integrate/integration-options/ensnode-plugins), implemented in [ENSIndexer](/docs/services/ensindexer), is what builds this unified model. The Unigraph models many Namegraphs and Nametables together — for example, the ENSv1 Nametable rooted at the ENSv1 Root Registry and the ENSv2 Namegraph rooted at the ENSv2 Root Registry. It also includes special support for unifying multiple ENSv1 Nametables across multiple chains into the Unigraph, including: Basenames (`.base.eth`), Lineanames (`.linea.eth`), and 3DNS names (`.box`).
 
 ```mermaid
 flowchart TD
@@ -120,7 +120,7 @@ query Basenames {
 
 Once ENSv2 launches, the ENSv2 Namegraphs will exist in parallel with the ENSv1 Nametables. When referencing a Domain by `name`, the Omnigraph will start at the **ENSv2 Root Registry**, and traverse the Unigraph to find the appropriate Domain. Once `.eth` names are reserved in the ENSv2 `EthRegistry`, then the **ENSv2 Domain** will be returned, since that's the Domain that would be referenced during resolution. This is part of why it's important to reference specific Domains by `id`; once `vitalik` has been reserved in the ENSv2 EthRegistry, the ENS protocol considers the ENSv2 Domain (_not_ the ENSv1 Domain) to be the 'real' one. That said, after the `.eth` names are reserved (but before they're individually migrated), their resolver will be the `ENSv1Resolver`, forwarding resolution to the ENSv1 Nametable.
 
-The end result is that there are **two** Domains considered to be "vitalik.eth", one in the ENSv1 Nametable and one in an ENSv2 Namegraph.
+The end result is that there are **two** Domains considered to be "vitalik.eth", one in an ENSv1 Nametable and one in an ENSv2 Namegraph.
 
 ```graphql title="example.gql"
 query ByProtocolVersion {
@@ -174,7 +174,7 @@ Addressing a Domain by **name** is a different operation. It's **forward travers
 These two views are not interchangeable:
 
 - The `id` you receive from a name lookup _is_ the stable reference to the on-chain entity that the Unigraph currently resolves `"vitalik.eth"` to.
-- But `"vitalik.eth"` is not a stable reference to that entity. A Domain's position in the namegraph can be re-parented or re-aliased — and tomorrow, `"vitalik.eth"` may resolve to an entirely different on-chain Domain, which may have a different resolver with different records.
+- But `"vitalik.eth"` is not a stable reference to that entity. A Domain's position in the Unigraph can be re-parented or re-aliased — and tomorrow, `"vitalik.eth"` may resolve to an entirely different on-chain Domain, which may have a different resolver with different records.
 
 Address the exact on-chain entity by `id` — stable across time:
 

--- a/docs/ensnode.io/src/content/docs/docs/integrate/omnigraph/ens-resolution.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/integrate/omnigraph/ens-resolution.mdx
@@ -9,7 +9,7 @@ import OmnigraphStaticExampleSet from "@components/organisms/OmnigraphStaticExam
 The ENS protocol defines two forms of resolution:
 
 - **Forward resolution** — given a name (`vitalik.eth`), resolve its records: avatar, bio, links, multichain addresses, and more.
-- **Reverse resolution** — given an address _and a coin type_ (the [ENSIP-19](https://docs.ens.domains/ensip/19) identifier for a chain), resolve the **primary name** that address has set for that chain. Reverse resolution is always defined for an `(address, coinType)` pair, not an address alone — the same address can have different primary names per chain.
+- **Reverse resolution** — given an address _and a coin type_ (the [ENSIP-19](https://docs.ens.domains/ensip/19) identifier for a chain), resolve the **primary name** that address has set for that chain. Reverse resolution is always defined for an `(address, coinType)` pair, not an address alone — the same address can have a different primary name per chain.
 
 One of the most common patterns when building on ENS is to combine both: given an address, first perform **reverse resolution** to get the primary name, then perform **forward resolution** on that name to fetch its avatar, social handles, and other display details. Because this pattern is so common, the Omnigraph provides support for it as a single operation we call **complete resolution** — reverse and forward in one query, with no extra round trips.
 

--- a/docs/ensnode.io/src/content/docs/docs/integrate/unigraph/concepts.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/integrate/unigraph/concepts.mdx
@@ -13,7 +13,7 @@ Performing SQL queries on the ENS Unigraph requires that you have the `unigraph`
 
 ## Canonical Nametree
 
-The **Canonical Nametree** is the set of all Domains that have an inferrable **Canonical Name** — materialized by traversing the namegraphs. For every Domain in it, the canonical fields are populated — `canonical_name`, `canonical_path`, `canonical_node`, and `canonical_depth` — across both ENSv1 and ENSv2. That means you can look a name up by `canonical_name = 'vitalik.eth'`, order by `canonical_depth`, or walk a name's path **without branching by `type` on protocol version** and without traversing the namegraph yourself.
+The **Canonical Nametree** is the set of all Domains that have an inferrable **Canonical Name** — materialized by traversing the namegraphs. For every Domain in it, the canonical fields are populated — `canonical_name`, `canonical_path`, `canonical_node`, and `canonical_depth` — across both ENSv1 and ENSv2. That means you can look a name up by `canonical_name = 'vitalik.eth'`, order by `canonical_depth`, or walk a name's path **without branching by `type` on protocol version** and without traversing the namegraphs yourself.
 
 Multichain coverage is part of the same model: Basenames (`.base.eth`), Lineanames (`.linea.eth`), and 3DNS names (`.box`) are materialized into the same Unigraph as mainnet `.eth`, so a single query spans every indexable name.
 

--- a/docs/ensnode.io/src/data/omnigraph-examples/examples.json
+++ b/docs/ensnode.io/src/data/omnigraph-examples/examples.json
@@ -141,7 +141,7 @@
     "id": "domain-resolver",
     "query": "query DomainResolver($name: InterpretedName!) {\n  domain(by: { name: $name }) {\n    resolver {\n      # the Resolver explicitly assigned to this Domain\n      assigned {\n        contract { address }\n      }\n      # the Resolver that ENS Forward Resolution (ENSIP-10) actually lands\n      # on for this Domain — i.e. its effective Resolver\n      effective {\n        contract { address }\n      }\n    }\n  }\n}",
     "variables": {
-      "name": "vitalik.eth"
+      "name": "jesse.base.eth"
     }
   },
   {

--- a/docs/ensnode.io/src/data/omnigraph-examples/responses.json
+++ b/docs/ensnode.io/src/data/omnigraph-examples/responses.json
@@ -1596,12 +1596,12 @@
         "resolver": {
           "assigned": {
             "contract": {
-              "address": "0x231b0ee14048e9dccd1d247744d114a4eb5e8e63"
+              "address": "0xc6d566a56a1aff6508b41f6c90ff131615583bcd"
             }
           },
           "effective": {
             "contract": {
-              "address": "0x231b0ee14048e9dccd1d247744d114a4eb5e8e63"
+              "address": "0xde9049636f4a1dfe0a64d1bfe3155c0a14c54f31"
             }
           }
         }

--- a/packages/ensnode-sdk/src/omnigraph-api/example-queries.ts
+++ b/packages/ensnode-sdk/src/omnigraph-api/example-queries.ts
@@ -42,7 +42,7 @@ const SEPOLIA_V2_NAME = asInterpretedName("roppp.eth");
 
 const VITALIK_NAME = asInterpretedName("vitalik.eth");
 
-// a Basename (`.base.eth`) — its assigned vs. effective Resolver differ, making it a
+// a Basename (`.base.eth`) — its assigned vs. effective resolvers differ, making it a
 // more interesting subject than a mainnet `.eth` name for the Domain resolver example
 const JESSE_BASE_NAME = asInterpretedName("jesse.base.eth");
 

--- a/packages/ensnode-sdk/src/omnigraph-api/example-queries.ts
+++ b/packages/ensnode-sdk/src/omnigraph-api/example-queries.ts
@@ -42,6 +42,10 @@ const SEPOLIA_V2_NAME = asInterpretedName("roppp.eth");
 
 const VITALIK_NAME = asInterpretedName("vitalik.eth");
 
+// a Basename (`.base.eth`) — its assigned vs. effective Resolver differ, making it a
+// more interesting subject than a mainnet `.eth` name for the Domain resolver example
+const JESSE_BASE_NAME = asInterpretedName("jesse.base.eth");
+
 const GREG_NAME = asInterpretedName("gregskril.eth");
 
 const GREG_ADDRESS = toNormalizedAddress("0x179a862703a4adfb29896552df9e307980d19285");
@@ -763,7 +767,7 @@ query DomainResolver($name: InterpretedName!) {
   }
 }`,
     variables: {
-      default: { name: VITALIK_NAME },
+      default: { name: JESSE_BASE_NAME },
       [ENSNamespaceIds.EnsTestEnv]: { name: DEVNET_NAME_WITH_OWNED_RESOLVER },
       [ENSNamespaceIds.SepoliaV2]: { name: SEPOLIA_V2_NAME },
     },


### PR DESCRIPTION
Follow-up to the review feedback on #2320 ([review](https://github.com/namehash/ensnode/pull/2320#pullrequestreview-4535285167)). Each item below maps to a review comment.

### Omnigraph concepts (`integrate/omnigraph/concepts.mdx`)
- The Unigraph **models** many Namegraphs and Nametables together (was "constructs many Namegraphs"). An ENSv1 Root Registry roots an ENSv1 **Nametable**, not a Namegraph — corrected the example.
- "one in **an** ENSv1 Nametable" (there is more than one ENSv1 Nametable).
- A Domain's position "in the **Unigraph**" rather than "in the namegraph" (avoids implying a single namegraph).

### ENS Resolution (`integrate/omnigraph/ens-resolution.mdx`)
- "the same address can have **a different primary name** per chain" (singular).

### Unigraph concepts (`integrate/unigraph/concepts.mdx`)
- Copilot nit: pluralize the trailing "without traversing the **namegraphs** yourself" to match "traversing the namegraphs" earlier in the sentence.

### Domain Resolver example (`packages/ensnode-sdk` + docs snapshot)
- Switched the `domain-resolver` Omnigraph example from `vitalik.eth` to `jesse.base.eth`. For a Basename the assigned and effective Resolvers differ (`0xc6d5…` vs `0xde90…`), which actually demonstrates the assigned-vs-effective distinction the example is about (they were identical for `vitalik.eth`). Updated the vendored docs snapshot (`examples.json`) and refreshed the rendered response (`responses.json`) to match.

## Validation
- `pnpm -F @ensnode/ensnode-sdk typecheck`
- prettier + biome formatting checks on changed files
- `vitest run` for `ensnode-sdk` and `docs/ensnode.io`