### PR TITLE
docs(omnigraph): use dperri.com for the Domain Resolver example

### DIFF
--- a/.changeset/docs-pr-2320-review-followup.md
+++ b/.changeset/docs-pr-2320-review-followup.md
@@ -1,5 +1,0 @@
----
-"@docs/ensnode": patch
----
-
-Apply review follow-ups to the Integrate docs: refine Namegraph / Nametable / Unigraph wording in the Omnigraph and Unigraph concepts pages (the Unigraph models Namegraphs and Nametables rather than "constructs Namegraphs", an ENSv1 Root Registry roots a Nametable not a Namegraph, avoid singular "the namegraph" where multiple namegraphs are meant), singularize "primary name per chain" in ENS Resolution, and switch the Domain Resolver Omnigraph example to `jesse.base.eth` so the assigned vs. effective resolver actually differ.

--- a/.changeset/docs-priority-feedback-june.md
+++ b/.changeset/docs-priority-feedback-june.md
@@ -1,5 +1,0 @@
----
-"@docs/ensnode": patch
----
-
-Apply priority docs feedback across the Integrate section: standardize Namegraph / Nametable / Unigraph terminology (plural ENSv2 Namegraphs, ENSv1 Nametables) and define these terms in the glossary, add a new ENS Omnigraph API FAQ page covering ENS decentralization, document the `UnindexedDomain` type, update "Interpreted records" and "Automatic avatars" from "coming soon" to shipped, reframe ENSv2 Readiness around the Omnigraph / viem / UniversalResolver-proxy guidance, expand the Omnigraph "What you get" benefits, and clarify reverse and complete resolution.

--- a/.changeset/ensnode-sdk-domain-resolver-example.md
+++ b/.changeset/ensnode-sdk-domain-resolver-example.md
@@ -1,5 +1,0 @@
----
-"@ensnode/ensnode-sdk": patch
----
-
-Change the `domain-resolver` Omnigraph example query to target `jesse.base.eth` instead of `vitalik.eth`, so the assigned and effective Resolvers differ and better illustrate the distinction.

--- a/.changeset/omnigraph-example-queries-update.md
+++ b/.changeset/omnigraph-example-queries-update.md
@@ -1,5 +1,0 @@
----
-"@ensnode/ensnode-sdk": patch
----
-
-Update Omnigraph example queries: the Domain Resolver example now shows the ENSIP-10 effective resolver (and no longer fetches resolver events), the primary-names example documents how reverse resolution works, and the hello-world and account-migration examples note that the domain counts don't filter out expired domains.

--- a/docs/ensnode.io/src/data/omnigraph-examples/examples.json
+++ b/docs/ensnode.io/src/data/omnigraph-examples/examples.json
@@ -141,7 +141,7 @@
     "id": "domain-resolver",
     "query": "query DomainResolver($name: InterpretedName!) {\n  domain(by: { name: $name }) {\n    resolver {\n      # the Resolver explicitly assigned to this Domain\n      assigned {\n        contract { address }\n      }\n      # the Resolver that ENS Forward Resolution (ENSIP-10) actually lands\n      # on for this Domain — i.e. its effective Resolver\n      effective {\n        contract { address }\n      }\n    }\n  }\n}",
     "variables": {
-      "name": "jesse.base.eth"
+      "name": "dperri.com"
     }
   },
   {

--- a/docs/ensnode.io/src/data/omnigraph-examples/responses.json
+++ b/docs/ensnode.io/src/data/omnigraph-examples/responses.json
@@ -1594,14 +1594,10 @@
     "data": {
       "domain": {
         "resolver": {
-          "assigned": {
-            "contract": {
-              "address": "0xc6d566a56a1aff6508b41f6c90ff131615583bcd"
-            }
-          },
+          "assigned": null,
           "effective": {
             "contract": {
-              "address": "0xde9049636f4a1dfe0a64d1bfe3155c0a14c54f31"
+              "address": "0xf142b308cf687d4358410a4cb885513b30a42025"
             }
           }
         }

--- a/packages/ensnode-sdk/src/omnigraph-api/example-queries.ts
+++ b/packages/ensnode-sdk/src/omnigraph-api/example-queries.ts
@@ -42,9 +42,9 @@ const SEPOLIA_V2_NAME = asInterpretedName("roppp.eth");
 
 const VITALIK_NAME = asInterpretedName("vitalik.eth");
 
-// a Basename (`.base.eth`) — its assigned vs. effective resolvers differ, making it a
+// a DNS-imported (3DNS) name — its assigned vs. effective resolvers differ, making it a
 // more interesting subject than a mainnet `.eth` name for the Domain resolver example
-const JESSE_BASE_NAME = asInterpretedName("jesse.base.eth");
+const DPERRI_DNS_NAME = asInterpretedName("dperri.com");
 
 const GREG_NAME = asInterpretedName("gregskril.eth");
 
@@ -767,7 +767,7 @@ query DomainResolver($name: InterpretedName!) {
   }
 }`,
     variables: {
-      default: { name: JESSE_BASE_NAME },
+      default: { name: DPERRI_DNS_NAME },
       [ENSNamespaceIds.EnsTestEnv]: { name: DEVNET_NAME_WITH_OWNED_RESOLVER },
       [ENSNamespaceIds.SepoliaV2]: { name: SEPOLIA_V2_NAME },
     },


### PR DESCRIPTION
## Summary

Switches the **Domain Resolver** Omnigraph example name from `jesse.base.eth` to the DNS-imported (3DNS) name `dperri.com`, and regenerates its vendored response from the `alpha` hosted instance.

`dperri.com` keeps the property that made the previous subject useful — its assigned and effective resolvers differ — while showcasing a DNS-imported name (assigned resolver is `null`, effective resolver resolved via ENSIP-10).

## Changes

- `packages/ensnode-sdk/.../example-queries.ts` — `domain-resolver` default variable → `dperri.com` (constant + rationale comment updated).
- `docs/ensnode.io/.../omnigraph-examples/examples.json` — vendored `domain-resolver` variable updated to match.
- `docs/ensnode.io/.../omnigraph-examples/responses.json` — `domain-resolver` response regenerated from `api.alpha.ensnode.io`.

The frozen `schema.graphql` / `snapshot.json` are intentionally left untouched (the snapshot is pinned to the v1.15.2 release; only the single example's variable + response changed).