### PR TITLE
fix: point publishConfig.module at emitted ./dist/index.js

### DIFF
--- a/.changeset/fix-published-module-field.md
+++ b/.changeset/fix-published-module-field.md
@@ -1,0 +1,8 @@
+---
+"@ensnode/datasources": patch
+"@ensnode/ensrainbow-sdk": patch
+"@namehash/namehash-ui": patch
+"@ensnode/ponder-subgraph": patch
+---
+
+Point `publishConfig.module` at the emitted `./dist/index.js` instead of `./dist/index.mjs`. These packages are `"type": "module"` and tsup emits ESM as `index.js`, so the published `module` field referenced a file that was never present in the tarball.

--- a/.changeset/fix-published-module-field.md
+++ b/.changeset/fix-published-module-field.md
@@ -1,8 +1,0 @@
----
-"@ensnode/datasources": patch
-"@ensnode/ensrainbow-sdk": patch
-"@namehash/namehash-ui": patch
-"@ensnode/ponder-subgraph": patch
----
-
-Point `publishConfig.module` at the emitted `./dist/index.js` instead of `./dist/index.mjs`. These packages are `"type": "module"` and tsup emits ESM as `index.js`, so the published `module` field referenced a file that was never present in the tarball.

--- a/packages/datasources/package.json
+++ b/packages/datasources/package.json
@@ -35,7 +35,7 @@
       }
     },
     "main": "./dist/index.js",
-    "module": "./dist/index.mjs",
+    "module": "./dist/index.js",
     "types": "./dist/index.d.ts"
   },
   "scripts": {

--- a/packages/ensrainbow-sdk/package.json
+++ b/packages/ensrainbow-sdk/package.json
@@ -40,7 +40,7 @@
       }
     },
     "main": "./dist/index.js",
-    "module": "./dist/index.mjs",
+    "module": "./dist/index.js",
     "types": "./dist/index.d.ts"
   },
   "scripts": {

--- a/packages/namehash-ui/package.json
+++ b/packages/namehash-ui/package.json
@@ -41,7 +41,7 @@
       }
     },
     "main": "./dist/index.js",
-    "module": "./dist/index.mjs",
+    "module": "./dist/index.js",
     "types": "./dist/index.d.ts",
     "styles": "./dist/index.css"
   },

--- a/packages/ponder-subgraph/package.json
+++ b/packages/ponder-subgraph/package.json
@@ -29,7 +29,7 @@
       }
     },
     "main": "./dist/index.js",
-    "module": "./dist/index.mjs",
+    "module": "./dist/index.js",
     "types": "./dist/index.d.ts"
   },
   "scripts": {


### PR DESCRIPTION
## Summary

Four published packages set `publishConfig.module` to `./dist/index.mjs`, but each is `"type": "module"` and tsup emits ESM as `index.js`. The published `module` field therefore pointed at a file that never exists in the tarball.

Aligns these stragglers with the rest of the published packages (`ens-referrals`, `ensdb-sdk`, `ensnode-sdk`, `ponder-sdk`), which already use `./dist/index.js`:

- `@ensnode/datasources`
- `@ensnode/ensrainbow-sdk`
- `@namehash/namehash-ui`
- `@ensnode/ponder-subgraph`

The standard `exports` field already resolves to `./dist/index.js` correctly; this only fixes the legacy `module` field consulted by some bundlers.

Supersedes #2310 and #2311.

## Verification

- Confirmed each package is `"type": "module"` with tsup `format: ["esm"]`, emitting `dist/index.js` (no `.mjs`).
- `biome check` clean on all four manifests.