### PR TITLE
Split CI/CD workflows for ENSNode and ENSDb Playground deployments

### DIFF
--- a/.github/actions/promote_vercel_deployment/action.yml
+++ b/.github/actions/promote_vercel_deployment/action.yml
@@ -1,6 +1,6 @@
 name: Promote Vercel Deployment
 description: Promotes the Vercel production deployment whose commit SHA matches
-  the active ENSIndexer image in the given Railway environment. Ensures exact
+  the active ENSIndexer image in the given ENSNode environment. Ensures exact
   version matching between the active ENSNode and the Vercel project.
 
 inputs:
@@ -16,12 +16,8 @@ inputs:
     description: "Vercel API token"
     required: true
 
-  railway_token:
-    description: "Railway API token"
-    required: true
-
-  railway_environment_id:
-    description: "Railway environment ID containing the active ENSIndexer image"
+  ensnode_environment:
+    description: "ENSNode environment to target (green, blue, or yellow)"
     required: true
 
 runs:
@@ -33,6 +29,5 @@ runs:
         VERCEL_PROJECT_ID: ${{ inputs.vercel_project_id }}
         VERCEL_TEAM_SLUG: ${{ inputs.vercel_team_slug }}
         VERCEL_TOKEN: ${{ inputs.vercel_token }}
-        RAILWAY_TOKEN: ${{ inputs.railway_token }}
-        RAILWAY_ENVIRONMENT_ID: ${{ inputs.railway_environment_id }}
+        ENSNODE_ENVIRONMENT: ${{ inputs.ensnode_environment }}
       run: ${{ github.action_path }}/promote_vercel_deployment.sh

--- a/.github/actions/promote_vercel_deployment/promote_vercel_deployment.sh
+++ b/.github/actions/promote_vercel_deployment/promote_vercel_deployment.sh
@@ -45,7 +45,7 @@ ENSNODE_VERSION=$(curl \
   --show-error \
   --fail \
   --url "$INDEXING_STATUS_URL" | \
-  jq -r '.stackInfo.ensApi.versionInfo.ensApi')
+  jq -r '.stackInfo.ensIndexer.versionInfo.ensIndexer')
 
 echo "Found ENSNode version: $ENSNODE_VERSION"
 

--- a/.github/actions/promote_vercel_deployment/promote_vercel_deployment.sh
+++ b/.github/actions/promote_vercel_deployment/promote_vercel_deployment.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Identifies the commit sha of the ENSIndexer image deployed to the active Railway environment
+# Identifies the commit sha of the ENSIndexer image deployed to the active ENSNode environment
 # and promotes the Vercel deployment with that sha to production for the given Vercel project.
 # Ensures exact version matching between the active ENSNode and the production Vercel deployment.
 
@@ -21,44 +21,43 @@ if [ -z "${VERCEL_TOKEN:-}" ]; then
   exit 1
 fi
 
-if [ -z "${RAILWAY_TOKEN:-}" ]; then
-  echo "Error: RAILWAY_TOKEN is not set or is empty"
+if [ -z "${ENSNODE_ENVIRONMENT:-}" ]; then
+  echo "Error: ENSNODE_ENVIRONMENT is not set or is empty"
   exit 1
 fi
 
-if [ -z "${RAILWAY_ENVIRONMENT_ID:-}" ]; then
-  echo "Error: RAILWAY_ENVIRONMENT_ID is not set or is empty"
-  exit 1
-fi
+case "$ENSNODE_ENVIRONMENT" in
+  green|blue|yellow)
+    ;;
+  *)
+    echo "Error: ENSNODE_ENVIRONMENT must be one of: green, blue, yellow (got: $ENSNODE_ENVIRONMENT)"
+    exit 1
+    ;;
+esac
 
-echo "Targeting Railway Environment: $RAILWAY_ENVIRONMENT_ID"
+echo "Targeting ENSNode Environment: $ENSNODE_ENVIRONMENT"
 echo "Targeting Vercel Project: $VERCEL_PROJECT_ID"
 
-# first, get deployed ENSIndexer image from Railway Environment
-RAILWAY_SERVICES_OUTPUT=$(curl \
-  --request POST \
+# first, get the deployed ENSNode version from the ENSApi indexing-status endpoint
+INDEXING_STATUS_URL="https://api.alpha.${ENSNODE_ENVIRONMENT}.ensnode.io/api/indexing-status"
+ENSNODE_VERSION=$(curl \
   --silent \
   --show-error \
-  --url https://backboard.railway.app/graphql/v2 \
-  --header "Authorization: Bearer $RAILWAY_TOKEN" \
-  --header 'Content-Type: application/json' \
-  --data "{\"query\": \"{ environment(id: \\\"$RAILWAY_ENVIRONMENT_ID\\\") { serviceInstances { edges { node { source { image } } } } } }\"}")
+  --fail \
+  --url "$INDEXING_STATUS_URL" | \
+  jq -r '.stackInfo.ensApi.versionInfo.ensApi')
 
-if [ $? -ne 0 ]; then
-  echo "Error: curl command failed. Output:"
-  echo "$RAILWAY_SERVICES_OUTPUT"
+echo "Found ENSNode version: $ENSNODE_VERSION"
+
+if [ -z "$ENSNODE_VERSION" ] || [ "$ENSNODE_VERSION" = "null" ]; then
+  echo "Error: Could not resolve ENSNode version from $INDEXING_STATUS_URL"
   exit 1
 fi
 
-# get the first ensindexer image
-ENSINDEXER_IMAGE=$(echo "$RAILWAY_SERVICES_OUTPUT" | jq -r '.data.environment.serviceInstances.edges[].node.source.image | select(type == "string" and startswith("ghcr.io/namehash/ensnode/ensindexer"))' | head -n1)
+# the version is the image tag for the deployed ENSNode images
+ENSINDEXER_IMAGE="ghcr.io/namehash/ensnode/ensindexer:${ENSNODE_VERSION}"
 
-echo "Found ENSIndexer image: $ENSINDEXER_IMAGE"
-
-if [ -z "$ENSINDEXER_IMAGE" ]; then
-  echo "Error: Could not find ENSIndexer image for the environment."
-  exit 1
-fi
+echo "Using ENSIndexer image: $ENSINDEXER_IMAGE"
 
 # get commit sha from labels of the docker image
 ENSINDEXER_COMMIT_SHA=$(skopeo inspect docker://$ENSINDEXER_IMAGE --override-arch amd64 --override-os linux | jq -r '.Labels."org.opencontainers.image.revision"')

--- a/.github/workflows/deploy_switch_ensdb_playground_environment.yml
+++ b/.github/workflows/deploy_switch_ensdb_playground_environment.yml
@@ -1,0 +1,59 @@
+name: "Deploy: Switch ENSDb Playground Environment"
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "New ENSDb Playground environment"
+        required: true
+        type: choice
+        options:
+          - green
+          - blue
+
+jobs:
+  switch-environment:
+    # NOTE: this needs to run on GH runner because of some obscure skopeo permissions thing
+    runs-on: ubuntu-latest
+    name: Switch Environment to ${{ inputs.target }}
+    env:
+      TARGET_ENVIRONMENT: ${{ inputs.target }}
+      REDIS_URL: ${{ secrets.TRAEFIK_REDIS_URL }}
+      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Calculate env variables
+        run: |
+          case "$TARGET_ENVIRONMENT" in
+            "green")
+              echo "SLACK_TITLE=:large_green_circle: ENSDb Playground GREEN Environment Activated" >> "$GITHUB_ENV"
+              ;;
+            "blue")
+              echo "SLACK_TITLE=:large_blue_circle: ENSDb Playground BLUE Environment Activated" >> "$GITHUB_ENV"
+              ;;
+            *)
+              echo "SLACK_TITLE=:large_red_circle: Unrecognized ENSDb Playground Environment Activated" >> "$GITHUB_ENV"
+          esac
+
+      - name: Switch Traefik Routing
+        run: |
+          sudo apt update
+          sudo apt install -y redis-tools
+
+          # ENSDB PLAYGROUND
+          redis-cli -u $REDIS_URL SET traefik/http/routers/ensdb-playground-router/service "${TARGET_ENVIRONMENT}-ensdb-playground"
+
+      - name: Send Slack Notification
+        uses: ./.github/actions/send_slack_notification
+        with:
+          slack_webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          slack_title: ${{ env.SLACK_TITLE }}
+          slack_message: "✅ Switch ENSDb Playground environment completed"

--- a/.github/workflows/deploy_switch_ensdb_playground_environment.yml
+++ b/.github/workflows/deploy_switch_ensdb_playground_environment.yml
@@ -22,7 +22,6 @@ jobs:
     env:
       TARGET_ENVIRONMENT: ${{ inputs.target }}
       REDIS_URL: ${{ secrets.TRAEFIK_REDIS_URL }}
-      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
 
     steps:
       - name: Checkout repository
@@ -41,6 +40,7 @@ jobs:
               ;;
             *)
               echo "SLACK_TITLE=:large_red_circle: Unrecognized ENSDb Playground Environment Activated" >> "$GITHUB_ENV"
+              exit 1
           esac
 
       - name: Switch Traefik Routing

--- a/.github/workflows/deploy_switch_ensdb_playground_environment.yml
+++ b/.github/workflows/deploy_switch_ensdb_playground_environment.yml
@@ -41,6 +41,7 @@ jobs:
             *)
               echo "SLACK_TITLE=:large_red_circle: Unrecognized ENSDb Playground Environment Activated" >> "$GITHUB_ENV"
               exit 1
+              ;;
           esac
 
       - name: Switch Traefik Routing

--- a/.github/workflows/deploy_switch_ensnode_environment.yml
+++ b/.github/workflows/deploy_switch_ensnode_environment.yml
@@ -24,7 +24,6 @@ jobs:
       TARGET_ENVIRONMENT: ${{ inputs.target }}
       REDIS_URL: ${{ secrets.TRAEFIK_REDIS_URL }}
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
 
     steps:
       - name: Checkout repository
@@ -37,15 +36,12 @@ jobs:
           case "$TARGET_ENVIRONMENT" in
             "green")
               echo "SLACK_TITLE=:large_green_circle: ENSNode GREEN Environment Activated" >> "$GITHUB_ENV"
-              echo "RAILWAY_ENVIRONMENT_ID=${{ secrets.GREEN_RAILWAY_ENVIRONMENT_ID }}" >> $GITHUB_ENV
               ;;
             "blue")
               echo "SLACK_TITLE=:large_blue_circle: ENSNode BLUE Environment Activated" >> "$GITHUB_ENV"
-              echo "RAILWAY_ENVIRONMENT_ID=${{ secrets.BLUE_RAILWAY_ENVIRONMENT_ID }}" >> $GITHUB_ENV
               ;;
             "yellow")
               echo "SLACK_TITLE=:large_yellow_circle: ENSNode YELLOW Environment Activated" >> "$GITHUB_ENV"
-              echo "RAILWAY_ENVIRONMENT_ID=${{ secrets.YELLOW_RAILWAY_ENVIRONMENT_ID }}" >> $GITHUB_ENV
               ;;
             *)
               echo "SLACK_TITLE=:large_red_circle: Unrecognized ENSNode Environment Activated" >> "$GITHUB_ENV"
@@ -103,8 +99,7 @@ jobs:
           vercel_team_slug: namehash
           vercel_project_id: prj_nKcHTO12hq9kcgascQMq4xokRhwp
           vercel_token: ${{ secrets.VERCEL_TOKEN }}
-          railway_token: ${{ secrets.RAILWAY_TOKEN }}
-          railway_environment_id: ${{ env.RAILWAY_ENVIRONMENT_ID }}
+          ensnode_environment: ${{ inputs.target }}
 
       - name: Promote Example App Vercel Deployment
         uses: ./.github/actions/promote_vercel_deployment
@@ -112,8 +107,7 @@ jobs:
           vercel_team_slug: namehash
           vercel_project_id: prj_Ux80vjjNyDfXMNvPEQo4zlx6Eq6D
           vercel_token: ${{ secrets.VERCEL_TOKEN }}
-          railway_token: ${{ secrets.RAILWAY_TOKEN }}
-          railway_environment_id: ${{ env.RAILWAY_ENVIRONMENT_ID }}
+          ensnode_environment: ${{ inputs.target }}
 
       - name: Send Slack Notification
         uses: ./.github/actions/send_slack_notification

--- a/.github/workflows/deploy_switch_ensnode_environment.yml
+++ b/.github/workflows/deploy_switch_ensnode_environment.yml
@@ -45,6 +45,8 @@ jobs:
               ;;
             *)
               echo "SLACK_TITLE=:large_red_circle: Unrecognized ENSNode Environment Activated" >> "$GITHUB_ENV"
+              exit 1
+              ;;
           esac
 
       - name: Switch Traefik Routing

--- a/.github/workflows/deploy_switch_ensnode_environment.yml
+++ b/.github/workflows/deploy_switch_ensnode_environment.yml
@@ -7,12 +7,13 @@ on:
   workflow_dispatch:
     inputs:
       target:
-        description: "New main environment (green or blue)"
+        description: "New main environment"
         required: true
         type: choice
         options:
           - green
           - blue
+          - yellow
 
 jobs:
   switch-environment:
@@ -35,15 +36,19 @@ jobs:
         run: |
           case "$TARGET_ENVIRONMENT" in
             "green")
-              echo "SLACK_TITLE=:large_green_circle: GREEN Environment Activated" >> "$GITHUB_ENV"
+              echo "SLACK_TITLE=:large_green_circle: ENSNode GREEN Environment Activated" >> "$GITHUB_ENV"
               echo "RAILWAY_ENVIRONMENT_ID=${{ secrets.GREEN_RAILWAY_ENVIRONMENT_ID }}" >> $GITHUB_ENV
               ;;
             "blue")
-              echo "SLACK_TITLE=:large_blue_circle: BLUE Environment Activated" >> "$GITHUB_ENV"
+              echo "SLACK_TITLE=:large_blue_circle: ENSNode BLUE Environment Activated" >> "$GITHUB_ENV"
               echo "RAILWAY_ENVIRONMENT_ID=${{ secrets.BLUE_RAILWAY_ENVIRONMENT_ID }}" >> $GITHUB_ENV
               ;;
+            "yellow")
+              echo "SLACK_TITLE=:large_yellow_circle: ENSNode YELLOW Environment Activated" >> "$GITHUB_ENV"
+              echo "RAILWAY_ENVIRONMENT_ID=${{ secrets.YELLOW_RAILWAY_ENVIRONMENT_ID }}" >> $GITHUB_ENV
+              ;;
             *)
-              echo "SLACK_TITLE=:large_red_circle: Unrecognized Environment Activated" >> "$GITHUB_ENV"
+              echo "SLACK_TITLE=:large_red_circle: Unrecognized ENSNode Environment Activated" >> "$GITHUB_ENV"
           esac
 
       - name: Switch Traefik Routing
@@ -85,9 +90,6 @@ jobs:
 
           redis-cli -u $REDIS_URL SET traefik/http/routers/lb-header-sepolia-api-router/service "${TARGET_ENVIRONMENT}-sepolia-api"
           redis-cli -u $REDIS_URL SET traefik/http/routers/lb-header-sepolia-indexer-router/service "${TARGET_ENVIRONMENT}-sepolia-indexer"
-
-          # ENSDB PLAYGROUND
-          redis-cli -u $REDIS_URL SET traefik/http/routers/ensdb-playground-router/service "${TARGET_ENVIRONMENT}-ensdb-playground"
 
           # ENSRAINBOW
           redis-cli -u $REDIS_URL SET traefik/http/routers/ensrainbow-api-router/service "${TARGET_ENVIRONMENT}-ensrainbow-api"


### PR DESCRIPTION
# Lite PR

[Tip: Review docs on the ENSNode PR process](https://ensnode.io/docs/contributing/prs)

## Summary

- The ENSNode deployment can have the production workload switched between all cloud environments (blue, green, yellow).
- The ENSDb Playground deployment can have the production workload switched between just blue environment and green environment.
- The `promote_vercel_deployment.sh` script has been updated to allow sourcing the ENSNode version independently from the platform (Railway, Render) that the current production deployment runs on.

---

## Why

- The ENSNode deployment should be operated independently from the ENSDb Playground deployment. 

---

## Testing

- Will be tested in CI workflow after changes from PR #2341 are released to production.

---

## Notes for Reviewer (Optional)

- Currently, switching the ENSNode production workload to the yellow env will not automatically promote ENSAdmin app and ENSKit React Example app. The script promoting selected app deployments is tied to Railway platform and will not work for the yellow env (hosted on Render.com).
- [ ] This PR requires ENSApi v1.17.0 deployed to production as the updated `promote_vercel_deployment.sh` script needs to use data model introduced in the v1.17.0.

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)
