### PR TITLE
Make the yellow env ready for serving as production backup

### DIFF
--- a/docs/ensnode.io/src/content/docs/docs/self-host/operations/troubleshooting.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/self-host/operations/troubleshooting.mdx
@@ -87,7 +87,7 @@ Aborted
 
 #### Resolution
 
-Increase the Node.js heap size with `NODE_OPTIONS` environment variable for ENSIndexer instance.
+Increase the Node.js heap size with the `NODE_OPTIONS` environment variable for your ENSIndexer instance.
 
 ```bash
 NODE_OPTIONS=--max-old-space-size=4096
@@ -107,7 +107,7 @@ error: canceling statement due to statement timeout
 
 #### Resolution
 
-Extend Ponder's internal SQL statement timeout with `PONDER_STATEMENT_TIMEOUT` (value in milliseconds) environment variable for ENSIndexer instance.
+Extend Ponder's internal SQL statement timeout with the `PONDER_STATEMENT_TIMEOUT` environment variable (value in milliseconds) for your ENSIndexer instance.
 
 ```bash
 PONDER_STATEMENT_TIMEOUT=600000

--- a/docs/ensnode.io/src/content/docs/docs/self-host/operations/troubleshooting.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/self-host/operations/troubleshooting.mdx
@@ -57,6 +57,66 @@ If you see frequent RPC errors:
 - **Spread load across providers.** [Configure multiple RPC endpoints](/docs/services/ensindexer/usage/configuration) for each indexed chain.
 - **Reduce the number of active plugins or chains.** Fewer plugins means fewer events to fetch.
 
+## ENSIndexer crashes or fails with database timeouts
+
+When your ENSIndexer instance has multiple plugins active, it may need extra runtime tuning.
+
+### Heap out of memory
+
+#### Issue
+
+Your ENSIndexer instance may run out of memory and crash with a message like:
+
+```log
+1: 0x744ae8 node::OOMErrorHandler(char const*, v8::OOMDetails const&) [node]
+<--- Last few GCs --->
+[15:0x1a5ac000] 15584424 ms: Mark-Compact (reduce) 1984.5 (2054.3) -> 1954.0 (1988.5) MB, pooled: 0 MB, 97.37 / 0.21 ms  (+ 776.3 ms in 87 steps since start of marking, biggest step 54.4 ms, walltime since start of marking 999 ms) (average mu = 0.397, cur
+FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
+----- Native stack trace -----
+[15:0x1a5ac000] 15583426 ms: Scavenge 1985.0 (2018.3) -> 1978.0 (2053.1) MB, pooled: 0 MB, 20.34 / 0.00 ms  (average mu = 0.366, current mu = 0.360) allocation failure;
+2: 0xc1a6f0  [node]
+3: 0xc1a7df  [node]
+4: 0xebdfe5  [node]
+5: 0xebe012  [node]
+6: 0xebe30a  [node]
+7: 0xecf00a  [node]
+8: 0xed33b0  [node]
+9: 0x1965811  [node]
+Aborted
+```
+
+#### Resolution
+
+Increase the Node.js heap size with `NODE_OPTIONS` environment variable for ENSIndexer instance.
+
+```bash
+NODE_OPTIONS=--max-old-space-size=4096
+```
+
+This is especially useful when running many plugins or chains and RPC retries temporarily spike memory usage.
+
+### Database statement timeout errors
+
+#### Issue
+
+Your ENSIndexer instance may fail to complete long-running internal Ponder queries, and you see errors like:
+
+```log
+error: canceling statement due to statement timeout
+```
+
+#### Resolution
+
+Extend Ponder's internal SQL statement timeout with `PONDER_STATEMENT_TIMEOUT` (value in milliseconds) environment variable for ENSIndexer instance.
+
+```bash
+PONDER_STATEMENT_TIMEOUT=600000
+```
+
+This gives enough time, up to 10 minutes, for long-running internal queries on large datasets.
+
+These overrides are typically only needed for for ENSIndexer instances which are indexing multiple chains.
+
 ## Next steps
 
 <LinkCard

--- a/docs/ensnode.io/src/content/docs/docs/self-host/operations/troubleshooting.mdx
+++ b/docs/ensnode.io/src/content/docs/docs/self-host/operations/troubleshooting.mdx
@@ -57,7 +57,7 @@ If you see frequent RPC errors:
 - **Spread load across providers.** [Configure multiple RPC endpoints](/docs/services/ensindexer/usage/configuration) for each indexed chain.
 - **Reduce the number of active plugins or chains.** Fewer plugins means fewer events to fetch.
 
-## ENSIndexer crashes or fails with database timeouts
+## ENSIndexer runtime tuning issues
 
 When your ENSIndexer instance has multiple plugins active, it may need extra runtime tuning.
 
@@ -115,7 +115,7 @@ PONDER_STATEMENT_TIMEOUT=600000
 
 This gives enough time, up to 10 minutes, for long-running internal queries on large datasets.
 
-These overrides are typically only needed for for ENSIndexer instances which are indexing multiple chains.
+These overrides are typically only needed for ENSIndexer instances that are indexing multiple chains.
 
 ## Next steps
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -28,6 +28,8 @@ locals {
       ensrainbow_label_set_id      = "subgraph"
       ensrainbow_label_set_version = "0"
       disk_size_gb                 = 50
+      render_instance_plan         = "starter"
+      subdomain_path               = "api"
     }
 
     # The Searchlight instance uses fixed label set ID "searchlight" and
@@ -36,6 +38,8 @@ locals {
       ensrainbow_label_set_id      = "searchlight"
       ensrainbow_label_set_version = var.ensrainbow_searchlight_label_set_version
       disk_size_gb                 = 100
+      render_instance_plan         = "standard"
+      subdomain_path               = "api.searchlight"
     }
   }
 
@@ -77,12 +81,20 @@ locals {
       ensindexer_label_set_version = "0"
     }
     alpha = {
-      ensnode_indexer_type         = "alpha"
-      ensnode_environment_name     = var.render_environment
-      ensindexer_schema_name       = "alphaSchema-${var.ensnode_version}"
-      plugins                      = "subgraph,basenames,lineanames,threedns,unigraph,protocol-acceleration,registrars,tokenscope"
-      namespace                    = "mainnet"
-      referral_program_editions    = "https://ensawards.org/production-editions.json"
+      ensnode_indexer_type      = "alpha"
+      ensnode_environment_name  = var.render_environment
+      ensindexer_schema_name    = "alphaSchema-${var.ensnode_version}"
+      plugins                   = "subgraph,basenames,lineanames,threedns,unigraph,protocol-acceleration,registrars,tokenscope"
+      namespace                 = "mainnet"
+      referral_program_editions = "https://ensawards.org/production-editions.json"
+      # The default Node.js heap size is ~2GB and can be exceeded
+      # when processing RPC request retries across multiple chains. Therefore,
+      # we increase the heap size to ~4GB to accommodate this increased memory usage.
+      node_options = "--max-old-space-size=4096"
+      # Long-running internal Ponder queries may exceed the default SQL statement timeout
+      # of 2 minutes. Therefore, we extend the SQL statement timeout to 10 minutes to accommodate
+      # these long-running queries.
+      ponder_statement_timeout     = "600000"
       render_instance_plan         = "standard"
       subgraph_compat              = false
       ensindexer_label_set_id      = "searchlight"
@@ -128,10 +140,14 @@ module "ensrainbow" {
 
   for_each = local.ensrainbow_instances
 
-  render_environment_id = render_project.ensnode.environments["default"].id
-  render_region         = local.render_region
-  disk_size_gb          = each.value.disk_size_gb
-  ensnode_version       = var.ensnode_version
+  render_environment_id    = render_project.ensnode.environments["default"].id
+  render_region            = local.render_region
+  render_instance_plan     = each.value.render_instance_plan
+  hosted_zone_name         = local.hosted_zone_name
+  ensnode_environment_name = var.render_environment
+  ensnode_version          = var.ensnode_version
+  subdomain_path           = each.value.subdomain_path
+  disk_size_gb             = each.value.disk_size_gb
 
   # Label set that ENSRainbow will offer to its clients
   ensrainbow_label_set_id      = each.value.ensrainbow_label_set_id
@@ -179,6 +195,10 @@ module "ensindexer" {
   alchemy_api_key         = var.alchemy_api_key
   quicknode_api_key       = var.quicknode_api_key
   quicknode_endpoint_name = var.quicknode_endpoint_name
+
+  # Optional runtime tuning overrides
+  node_options             = try(each.value.node_options, null)
+  ponder_statement_timeout = try(each.value.ponder_statement_timeout, null)
 
   # The "fully pinned" label set reference that ENSIndexer will request ENSRainbow use for deterministic label healing across time. This label set reference is "fully pinned" as it requires both the labelSetId and labelSetVersion fields to be defined.
   ensindexer_label_set_id      = each.value.ensindexer_label_set_id

--- a/terraform/modules/ensindexer/main.tf
+++ b/terraform/modules/ensindexer/main.tf
@@ -3,10 +3,15 @@ locals {
     # Common configuration
     "ENSDB_URL"               = { value = var.ensdb_url },
     "ENSINDEXER_SCHEMA_NAME"  = { value = var.ensindexer_schema_name },
-    "ALCHEMY_API_KEY"         = { value = var.alchemy_api_key }
-    "QUICKNODE_API_KEY"       = { value = var.quicknode_api_key }
-    "QUICKNODE_ENDPOINT_NAME" = { value = var.quicknode_endpoint_name }
+    "ALCHEMY_API_KEY"         = { value = var.alchemy_api_key },
+    "QUICKNODE_API_KEY"       = { value = var.quicknode_api_key },
+    "QUICKNODE_ENDPOINT_NAME" = { value = var.quicknode_endpoint_name },
   }
+
+  optional_variables = merge(
+    var.node_options != null ? { "NODE_OPTIONS" = { value = var.node_options } } : {},
+    var.ponder_statement_timeout != null ? { "PONDER_STATEMENT_TIMEOUT" = { value = var.ponder_statement_timeout } } : {},
+  )
 
   ensindexer_fqdn = "indexer.${var.ensnode_indexer_type}.${var.ensnode_environment_name}.${var.hosted_zone_name}"
 
@@ -28,14 +33,18 @@ resource "render_web_service" "ensindexer" {
     }
   }
 
-  env_vars = merge(local.common_variables, {
-    "ENSRAINBOW_URL"    = { value = var.ensrainbow_url },
-    "LABEL_SET_ID"      = { value = var.ensindexer_label_set_id },
-    "LABEL_SET_VERSION" = { value = var.ensindexer_label_set_version },
-    "PLUGINS"           = { value = var.plugins },
-    "NAMESPACE"         = { value = var.namespace },
-    "SUBGRAPH_COMPAT"   = { value = var.subgraph_compat }
-  })
+  env_vars = merge(
+    local.common_variables,
+    local.optional_variables,
+    {
+      "ENSRAINBOW_URL"    = { value = var.ensrainbow_url },
+      "LABEL_SET_ID"      = { value = var.ensindexer_label_set_id },
+      "LABEL_SET_VERSION" = { value = var.ensindexer_label_set_version },
+      "PLUGINS"           = { value = var.plugins },
+      "NAMESPACE"         = { value = var.namespace },
+      "SUBGRAPH_COMPAT"   = { value = var.subgraph_compat },
+    }
+  )
 
   # See https://render.com/docs/custom-domains
   custom_domains = [

--- a/terraform/modules/ensindexer/variables.tf
+++ b/terraform/modules/ensindexer/variables.tf
@@ -81,6 +81,16 @@ variable "subgraph_compat" {
   type = bool
 }
 
+variable "node_options" {
+  type    = string
+  default = null
+}
+
+variable "ponder_statement_timeout" {
+  type    = string
+  default = null
+}
+
 variable "alchemy_api_key" {
   type = string
 }

--- a/terraform/modules/ensrainbow/main.tf
+++ b/terraform/modules/ensrainbow/main.tf
@@ -1,13 +1,14 @@
 locals {
   mount_path           = "/app/apps/ensrainbow/data"
   resource_name_suffix = var.ensrainbow_label_set_id
+  fqdn                 = "${var.subdomain_path}.${var.ensnode_environment_name}.${var.hosted_zone_name}"
 }
 
 # For details on "render_web_service", see:
 # https://registry.terraform.io/providers/render-oss/render/latest/docs/resources/web_service
 resource "render_web_service" "ensrainbow" {
   name           = "ensrainbow-${local.resource_name_suffix}"
-  plan           = "starter"
+  plan           = var.render_instance_plan
   region         = var.render_region
   environment_id = var.render_environment_id
 
@@ -32,4 +33,8 @@ resource "render_web_service" "ensrainbow" {
     "DB_SCHEMA_VERSION" = { value = var.db_schema_version }
   }
 
+  # See https://render.com/docs/custom-domains
+  custom_domains = [
+    { name : local.fqdn },
+  ]
 }

--- a/terraform/modules/ensrainbow/variables.tf
+++ b/terraform/modules/ensrainbow/variables.tf
@@ -9,10 +9,33 @@ variable "render_environment_id" {
 variable "render_region" {
   type = string
 }
+
+# See https://render.com/docs/web-services
+variable "render_instance_plan" {
+  type = string
+}
+
+# DNS configuration
+
+# Example: "ensnode.io"
+# See main.tf for more details
+variable "hosted_zone_name" {
+  type = string
+}
+
+# Example: blue
+# See main.tf for more details on how this is used, including for building fqdn values.
+variable "ensnode_environment_name" {
+  type = string
+}
+
+variable "subdomain_path" {
+  type = string
+}
+
 variable "disk_size_gb" {
   type = number
 }
-
 
 # ENSRainbow configuration
 


### PR DESCRIPTION
# Lite PR

[Tip: Review docs on the ENSNode PR process](https://ensnode.io/docs/contributing/prs)

## Summary

- Terraform configuration was updated to allow each ENSRainbow instance to be available as a subname under `*.yellow.ensnode.io` domain
- ENSRainbow Searchlight instance needs to use the `standard` render instance type, while the ENSRainbow Subgraph instance requires just the `starter` render instance type.
- For each ENSIndexer instance, `PONDER_STATEMENT_TIMEOUT` has been set to 10 minutes (prev. it was 2 minutes), and the heap size has been set ~4GB (previously it was ~2GB).

---

## Why

- We're upgrading the yellow env to be able to serve as production backup.

---

## Testing

- Will be tested on CI via `terraform plan` call.

---

## Notes for Reviewer (Optional)

- This PR needs to be merged after #2219

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)
