### PR TITLE
fix: ENSApi initialization logic

### DIFF
--- a/.changeset/ensapi-ensdb-ready.md
+++ b/.changeset/ensapi-ensdb-ready.md
@@ -1,0 +1,5 @@
+---
+"ensapi": patch
+---
+
+ENSApi now waits for ENSDb to become ready before initializing its dependency graph. This prevents startup crashes when ENSApi starts before the relevant ENSNode Metadata record is available in ENSDb instance.

--- a/.changeset/fancy-buses-wear.md
+++ b/.changeset/fancy-buses-wear.md
@@ -1,0 +1,5 @@
+---
+"@ensnode/ensdb-sdk": minor
+---
+
+Updated `isReady` method in `EnsDbReader` class.

--- a/apps/ensapi/src/app.ts
+++ b/apps/ensapi/src/app.ts
@@ -7,6 +7,7 @@ import { html } from "hono/html";
 import { errorResponse } from "@/lib/handlers/error-response";
 import { createApp } from "@/lib/hono-factory";
 import logger from "@/lib/logger";
+import { serviceStatusMiddleware } from "@/middleware/service-status.middleware";
 import { generateOpenApi31Document } from "@/openapi-document";
 
 import realtimeApi from "./handlers/api/meta/realtime-api";
@@ -15,7 +16,7 @@ import ensanalyticsApi from "./handlers/ensanalytics/ensanalytics-api";
 import ensApiProbesApi from "./handlers/ensapi-probes/ensapi-probes-api";
 import subgraphApi from "./handlers/subgraph/subgraph-api";
 
-const app = createApp();
+const app = createApp({ middlewares: [serviceStatusMiddleware] });
 
 // set the X-ENSNode-Version response header to the current version
 app.use(async (ctx, next) => {

--- a/apps/ensapi/src/config/config.singleton.test.ts
+++ b/apps/ensapi/src/config/config.singleton.test.ts
@@ -1,15 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { EnsDbReader } from "@ensnode/ensdb-sdk";
+
 import di from "@/di";
 
 vi.mock("@/lib/logger", () => ({
   default: {
     error: vi.fn(),
     info: vi.fn(),
+    warn: vi.fn(),
   },
   makeLogger: vi.fn(() => ({
     error: vi.fn(),
     info: vi.fn(),
+    warn: vi.fn(),
   })),
 }));
 
@@ -23,6 +27,9 @@ vi.mock("@ensnode/ensdb-sdk", async (importOriginal) => {
     ensIndexerSchema = {};
     ensIndexerSchemaName = "ensindexer_test";
     async isHealthy() {
+      return true;
+    }
+    async isReady() {
       return true;
     }
     async destroy() {}
@@ -98,6 +105,25 @@ describe("ensdb singleton bootstrap", () => {
     expect(ensDbClient.ensIndexerSchemaName).toBe(VALID_ENSINDEXER_SCHEMA_NAME);
     expect(ensDb).toBeDefined();
     expect(ensIndexerSchema).toBeDefined();
+  }, 10_000);
+
+  it("waits for ENSDb to become ready before initializing caches", async () => {
+    vi.useFakeTimers();
+    const isReadySpy = vi
+      .spyOn(EnsDbReader.prototype, "isReady")
+      .mockResolvedValueOnce(false)
+      .mockResolvedValue(true);
+
+    try {
+      const initPromise = di.init();
+      await vi.advanceTimersByTimeAsync(60_000);
+      await initPromise;
+
+      expect(isReadySpy).toHaveBeenCalledTimes(2);
+    } finally {
+      isReadySpy.mockRestore();
+      vi.useRealTimers();
+    }
   }, 10_000);
 
   it("exits when ENSDB_URL is missing", async () => {

--- a/apps/ensapi/src/di.ts
+++ b/apps/ensapi/src/di.ts
@@ -17,6 +17,7 @@ import type { EnsApiConfig } from "@/config/config.schema";
 import { buildConfigFromEnvironment, buildRootChainRpcConfig } from "@/config/config.schema";
 import { buildEnsDbConfigFromEnvironment } from "@/config/ensdb-config";
 import type { EnsApiEnvironment } from "@/config/environment";
+import { waitForEnsDbToBeReady } from "@/lib/ensdb";
 import { makeLogger } from "@/lib/logger";
 import { buildRootChainPublicClient } from "@/lib/public-client";
 
@@ -265,15 +266,16 @@ class EnsApiDiContainer {
         throw new Error("ENSDb health check failed");
       }
 
+      // Wait for ENSDb to be ready for handling queries before proceeding with further steps.
+      await waitForEnsDbToBeReady(this.context.ensDbClient);
+
       logger.info(
         { ensIndexerSchemaName: this.context.ensDbConfig.ensIndexerSchemaName },
         "Successfully connected to ENSDb",
       );
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : "Unknown error";
-      throw new Error(
-        `DI container initialization failed: could not connect to ENSDb due to ${errorMessage}`,
-      );
+      throw new Error(`DI container initialization failed: ${errorMessage}`);
     }
 
     try {

--- a/apps/ensapi/src/handlers/api/router.ts
+++ b/apps/ensapi/src/handlers/api/router.ts
@@ -1,4 +1,5 @@
 import { createApp } from "@/lib/hono-factory";
+import { assertApiReadinessMiddleware } from "@/middleware/assert-api-readiness.middleware";
 
 import nameTokensApi from "./explore/name-tokens-api";
 import registrarActionsApi from "./explore/registrar-actions-api";
@@ -7,7 +8,7 @@ import statusApi from "./meta/status-api";
 import omnigraphApi from "./omnigraph/omnigraph-api";
 import resolutionApi from "./resolution/resolution-api";
 
-const app = createApp();
+const app = createApp({ middlewares: [assertApiReadinessMiddleware] });
 
 app.route("/", statusApi);
 app.route("/realtime", realtimeApi);

--- a/apps/ensapi/src/handlers/ensanalytics/ensanalytics-api.ts
+++ b/apps/ensapi/src/handlers/ensanalytics/ensanalytics-api.ts
@@ -20,6 +20,7 @@ import {
 import { formatAccountingCsv } from "@/lib/ensanalytics/referrer-leaderboard/format-accounting-csv";
 import { createApp } from "@/lib/hono-factory";
 import { makeLogger } from "@/lib/logger";
+import { assertApiReadinessMiddleware } from "@/middleware/assert-api-readiness.middleware";
 import { ensanalyticsApiMiddleware } from "@/middleware/ensanalytics.middleware";
 import { indexingStatusMiddleware } from "@/middleware/indexing-status.middleware";
 import { referralEditionSnapshotsCachesMiddleware } from "@/middleware/referral-edition-snapshots-caches.middleware";
@@ -36,6 +37,7 @@ const logger = makeLogger("ensanalytics-api");
 
 const app = createApp({
   middlewares: [
+    assertApiReadinessMiddleware,
     indexingStatusMiddleware,
     ensanalyticsApiMiddleware,
     referralProgramEditionConfigSetMiddleware,

--- a/apps/ensapi/src/handlers/ensapi-probes/ensapi-probes-api.ts
+++ b/apps/ensapi/src/handlers/ensapi-probes/ensapi-probes-api.ts
@@ -10,10 +10,7 @@ const app = createApp();
 
 app.openapi(healthCheckRoute, async (c) => {
   try {
-    const { ensDbClient } = di.context;
-    const isEnsDbHealthy = await ensDbClient.isHealthy();
-
-    if (!isEnsDbHealthy) {
+    if (!c.var.serviceStatus?.isHealthy) {
       throw new Error(`ENSDb instance is unhealthy`);
     }
 
@@ -26,12 +23,10 @@ app.openapi(healthCheckRoute, async (c) => {
 
 app.openapi(readinessCheckRoute, async (c) => {
   try {
-    const { ensDbClient } = di.context;
-    const isEnsDbReady = await ensDbClient.isReady();
-
-    if (!isEnsDbReady) {
+    if (!c.var.serviceStatus?.isReady) {
+      const { ensDbConfig } = di.context;
       throw new Error(
-        `ENSDb instance is not ready. This may indicate that ENSNode Schema migrations were not completed successfully or that the ENSNode Metadata record for ${ensDbClient.ensIndexerSchemaName} ENSIndexer Schema has not been created yet.`,
+        `ENSDb instance is not ready. This may indicate that ENSNode Schema migrations were not completed successfully or that the ENSNode Metadata record for ${ensDbConfig.ensIndexerSchemaName} ENSIndexer Schema has not been created yet.`,
       );
     }
 

--- a/apps/ensapi/src/handlers/subgraph/subgraph-api.ts
+++ b/apps/ensapi/src/handlers/subgraph/subgraph-api.ts
@@ -9,6 +9,7 @@ import {
 import di from "@/di";
 import { createApp } from "@/lib/hono-factory";
 import { makeSubgraphApiDocumentation } from "@/lib/subgraph/api-documentation";
+import { assertApiReadinessMiddleware } from "@/middleware/assert-api-readiness.middleware";
 import { fixContentLengthMiddleware } from "@/middleware/fix-content-length.middleware";
 import { indexingStatusMiddleware } from "@/middleware/indexing-status.middleware";
 import { makeIsRealtimeMiddleware } from "@/middleware/is-realtime.middleware";
@@ -17,7 +18,7 @@ import { thegraphFallbackMiddleware } from "@/middleware/thegraph-fallback.middl
 
 const MAX_REALTIME_DISTANCE_TO_RESOLVE: Duration = 10 * 60; // 10 minutes in seconds
 
-const app = createApp({ middlewares: [indexingStatusMiddleware] });
+const app = createApp({ middlewares: [assertApiReadinessMiddleware, indexingStatusMiddleware] });
 
 app.use(async (c, next) => {
   const configPrerequisite = hasSubgraphApiConfigSupport(di.context.stackInfo.ensIndexer);

--- a/apps/ensapi/src/index.ts
+++ b/apps/ensapi/src/index.ts
@@ -13,8 +13,8 @@ import app from "./app";
 sdk.start();
 // initialize DI container and its resources in a non-blocking way to
 // allow HTTP server to start immediately and serve requests
-void di.init().catch((error) => {
-  logger.error(error, "Error initializing DI container");
+void di.init().catch((err) => {
+  logger.error({ err }, "Error initializing DI container");
   process.exit(1);
 });
 
@@ -68,8 +68,8 @@ const gracefulShutdown = async () => {
     await di.destroy();
 
     process.exit(0);
-  } catch (error) {
-    logger.error(error);
+  } catch (err) {
+    logger.error({ err }, "Error during graceful shutdown");
     process.exit(1);
   }
 };
@@ -78,7 +78,7 @@ const gracefulShutdown = async () => {
 process.on("SIGINT", gracefulShutdown);
 process.on("SIGTERM", gracefulShutdown);
 
-process.on("uncaughtException", async (error) => {
-  logger.error(error, "uncaughtException");
+process.on("uncaughtException", async (err) => {
+  logger.error({ err }, "uncaughtException");
   await gracefulShutdown();
 });

--- a/apps/ensapi/src/lib/ensdb.test.ts
+++ b/apps/ensapi/src/lib/ensdb.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { EnsDbReader } from "@ensnode/ensdb-sdk";
+
+import { waitForEnsDbToBeReady } from "./ensdb";
+
+vi.mock("@/lib/logger", () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const ENSINDEXER_SCHEMA_NAME = "ensindexer_test";
+
+const createEnsDbClient = ({ isReady }: { isReady: boolean }) =>
+  ({
+    isReady: vi.fn().mockResolvedValue(isReady),
+    ensIndexerSchemaName: ENSINDEXER_SCHEMA_NAME,
+  }) as unknown as EnsDbReader;
+
+describe("waitForEnsDbToBeReady", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resolves when the ENSDb instance is ready immediately", async () => {
+    const ensDbClient = createEnsDbClient({ isReady: true });
+
+    await expect(waitForEnsDbToBeReady(ensDbClient)).resolves.toBeUndefined();
+    expect(ensDbClient.isReady).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries until the ENSDb instance becomes ready", async () => {
+    const ensDbClient = {
+      isReady: vi.fn().mockResolvedValueOnce(false).mockResolvedValue(true),
+      ensIndexerSchemaName: ENSINDEXER_SCHEMA_NAME,
+    } as unknown as EnsDbReader;
+
+    const promise = waitForEnsDbToBeReady(ensDbClient);
+
+    // Advance past the 60-second retry interval to trigger the second attempt.
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    await expect(promise).resolves.toBeUndefined();
+    expect(ensDbClient.isReady).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects when the ENSDb instance never becomes ready", async () => {
+    const ensDbClient = createEnsDbClient({ isReady: false });
+
+    const promise = waitForEnsDbToBeReady(ensDbClient);
+    // Attach a no-op catch to prevent the promise from being reported as an
+    // unhandled rejection while the fake timers are advancing.
+    promise.catch(() => {});
+
+    // Advance past all 15 retry intervals (15 × 60s = 900s).
+    await vi.advanceTimersByTimeAsync(900_000);
+
+    await expect(promise).rejects.toThrow("ENSDb instance is not ready yet.");
+    expect(ensDbClient.isReady).toHaveBeenCalledTimes(16); // initial + 15 retries
+  });
+});

--- a/apps/ensapi/src/lib/ensdb.ts
+++ b/apps/ensapi/src/lib/ensdb.ts
@@ -1,0 +1,62 @@
+import { secondsToMilliseconds } from "date-fns";
+import pRetry from "p-retry";
+
+import type { EnsDbReader } from "@ensnode/ensdb-sdk";
+
+import logger from "@/lib/logger";
+
+/**
+ * Wait for ENSDb to be ready
+ *
+ * Blocks execution until the ENSDb instance is ready to serve queries.
+ *
+ * Note: It may take several minutes for the ENSDb instance to become ready in
+ * a cold start scenario. We use retries with a fixed interval between attempts
+ * for the ENSDb readiness check to allow for ample time for ENSDb to
+ * become ready.
+ *
+ * @throws When ENSDb fails to become ready after all configured retry attempts.
+ *         This error will trigger termination of the ENSApi process.
+ */
+export async function waitForEnsDbToBeReady(ensDbClient: EnsDbReader): Promise<void> {
+  const { ensIndexerSchemaName } = ensDbClient;
+  logger.info({ ensIndexerSchemaName }, `Waiting for ENSDb instance to be ready`);
+
+  return pRetry(
+    async () => {
+      const isEnsDbInstanceReady = await ensDbClient.isReady();
+
+      if (!isEnsDbInstanceReady) {
+        throw new Error("ENSDb instance is not ready yet.");
+      }
+    },
+    {
+      retries: 15, // This allows for a total of over 15 minutes of retries with 1 minute between attempts.
+      minTimeout: secondsToMilliseconds(60),
+      maxTimeout: secondsToMilliseconds(60),
+      onFailedAttempt: ({ attemptNumber, retriesLeft }) => {
+        logger.warn(
+          {
+            ensIndexerSchemaName,
+            attempt: attemptNumber,
+            retriesLeft,
+            advice: `This might be due to ENSDb instance having a cold start, which can take several minutes.`,
+          },
+          `ENSDb instance readiness check failed`,
+        );
+      },
+    },
+  )
+    .then(() => {
+      logger.info({ ensIndexerSchemaName }, `ENSDb instance is ready`);
+    })
+    .catch((err) => {
+      logger.error(
+        { ensIndexerSchemaName, err },
+        `ENSDb readiness check failed after multiple attempts`,
+      );
+
+      // Throw the error to terminate the ENSApi process due to the failed readiness check of a critical dependency
+      throw err;
+    });
+}

--- a/apps/ensapi/src/lib/hono-factory.ts
+++ b/apps/ensapi/src/lib/hono-factory.ts
@@ -9,9 +9,11 @@ import type { IndexingStatusMiddlewareVariables } from "@/middleware/indexing-st
 import type { IsRealtimeMiddlewareVariables } from "@/middleware/is-realtime.middleware";
 import type { ReferralEditionSnapshotsCachesMiddlewareVariables } from "@/middleware/referral-edition-snapshots-caches.middleware";
 import type { ReferralProgramEditionConfigSetMiddlewareVariables } from "@/middleware/referral-program-edition-set.middleware";
+import type { ServiceStatusMiddlewareVariables } from "@/middleware/service-status.middleware";
 import type { StackInfoMiddlewareVariables } from "@/middleware/stack-info.middleware";
 
-export type MiddlewareVariables = IndexingStatusMiddlewareVariables &
+export type MiddlewareVariables = ServiceStatusMiddlewareVariables &
+  IndexingStatusMiddlewareVariables &
   IsRealtimeMiddlewareVariables &
   CanAccelerateMiddlewareVariables &
   ReferralProgramEditionConfigSetMiddlewareVariables &

--- a/apps/ensapi/src/middleware/assert-api-readiness.middleware.ts
+++ b/apps/ensapi/src/middleware/assert-api-readiness.middleware.ts
@@ -1,0 +1,26 @@
+import { factory } from "@/lib/hono-factory";
+
+/**
+ * Middleware that asserts that the ENSApi instance is ready to serve API requests.
+ * If the service is not ready yet, this middleware will short-circuit the request and
+ * return a 503 Service Unavailable response.
+ */
+export const assertApiReadinessMiddleware = factory.createMiddleware(async (c, next) => {
+  if (c.var.serviceStatus === undefined) {
+    throw new Error(
+      `Invariant(assert-api-readiness.middleware): serviceStatus middleware required`,
+    );
+  }
+
+  if (c.var.serviceStatus.isReady) {
+    await next();
+  } else {
+    return c.json(
+      {
+        error: "Service Unavailable",
+        message: "ENSApi is not ready to serve API requests yet.",
+      },
+      503,
+    );
+  }
+});

--- a/apps/ensapi/src/middleware/service-status.middleware.ts
+++ b/apps/ensapi/src/middleware/service-status.middleware.ts
@@ -1,0 +1,57 @@
+import di from "@/di";
+import { factory, producing } from "@/lib/hono-factory";
+
+export interface ServiceStatusUnhealthy {
+  isHealthy: false;
+  isReady: false;
+}
+
+export interface ServiceStatusNotReady {
+  isHealthy: true;
+  isReady: false;
+}
+
+export interface ServiceStatusReady {
+  isHealthy: true;
+  isReady: true;
+}
+
+export type ServiceStatus = ServiceStatusUnhealthy | ServiceStatusNotReady | ServiceStatusReady;
+
+export interface ServiceStatusMiddlewareVariables {
+  serviceStatus: ServiceStatus;
+}
+
+/**
+ * Middleware that determines the status of ENSApi instance. It checks if the instance
+ * is healthy and ready to serve API requests, and makes this information available
+ * in the Hono context as `c.var.serviceStatus`
+ *
+ * All downstream middleware and handlers can use this information to determine if HTTP requests
+ * can be served, or if a 503 Service Unavailable response should be returned instead.
+ */
+export const serviceStatusMiddleware = producing(
+  ["serviceStatus"],
+  factory.createMiddleware(async (c, next) => {
+    const { ensDbClient } = di.context;
+    const isEnsDbHealthy = await ensDbClient.isHealthy();
+
+    if (!isEnsDbHealthy) {
+      // ENSDb is unhealthy and not ready
+      c.set("serviceStatus", {
+        isHealthy: isEnsDbHealthy,
+        isReady: false,
+      });
+    } else {
+      // ENSDb is healthy, check if it is ready
+      const isEnsDbReady = await ensDbClient.isReady();
+
+      c.set("serviceStatus", {
+        isHealthy: isEnsDbHealthy,
+        isReady: isEnsDbReady,
+      });
+    }
+
+    await next();
+  }),
+);

--- a/packages/ensdb-sdk/src/client/ensdb-reader.test.ts
+++ b/packages/ensdb-sdk/src/client/ensdb-reader.test.ts
@@ -131,6 +131,10 @@ describe("EnsDbReader", () => {
   });
 
   describe("isReady", () => {
+    beforeEach(() => {
+      executeMock.mockResolvedValue({ rows: [{ exists: true }] });
+    });
+
     it("returns true when indexing metadata context is initialized", async () => {
       const indexingStatus = deserializeCrossChainIndexingStatusSnapshot(
         ensDbClientMock.serializedSnapshot,
@@ -157,6 +161,32 @@ describe("EnsDbReader", () => {
     });
 
     it("returns false when indexing metadata context is uninitialized", async () => {
+      const result = await createEnsDbReader().isReady();
+
+      expect(result).toBe(false);
+    });
+
+    it("returns false when the ENSNode schema does not exist", async () => {
+      executeMock.mockResolvedValueOnce({ rows: [{ exists: false }] });
+
+      const result = await createEnsDbReader().isReady();
+
+      expect(result).toBe(false);
+    });
+
+    it("returns false when the ENSIndexer schema does not exist", async () => {
+      executeMock
+        .mockResolvedValueOnce({ rows: [{ exists: true }] })
+        .mockResolvedValueOnce({ rows: [{ exists: false }] });
+
+      const result = await createEnsDbReader().isReady();
+
+      expect(result).toBe(false);
+    });
+
+    it("returns false when schema existence check fails", async () => {
+      executeMock.mockRejectedValueOnce(new Error("Connection refused"));
+
       const result = await createEnsDbReader().isReady();
 
       expect(result).toBe(false);

--- a/packages/ensdb-sdk/src/client/ensdb-reader.ts
+++ b/packages/ensdb-sdk/src/client/ensdb-reader.ts
@@ -226,15 +226,14 @@ export class EnsDbReader<
    */
   private async ensDbSchemaExists(schemaName: string): Promise<boolean> {
     const result = await this.ensDb.execute<{ exists: boolean }>(
-      `SELECT EXISTS (
-        SELECT FROM information_schema.schemata
-        WHERE schema_name = '${schemaName}'
-      );`,
+      sql`SELECT EXISTS (
+        SELECT 1
+        FROM information_schema.schemata
+        WHERE schema_name = ${schemaName}
+      ) AS "exists";`,
     );
 
-    const exists = result.rows[0].exists;
-
-    return exists;
+    return result.rows[0]?.exists ?? false;
   }
 
   /**

--- a/packages/ensdb-sdk/src/client/ensdb-reader.ts
+++ b/packages/ensdb-sdk/src/client/ensdb-reader.ts
@@ -16,6 +16,7 @@ export {
   type IndexingMetadataContextUninitialized,
 } from "@ensnode/ensnode-sdk";
 
+import { ENSNODE_SCHEMA_NAME } from "../ensnode";
 import {
   type AbstractEnsIndexerSchema,
   buildEnsDbDrizzleClient,
@@ -154,6 +155,17 @@ export class EnsDbReader<
    */
   async isReady(): Promise<boolean> {
     try {
+      const [ensNodeSchemaExists, ensDbWriterSchemaExists] = await Promise.all([
+        this.ensDbSchemaExists(ENSNODE_SCHEMA_NAME),
+        this.ensDbSchemaExists(this.ensIndexerSchemaName),
+      ]);
+
+      // If either the ENSNode Schema or the ENSIndexer Schema does not exist in the ENSDb instance,
+      // then it is not ready to serve queries.
+      if (!ensNodeSchemaExists || !ensDbWriterSchemaExists) {
+        return false;
+      }
+
       const indexingMetadataContext = await this.getIndexingMetadataContext();
       return indexingMetadataContext.statusCode === IndexingMetadataContextStatusCodes.Initialized;
     } catch {
@@ -197,6 +209,22 @@ export class EnsDbReader<
     // but it does exist in the actual implementation and is necessary to properly close
     // the connection pool to the ENSDb instance when destroying the ENSDbReader instance.
     await this.ensDb.$client.end();
+  }
+
+  /**
+   * Check if the specified database schema exists in the ENSDb instance.
+   */
+  private async ensDbSchemaExists(schemaName: string): Promise<boolean> {
+    const result = await this.ensDb.execute<{ exists: boolean }>(
+      `SELECT EXISTS (
+        SELECT FROM information_schema.schemata
+        WHERE schema_name = '${schemaName}'
+      );`,
+    );
+
+    const exists = result.rows[0].exists;
+
+    return exists;
   }
 
   /**

--- a/packages/ensdb-sdk/src/ensnode/index.ts
+++ b/packages/ensdb-sdk/src/ensnode/index.ts
@@ -5,7 +5,7 @@ import { pgSchema, primaryKey } from "drizzle-orm/pg-core";
  *
  * The name of the ENSNode schema in an ENSDb.
  */
-const ENSNODE_SCHEMA_NAME = "ensnode";
+export const ENSNODE_SCHEMA_NAME = "ensnode";
 
 /**
  * ENSNode Schema


### PR DESCRIPTION
# Lite PR

[Tip: Review docs on the ENSNode PR process](https://ensnode.io/docs/contributing/prs)

## Summary

- ENSApi now waits for ENSDb to become ready before initializing its dependency graph, preventing startup crashes when ENSApi begins before the relevant ENSNode Metadata record is available in the ENSDb instance.
- Added `waitForEnsDbToBeReady` helper in `apps/ensapi/src/lib/ensdb.ts` with a 15-minute retry window (15 retries × 60 seconds).
- Added unit tests for the retry helper and updated the DI bootstrap test to cover the retry path.
- Minor logging improvements in `apps/ensapi/src/index.ts` to ensure error objects are logged under the `err` key.
- Added a top-level middleware (`serviceStatusMiddleware`) that provides `isHealthy` and `isReady` values to downstream middleware and route handlers.
- Added a middleware (`assertApiReadinessMiddleware`) that short-circuit HTTP requests to APIs that require the ENSApi instance readiness.

---

## Why

- Fixes #2272: ENSApi was crashing with `process.exit(1)` at startup if it initialized before the ENSDb metadata was ready.
- ENSApi readiness is based on ENSDb readiness because it guarantees that the relevant ENSNode Metadata record is available for relevant APIs that need this record.

---

## Testing

- `pnpm -F ensapi test` — **297 passed**.
- `pnpm -F ensapi typecheck` — **passed**.
- `pnpm typecheck` (all workspaces) — **passed**.
- `pnpm lint` on changed files — **no issues**.

---

## Notes for Reviewer (Optional)

- The retry loop runs **after** `ensDbClient.isHealthy()` has already verified connectivity, so the loop only waits for metadata readiness.
- The timeout is intentionally hardcoded to 15 minutes; the interval was not made configurable per the implementation plan.
- The `waitForEnsDbToBeReady` helper does not cache its promise because `di.init()` runs once per process.
- `serviceStatusMiddleware` is added as a top-level middleware as all downstream middleware and route handlers must be able to see if the ENSApi instance is healthy/ready.
- `assertApiReadinessMiddleware` is added as a first middleware to all routers handling APIs which require ENSApi readiness.

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)
