### PR TITLE
feat(ensnode-sdk): remove deprecated PluginName.ENSv2

### DIFF
--- a/.agents/skills/ensindexer-perf-testing/SKILL.md
+++ b/.agents/skills/ensindexer-perf-testing/SKILL.md
@@ -69,7 +69,7 @@ Pick a unique schema per run so concurrent/sequential runs don't pollute each ot
 
 ```env
 NAMESPACE=mainnet
-PLUGINS=ensv2,protocol-acceleration   # or whatever combo
+PLUGINS=unigraph,protocol-acceleration   # or whatever combo
 ENSINDEXER_SCHEMA_NAME=ensindexer_perf_<label>
 DISABLE_ENSRAINBOW_HEAL=true
 
@@ -84,8 +84,8 @@ validation against the subgraph label set baseline.
 
 Useful preset combos:
 
-- "alpha": `subgraph,basenames,lineanames,threedns,ensv2,protocol-acceleration,registrars,tokenscope`
-- "ensv2": `ensv2,protocol-acceleration`
+- "alpha": `subgraph,basenames,lineanames,threedns,unigraph,protocol-acceleration,registrars,tokenscope`
+- "unigraph": `unigraph,protocol-acceleration`
 - "subgraph": `subgraph,basenames,lineanames,threedns,protocol-acceleration`
 
 ## Step 5 — wipe state
@@ -280,7 +280,7 @@ block range` log lines stop appearing for minutes.
   `curl :42069/metrics | grep -E "^ponder_indexing_(store|rpc)"` is the source of truth.
 - **Querying prometheus after indexer stops** without a `time=` parameter returns empty results.
   Always snapshot at `end-epoch`.
-- **`ensv2-only` is not v2-only** — the ensv2 plugin pulls in chains 1/8453/10/42161/59144/534352
+- **`unigraph-only` is not v2-only** — the unigraph plugin pulls in chains 1/8453/10/42161/59144/534352
   to mirror v1 state. Same shape as the canonical multichain configs in terms of chain count.
 - **TOCTOU during snapshot** — wait until the wait script signals all chains live before
   snapshotting. Mid-realtime numbers are not stable.

--- a/.changeset/remove-ensv2-plugin-name.md
+++ b/.changeset/remove-ensv2-plugin-name.md
@@ -1,0 +1,5 @@
+---
+"@ensnode/ensnode-sdk": minor
+---
+
+Removes the deprecated `PluginName.ENSv2` (`"ensv2"`) enum member. It was retained for one release as a backwards-compatible alias for `PluginName.Unigraph` and is now fully removed; use `PluginName.Unigraph` (`"unigraph"`) instead.

--- a/packages/ensnode-sdk/src/ensindexer/config/types.ts
+++ b/packages/ensnode-sdk/src/ensindexer/config/types.ts
@@ -16,8 +16,6 @@ export enum PluginName {
   ProtocolAcceleration = "protocol-acceleration",
   Registrars = "registrars",
   TokenScope = "tokenscope",
-  /** @deprecated use {@link PluginName.Unigraph} instead */
-  ENSv2 = "ensv2",
   Unigraph = "unigraph",
   EFP = "efp",
 }

--- a/packages/ensnode-sdk/src/omnigraph-api/prerequisites.test.ts
+++ b/packages/ensnode-sdk/src/omnigraph-api/prerequisites.test.ts
@@ -8,16 +8,13 @@ const configWithPlugins = (plugins: PluginName[]) =>
   ({ plugins }) as unknown as EnsIndexerPublicConfig;
 
 describe("hasOmnigraphApiConfigSupport", () => {
-  it("is supported by unigraph or ensv2", () => {
+  it("is supported by unigraph", () => {
     expect(hasOmnigraphApiConfigSupport(configWithPlugins([PluginName.Unigraph])).supported).toBe(
-      true,
-    );
-    expect(hasOmnigraphApiConfigSupport(configWithPlugins([PluginName.ENSv2])).supported).toBe(
       true,
     );
   });
 
-  it("is unsupported without one of those plugins", () => {
+  it("is unsupported without the unigraph plugin", () => {
     const result = hasOmnigraphApiConfigSupport(configWithPlugins([PluginName.Subgraph]));
     expect(result.supported).toBe(false);
   });

--- a/packages/ensnode-sdk/src/omnigraph-api/prerequisites.ts
+++ b/packages/ensnode-sdk/src/omnigraph-api/prerequisites.ts
@@ -7,16 +7,15 @@ import type { PrerequisiteResult } from "../shared/prerequisites";
  * Check if provided EnsIndexerPublicConfig supports the Omnigraph API.
  *
  * The Omnigraph API is served whenever the config indexes the ENS data model
- * (`unigraph` / `ensv2`).
+ * (`unigraph`).
  */
 export function hasOmnigraphApiConfigSupport(config: EnsIndexerPublicConfig): PrerequisiteResult {
-  const supported =
-    config.plugins.includes(PluginName.Unigraph) || config.plugins.includes(PluginName.ENSv2);
+  const supported = config.plugins.includes(PluginName.Unigraph);
   if (supported) return { supported };
 
   return {
     supported: false,
-    reason: `The connected ENSNode's Config must have one of the '${PluginName.Unigraph}' or '${PluginName.ENSv2}' plugins enabled.`,
+    reason: `The connected ENSNode's Config must have the '${PluginName.Unigraph}' plugin enabled.`,
   };
 }
 


### PR DESCRIPTION
## Summary

Removes the deprecated `PluginName.ENSv2` (`"ensv2"`) enum member from `@ensnode/ensnode-sdk`. It was retained for one release as a backwards-compatible alias for `PluginName.Unigraph` and can now be fully removed.

- **`packages/ensnode-sdk/src/ensindexer/config/types.ts`** — drop the `ENSv2 = "ensv2"` enum member and its `@deprecated` comment.
- **`packages/ensnode-sdk/src/omnigraph-api/prerequisites.ts`** — `hasOmnigraphApiConfigSupport` now gates on `unigraph` only; doc comment and error message updated.
- **`.agents/skills/ensindexer-perf-testing/SKILL.md`** — update stale `ensv2` PLUGINS examples to `unigraph` (no plugin is registered under `ensv2`, so those example configs already failed at `getPlugin`).

## Notes

- No plugin was ever registered under `ensv2`; the enum value was purely a wire/config compatibility alias, so this only affects consumers referencing the SDK enum member directly.
- The many other `ensv2`/`ENSv2` references in the codebase are the ENSv2 **protocol** (registry, handlers, `ENSv2Root` datasource, contracts) — unrelated to this enum member and untouched.

## Tests

- `hasOmnigraphApiConfigSupport` SDK test drops the `ENSv2` assertion; renamed for clarity.

Verified in-worktree: full-repo `pnpm typecheck`, SDK prerequisites tests, and `pnpm lint` all pass. Per ENSNode convention, removing a public enum member is a breaking change → `minor` changeset.