### PR TITLE
feat(ensindexer): require unigraph when efp plugin is enabled

### DIFF
--- a/.changeset/efp-ensnode-sdk.md
+++ b/.changeset/efp-ensnode-sdk.md
@@ -1,5 +1,0 @@
----
-"@ensnode/ensnode-sdk": minor
----
-
-Adds EFP (Ethereum Follow Protocol) support to the SDK: the `efp` `PluginName`, and `hasOmnigraphApiConfigSupport` now recognizes an `efp`-only config as Omnigraph-capable (so the `efp` namespace is queryable without `unigraph`).

--- a/apps/ensindexer/src/config/config.schema.ts
+++ b/apps/ensindexer/src/config/config.schema.ts
@@ -21,6 +21,7 @@ import { derive_indexedChainIds } from "./derived-params";
 import type { EnsIndexerConfig } from "./types";
 import {
   invariant_chainEndBlocks,
+  invariant_efpRequiresUnigraph,
   invariant_requiredDatasources,
   invariant_requiredDatasourcesSubsetOfAll,
   invariant_rpcConfigsSpecifiedForIndexedChains,
@@ -144,6 +145,7 @@ const ENSIndexerConfigSchema = z
   .check(invariant_rpcConfigsSpecifiedForRootChain)
   .check(invariant_validContractConfigs)
   .check(invariant_unigraphRequiresProtocolAcceleration)
+  .check(invariant_efpRequiresUnigraph)
   .check(invariant_isSubgraphCompatibleRequirements)
   .check(invariant_rpcConfigsSpecifiedForIndexedChains)
   .check(invariant_chainEndBlocks);

--- a/apps/ensindexer/src/config/config.test.ts
+++ b/apps/ensindexer/src/config/config.test.ts
@@ -523,15 +523,28 @@ describe("config (with base env)", () => {
     // EFP exists on `mainnet` and `ens-test-env`. On the devnet all three EFP datasources
     // (Base/Optimism/Ethereum) point at the single Anvil chain, so the plugin must activate and
     // index exactly one chain — guarding both the datasource-presence unlock and the collapse.
+    // EFP requires unigraph (which itself requires protocol-acceleration); on the devnet those
+    // datasources also collapse onto the single Anvil chain.
     it("derives the single devnet chain id for efp on ens-test-env", async () => {
       vi.stubEnv("NAMESPACE", ENSNamespaceIds.EnsTestEnv);
-      vi.stubEnv("PLUGINS", PluginName.EFP);
+      vi.stubEnv(
+        "PLUGINS",
+        [PluginName.Unigraph, PluginName.ProtocolAcceleration, PluginName.EFP].join(","),
+      );
       stubRpcUrlsForNamespace(ENSNamespaceIds.EnsTestEnv);
 
       const config = await getConfig();
 
       expect(config.plugins).toContain(PluginName.EFP);
       expect(config.indexedChainIds).toEqual(new Set([ensTestEnvChain.id]));
+    });
+
+    it("rejects efp without unigraph", async () => {
+      vi.stubEnv("NAMESPACE", ENSNamespaceIds.EnsTestEnv);
+      vi.stubEnv("PLUGINS", PluginName.EFP);
+      stubRpcUrlsForNamespace(ENSNamespaceIds.EnsTestEnv);
+
+      await expect(getConfig()).rejects.toThrow(/depends on the inclusion of 'unigraph'/i);
     });
   });
 

--- a/apps/ensindexer/src/config/validations.ts
+++ b/apps/ensindexer/src/config/validations.ts
@@ -136,3 +136,16 @@ export function invariant_unigraphRequiresProtocolAcceleration(
     );
   }
 }
+
+// Invariant: efp plugin requires unigraph
+export function invariant_efpRequiresUnigraph(
+  ctx: ZodCheckFnInput<Pick<EnsIndexerConfig, "plugins">>,
+) {
+  const { value: config } = ctx;
+
+  if (config.plugins.includes(PluginName.EFP) && !config.plugins.includes(PluginName.Unigraph)) {
+    throw new Error(
+      `The '${PluginName.EFP}' plugin depends on the inclusion of '${PluginName.Unigraph}' plugin.`,
+    );
+  }
+}

--- a/packages/ensnode-sdk/src/omnigraph-api/prerequisites.test.ts
+++ b/packages/ensnode-sdk/src/omnigraph-api/prerequisites.test.ts
@@ -8,18 +8,13 @@ const configWithPlugins = (plugins: PluginName[]) =>
   ({ plugins }) as unknown as EnsIndexerPublicConfig;
 
 describe("hasOmnigraphApiConfigSupport", () => {
-  it("is supported by unigraph, ensv2, or efp (efp alone counts)", () => {
+  it("is supported by unigraph or ensv2", () => {
     expect(hasOmnigraphApiConfigSupport(configWithPlugins([PluginName.Unigraph])).supported).toBe(
       true,
     );
     expect(hasOmnigraphApiConfigSupport(configWithPlugins([PluginName.ENSv2])).supported).toBe(
       true,
     );
-    expect(hasOmnigraphApiConfigSupport(configWithPlugins([PluginName.EFP])).supported).toBe(true);
-    expect(
-      hasOmnigraphApiConfigSupport(configWithPlugins([PluginName.Subgraph, PluginName.EFP]))
-        .supported,
-    ).toBe(true);
   });
 
   it("is unsupported without one of those plugins", () => {

--- a/packages/ensnode-sdk/src/omnigraph-api/prerequisites.ts
+++ b/packages/ensnode-sdk/src/omnigraph-api/prerequisites.ts
@@ -6,21 +6,17 @@ import type { PrerequisiteResult } from "../shared/prerequisites";
 /**
  * Check if provided EnsIndexerPublicConfig supports the Omnigraph API.
  *
- * The Omnigraph API is served whenever the config indexes data it can expose: the ENS data model
- * (`unigraph` / `ensv2`) or the highly-ENS-adjacent EFP protocol (`efp`). EFP qualifies on its own
- * so an EFP-only config can still query the `efp` namespace (the ENS query fields are present but
- * return no data without `unigraph`).
+ * The Omnigraph API is served whenever the config indexes the ENS data model
+ * (`unigraph` / `ensv2`).
  */
 export function hasOmnigraphApiConfigSupport(config: EnsIndexerPublicConfig): PrerequisiteResult {
   const supported =
-    config.plugins.includes(PluginName.Unigraph) ||
-    config.plugins.includes(PluginName.ENSv2) ||
-    config.plugins.includes(PluginName.EFP);
+    config.plugins.includes(PluginName.Unigraph) || config.plugins.includes(PluginName.ENSv2);
   if (supported) return { supported };
 
   return {
     supported: false,
-    reason: `The connected ENSNode's Config must have one of the '${PluginName.Unigraph}', '${PluginName.ENSv2}', or '${PluginName.EFP}' plugins enabled.`,
+    reason: `The connected ENSNode's Config must have one of the '${PluginName.Unigraph}' or '${PluginName.ENSv2}' plugins enabled.`,
   };
 }
 


### PR DESCRIPTION
## Summary

- Adds a config invariant (`invariant_efpRequiresUnigraph`) so enabling the `efp` plugin requires the `unigraph` plugin. An `efp`-without-`unigraph` config now fails fast: `The 'efp' plugin depends on the inclusion of 'unigraph' plugin.`
- Since EFP is now always paired with `unigraph`, removes the SDK special-case in `hasOmnigraphApiConfigSupport` that treated an `efp`-only config as Omnigraph-capable. The gate is back to `unigraph`/`ensv2` only.
- Deletes the now-obsolete `.changeset/efp-ensnode-sdk.md` (it documented the removed `efp`-only-is-Omnigraph-capable behavior).

## Tests

- `hasOmnigraphApiConfigSupport` SDK test drops the `efp`-alone assertions.
- The ensindexer devnet-efp test now enables `unigraph,protocol-acceleration,efp` (efp → unigraph → protocol-acceleration).
- New test: `rejects efp without unigraph`.

Verified in-worktree: `typecheck` (ensindexer + ensnode-sdk), config/prerequisites tests, and `lint` all pass.