### PR TITLE
Tokenscope: allow re-minting by `BaseRegistar` contracts

### DIFF
--- a/apps/ensindexer/src/plugins/tokenscope/handlers/BaseRegistrars.ts
+++ b/apps/ensindexer/src/plugins/tokenscope/handlers/BaseRegistrars.ts
@@ -33,7 +33,9 @@ export default function () {
         nft,
       };
 
-      await handleNFTTransfer(context, event.args.from, event.args.to, false, nft, metadata);
+      // BaseRegistrar contracts allow re-registration of expired names, which emits
+      // a Transfer from 0x0 even though the token was previously minted and never burned.
+      await handleNFTTransfer(context, event.args.from, event.args.to, true, nft, metadata);
     },
   );
 
@@ -55,7 +57,9 @@ export default function () {
         nft,
       };
 
-      await handleNFTTransfer(context, event.args.from, event.args.to, false, nft, metadata);
+      // BaseRegistrar contracts allow re-registration of expired names, which emits
+      // a Transfer from 0x0 even though the token was previously minted and never burned.
+      await handleNFTTransfer(context, event.args.from, event.args.to, true, nft, metadata);
     },
   );
 
@@ -77,7 +81,9 @@ export default function () {
         nft,
       };
 
-      await handleNFTTransfer(context, event.args.from, event.args.to, false, nft, metadata);
+      // BaseRegistrar contracts allow re-registration of expired names, which emits
+      // a Transfer from 0x0 even though the token was previously minted and never burned.
+      await handleNFTTransfer(context, event.args.from, event.args.to, true, nft, metadata);
     },
   );
 }


### PR DESCRIPTION
# Lite PR

[Tip: Review docs on the ENSNode PR process](https://ensnode.io/docs/contributing/prs)

## Summary

- Fixes `tokenscope` invariant crash when a `BaseRegistrar` re-registers an **expired** name.
- Enables `allowMintedRemint = true` for `EthBaseRegistrar`, `BaseBaseRegistrar`, and `LineaBaseRegistrar` Transfer handlers, matching the existing 3DNS pattern.

---

## Why

**RCA**

ENSNode's `tokenscope` plugin enforces strict NFT transfer invariants: a `Transfer(from=0x0)` event (mint) for an already-minted token is only accepted if `allowMintedRemint` is `true`. This was `false` for all `BaseRegistrar` contracts because canonical OZ ERC-721 contracts revert on double-mint.

However, `BaseRegistrar` contracts have a legitimate behavior gap: **when a previously-registered name expires, the contract does NOT emit a burn event.** The token simply becomes `Expired`. When someone later re-registers that same name, the contract emits a fresh `Transfer(from=0x0, ...)` — effectively a "minted remint" without an intermediate burn.

This caused the following crash on Base mainnet at block `48080423`:

```
Error: Sending from 0x0000...0000 conflicts with currently indexed owner 0x664a...
Event: BaseBaseRegistrar:Transfer
Chain ID: 8453
Block Number: 48080423
Transaction Hash: 0x04b6b3c...
```

**On-chain proof**
An `eth_call` to `ownerOf(tokenId)` at block `48080422` reverted with `Expired(uint256)`, confirming the token existed but had expired. At block `48080423`, the contract re-registered it with a mint-like `Transfer` event.

**Fix rationale**
The 3DNS plugin already handled this same "improperly implemented NFT" pattern with `allowMintedRemint = true`. The `BaseRegistrar` contracts aren't "improper" — expiration without burn is by design — but the indexing outcome is identical: a mint-from-zero for a previously-minted token. Enabling `MintedRemint` handling for all three `BaseRegistrar` variants correctly updates the owner in-place without throwing.

---

## Testing

- `pnpm -F ensindexer typecheck` ✅
- `pnpm lint` (biome + prettier) ✅
- `pnpm test` (ensindexer, 254 tests) ✅
- **On-chain `eth_call` verified the `Expired` revert before the failing block:**

  ```bash
  # 1. Compute hex tokenId
  python3 -c "print(format(89243471783238721179627283578674756040626838641058128025760321534307875241527, '064x'))"
  # → c54e03d8788bdb0217122a9d46ea88323baf075f5a53f2d2d8faf76eda813e37

  # 2. Compute block before the failing event
  python3 -c "print(hex(48080423 - 1))"
  # → 0x2dda626

  # 3. Call ownerOf at that block
  curl -s -X POST "https://gateway.tenderly.co/public/base" \
    -H "Content-Type: application/json" \
    -d '{
      "jsonrpc":"2.0","id":1,"method":"eth_call",
      "params":[
        {"to":"0x03c4738ee98ae44591e1a4a4f3cab6641d95dd9a","data":"0x6352211ec54e03d8788bdb0217122a9d46ea88323baf075f5a53f2d2d8faf76eda813e37"},
        "0x2dda626"
      ]
    }'
  # → {"id":1,"jsonrpc":"2.0","error":{"code":3,"message":"execution reverted","data":"0xf80dbaea..."}}

  # 4. Decode error selector
  cast sig 'Expired(uint256)'
  # → 0xf80dbaea
  ```

  The `Expired(uint256)` revert at block `48080422` on the Base Mainnet chain confirms the token existed but had expired. This proves block `48080423` is a legitimate re-registration, not a double-mint or stale cache.

---

## Notes for Reviewer (Optional)

- This is a behavioral change to indexing output: re-registered expired names will now transition from `minted` → `minted` with an owner update, rather than crashing. This changes the `nameTokens` table for any past/future expired-name re-registrations.
- All three `BaseRegistrar` variants (mainnet `.eth`, `base.eth`, `linea.eth`) share the same contract pattern, so they all got the same fix.
- No test file exists for `BaseRegistrars.ts` or the `handleNFTTransfer` path — the fix was validated by existing tests plus on-chain verification.
- The branch for this fix has been created from https://github.com/namehash/ensnode/commit/fb3f45fb41b54b45aa14ffae25d1ec37f239094c to allow a hot-fix for existing ENSIndexer 1.16.0 instances.

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)
