### PR TITLE
Update broken lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1068,7 +1068,7 @@ importers:
         version: 0.41.0(@electric-sql/pglite@0.2.13)(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))(@types/pg@8.16.0)(kysely@0.28.17)(pg@8.16.3)
       ponder:
         specifier: 'catalog:'
-        version: 0.16.6(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))(@types/node@24.10.9)(@types/pg@8.16.0)(hono@4.12.25)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.3.6))(yaml@2.8.3)(zod@4.3.6)
+        version: 0.16.6(patch_hash=07ce9ff0276cbbcf8d5b7a93d4109d50575d5b305099e06eb2e0c19953f1eab9)(@opentelemetry/api@1.9.0(patch_hash=4b2adeefaf7c22f9987d0a125d69cab900719bec7ed7636648bea6947107033a))(@types/node@24.10.9)(@types/pg@8.16.0)(hono@4.12.25)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(typescript@5.9.3)(viem@2.50.3(typescript@5.9.3)(zod@4.3.6))(yaml@2.8.3)(zod@4.3.6)
       viem:
         specifier: 'catalog:'
         version: 2.50.3(typescript@5.9.3)(zod@4.3.6)


### PR DESCRIPTION
PRs merged previously have introduced a mismatch to the pnpm lockfile. This PR resolves the mismatch.