### PR TITLE
Make ENSApi to wait for ENSDb to be ready

### DIFF
--- a/.changeset/odd-keys-like.md
+++ b/.changeset/odd-keys-like.md
@@ -1,0 +1,5 @@
+---
+"@ensnode/ensdb-sdk": minor
+---
+
+Updated `isReady()` method in `EnsDbReader` to check for relevant database schemas existence.

--- a/apps/ensapi/src/config/config.singleton.test.ts
+++ b/apps/ensapi/src/config/config.singleton.test.ts
@@ -6,10 +6,12 @@ vi.mock("@/lib/logger", () => ({
   default: {
     error: vi.fn(),
     info: vi.fn(),
+    warn: vi.fn(),
   },
   makeLogger: vi.fn(() => ({
     error: vi.fn(),
     info: vi.fn(),
+    warn: vi.fn(),
   })),
 }));
 
@@ -23,6 +25,9 @@ vi.mock("@ensnode/ensdb-sdk", async (importOriginal) => {
     ensIndexerSchema = {};
     ensIndexerSchemaName = "ensindexer_test";
     async isHealthy() {
+      return true;
+    }
+    async isReady() {
       return true;
     }
     async destroy() {}

--- a/apps/ensapi/src/di.ts
+++ b/apps/ensapi/src/di.ts
@@ -17,6 +17,7 @@ import type { EnsApiConfig } from "@/config/config.schema";
 import { buildConfigFromEnvironment, buildRootChainRpcConfig } from "@/config/config.schema";
 import { buildEnsDbConfigFromEnvironment } from "@/config/ensdb-config";
 import type { EnsApiEnvironment } from "@/config/environment";
+import { waitForEnsDbToBeReady } from "@/lib/ensdb";
 import { makeLogger } from "@/lib/logger";
 import { buildRootChainPublicClient } from "@/lib/public-client";
 
@@ -265,15 +266,16 @@ class EnsApiDiContainer {
         throw new Error("ENSDb health check failed");
       }
 
+      // Wait for ENSDb to be ready for handling queries before proceeding with further steps.
+      await waitForEnsDbToBeReady(this.context.ensDbClient);
+
       logger.info(
         { ensIndexerSchemaName: this.context.ensDbConfig.ensIndexerSchemaName },
         "Successfully connected to ENSDb",
       );
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : "Unknown error";
-      throw new Error(
-        `DI container initialization failed: could not connect to ENSDb due to ${errorMessage}`,
-      );
+      throw new Error(`DI container initialization failed: ${errorMessage}`);
     }
 
     try {

--- a/apps/ensapi/src/lib/ensdb.test.ts
+++ b/apps/ensapi/src/lib/ensdb.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { EnsDbReader } from "@ensnode/ensdb-sdk";
+
+import { waitForEnsDbToBeReady } from "./ensdb";
+
+vi.mock("@/lib/logger", () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const ENSINDEXER_SCHEMA_NAME = "ensindexer_test";
+
+const createEnsDbClient = ({ isReady }: { isReady: boolean }) =>
+  ({
+    isReady: vi.fn().mockResolvedValue(isReady),
+    ensIndexerSchemaName: ENSINDEXER_SCHEMA_NAME,
+  }) as unknown as EnsDbReader;
+
+describe("waitForEnsDbToBeReady", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resolves when the ENSDb instance is ready immediately", async () => {
+    const ensDbClient = createEnsDbClient({ isReady: true });
+
+    await expect(waitForEnsDbToBeReady(ensDbClient)).resolves.toBeUndefined();
+    expect(ensDbClient.isReady).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries until the ENSDb instance becomes ready", async () => {
+    const ensDbClient = {
+      isReady: vi.fn().mockResolvedValueOnce(false).mockResolvedValue(true),
+      ensIndexerSchemaName: ENSINDEXER_SCHEMA_NAME,
+    } as unknown as EnsDbReader;
+
+    const promise = waitForEnsDbToBeReady(ensDbClient);
+
+    // Advance past the 60-second retry interval to trigger the second attempt.
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    await expect(promise).resolves.toBeUndefined();
+    expect(ensDbClient.isReady).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects when the ENSDb instance never becomes ready", async () => {
+    const ensDbClient = createEnsDbClient({ isReady: false });
+
+    const promise = waitForEnsDbToBeReady(ensDbClient);
+    // Attach a no-op catch to prevent the promise from being reported as an
+    // unhandled rejection while the fake timers are advancing.
+    promise.catch(() => {});
+
+    // Advance past all 15 retry intervals (15 × 60s = 900s).
+    await vi.advanceTimersByTimeAsync(900_000);
+
+    await expect(promise).rejects.toThrow("ENSDb instance is not ready yet.");
+    expect(ensDbClient.isReady).toHaveBeenCalledTimes(16); // initial + 15 retries
+  });
+});

--- a/apps/ensapi/src/lib/ensdb.ts
+++ b/apps/ensapi/src/lib/ensdb.ts
@@ -34,12 +34,13 @@ export async function waitForEnsDbToBeReady(ensDbClient: EnsDbReader): Promise<v
       retries: 15, // This allows for a total of over 15 minutes of retries with 1 minute between attempts.
       minTimeout: secondsToMilliseconds(60),
       maxTimeout: secondsToMilliseconds(60),
-      onFailedAttempt: ({ attemptNumber, retriesLeft }) => {
+      onFailedAttempt: ({ attemptNumber, retriesLeft, error }) => {
         logger.warn(
           {
             ensIndexerSchemaName,
             attempt: attemptNumber,
             retriesLeft,
+            err: error,
             advice: `This might be due to ENSDb instance having a cold start, which can take several minutes.`,
           },
           `ENSDb instance readiness check failed`,

--- a/apps/ensapi/src/lib/ensdb.ts
+++ b/apps/ensapi/src/lib/ensdb.ts
@@ -1,0 +1,62 @@
+import { secondsToMilliseconds } from "date-fns";
+import pRetry from "p-retry";
+
+import type { EnsDbReader } from "@ensnode/ensdb-sdk";
+
+import logger from "@/lib/logger";
+
+/**
+ * Wait for ENSDb to be ready
+ *
+ * Blocks execution until the ENSDb instance is ready to serve queries.
+ *
+ * Note: It may take several minutes for the ENSDb instance to become ready in
+ * a cold start scenario. We use retries with a fixed interval between attempts
+ * for the ENSDb readiness check to allow for ample time for ENSDb to
+ * become ready.
+ *
+ * @throws When ENSDb fails to become ready after all configured retry attempts.
+ *         This error will trigger termination of the ENSApi process.
+ */
+export async function waitForEnsDbToBeReady(ensDbClient: EnsDbReader): Promise<void> {
+  const { ensIndexerSchemaName } = ensDbClient;
+  logger.info({ ensIndexerSchemaName }, `Waiting for ENSDb instance to be ready`);
+
+  return pRetry(
+    async () => {
+      const isEnsDbInstanceReady = await ensDbClient.isReady();
+
+      if (!isEnsDbInstanceReady) {
+        throw new Error("ENSDb instance is not ready yet.");
+      }
+    },
+    {
+      retries: 15, // This allows for a total of over 15 minutes of retries with 1 minute between attempts.
+      minTimeout: secondsToMilliseconds(60),
+      maxTimeout: secondsToMilliseconds(60),
+      onFailedAttempt: ({ attemptNumber, retriesLeft }) => {
+        logger.warn(
+          {
+            ensIndexerSchemaName,
+            attempt: attemptNumber,
+            retriesLeft,
+            advice: `This might be due to ENSDb instance having a cold start, which can take several minutes.`,
+          },
+          `ENSDb instance readiness check failed`,
+        );
+      },
+    },
+  )
+    .then(() => {
+      logger.info({ ensIndexerSchemaName }, `ENSDb instance is ready`);
+    })
+    .catch((err) => {
+      logger.error(
+        { ensIndexerSchemaName, err },
+        `ENSDb readiness check failed after multiple attempts`,
+      );
+
+      // Throw the error to terminate the ENSApi process due to the failed readiness check of a critical dependency
+      throw err;
+    });
+}

--- a/packages/ensdb-sdk/src/client/ensdb-reader.test.ts
+++ b/packages/ensdb-sdk/src/client/ensdb-reader.test.ts
@@ -131,6 +131,10 @@ describe("EnsDbReader", () => {
   });
 
   describe("isReady", () => {
+    beforeEach(() => {
+      executeMock.mockResolvedValue({ rows: [{ exists: true }] });
+    });
+
     it("returns true when indexing metadata context is initialized", async () => {
       const indexingStatus = deserializeCrossChainIndexingStatusSnapshot(
         ensDbClientMock.serializedSnapshot,
@@ -157,6 +161,32 @@ describe("EnsDbReader", () => {
     });
 
     it("returns false when indexing metadata context is uninitialized", async () => {
+      const result = await createEnsDbReader().isReady();
+
+      expect(result).toBe(false);
+    });
+
+    it("returns false when the ENSNode schema does not exist", async () => {
+      executeMock.mockResolvedValueOnce({ rows: [{ exists: false }] });
+
+      const result = await createEnsDbReader().isReady();
+
+      expect(result).toBe(false);
+    });
+
+    it("returns false when the ENSIndexer schema does not exist", async () => {
+      executeMock
+        .mockResolvedValueOnce({ rows: [{ exists: true }] })
+        .mockResolvedValueOnce({ rows: [{ exists: false }] });
+
+      const result = await createEnsDbReader().isReady();
+
+      expect(result).toBe(false);
+    });
+
+    it("returns false when schema existence check fails", async () => {
+      executeMock.mockRejectedValueOnce(new Error("Connection refused"));
+
       const result = await createEnsDbReader().isReady();
 
       expect(result).toBe(false);

--- a/packages/ensdb-sdk/src/client/ensdb-reader.ts
+++ b/packages/ensdb-sdk/src/client/ensdb-reader.ts
@@ -156,12 +156,12 @@ export class EnsDbReader<
   async isReady(): Promise<boolean> {
     try {
       const [ensNodeSchemaExists, ensDbWriterSchemaExists] = await Promise.all([
-        this.ensDbSchemaExists(ENSNODE_SCHEMA_NAME),
-        this.ensDbSchemaExists(this.ensIndexerSchemaName),
+        this.schemaExists(ENSNODE_SCHEMA_NAME),
+        this.schemaExists(this.ensIndexerSchemaName),
       ]);
 
-      // If either the ENSNode Schema or the ENSIndexer Schema does not exist in the ENSDb instance,
-      // then it is not ready to serve queries.
+      // If either the ENSNode Schema or the ENSIndexer Schema does not exist in
+      // the ENSDb instance then it is not ready to serve queries.
       if (!ensNodeSchemaExists || !ensDbWriterSchemaExists) {
         return false;
       }
@@ -287,20 +287,5 @@ export class EnsDbReader<
     return {
       postgresql: postgresVersion,
     };
-  }
-
-  /**
-   * Check if the specified database schema exists in the ENSDb instance.
-   */
-  private async ensDbSchemaExists(schemaName: string): Promise<boolean> {
-    const result = await this.ensDb.execute<{ exists: boolean }>(
-      sql`SELECT EXISTS (
-        SELECT 1
-        FROM information_schema.schemata
-        WHERE schema_name = ${schemaName}
-      ) AS "exists";`,
-    );
-
-    return result.rows[0]?.exists ?? false;
   }
 }

--- a/packages/ensdb-sdk/src/client/ensdb-reader.ts
+++ b/packages/ensdb-sdk/src/client/ensdb-reader.ts
@@ -16,6 +16,7 @@ export {
   type IndexingMetadataContextUninitialized,
 } from "@ensnode/ensnode-sdk";
 
+import { ENSNODE_SCHEMA_NAME } from "../ensnode";
 import {
   type AbstractEnsIndexerSchema,
   buildEnsDbDrizzleClient,
@@ -154,6 +155,17 @@ export class EnsDbReader<
    */
   async isReady(): Promise<boolean> {
     try {
+      const [ensNodeSchemaExists, ensDbWriterSchemaExists] = await Promise.all([
+        this.ensDbSchemaExists(ENSNODE_SCHEMA_NAME),
+        this.ensDbSchemaExists(this.ensIndexerSchemaName),
+      ]);
+
+      // If either the ENSNode Schema or the ENSIndexer Schema does not exist in the ENSDb instance,
+      // then it is not ready to serve queries.
+      if (!ensNodeSchemaExists || !ensDbWriterSchemaExists) {
+        return false;
+      }
+
       const indexingMetadataContext = await this.getIndexingMetadataContext();
       return indexingMetadataContext.statusCode === IndexingMetadataContextStatusCodes.Initialized;
     } catch {
@@ -275,5 +287,20 @@ export class EnsDbReader<
     return {
       postgresql: postgresVersion,
     };
+  }
+
+  /**
+   * Check if the specified database schema exists in the ENSDb instance.
+   */
+  private async ensDbSchemaExists(schemaName: string): Promise<boolean> {
+    const result = await this.ensDb.execute<{ exists: boolean }>(
+      sql`SELECT EXISTS (
+        SELECT 1
+        FROM information_schema.schemata
+        WHERE schema_name = ${schemaName}
+      ) AS "exists";`,
+    );
+
+    return result.rows[0]?.exists ?? false;
   }
 }

--- a/packages/ensdb-sdk/src/ensnode/index.ts
+++ b/packages/ensdb-sdk/src/ensnode/index.ts
@@ -5,7 +5,7 @@ import { pgSchema, primaryKey } from "drizzle-orm/pg-core";
  *
  * The name of the ENSNode schema in an ENSDb.
  */
-const ENSNODE_SCHEMA_NAME = "ensnode";
+export const ENSNODE_SCHEMA_NAME = "ensnode";
 
 /**
  * ENSNode Schema


### PR DESCRIPTION
# Lite PR

[Tip: Review docs on the ENSNode PR process](https://ensnode.io/docs/contributing/prs)

## Summary

- Updated `isReady()` method in ENSDb SDK to check for relevant database schemas (ENSNode Schema, ENSDb Writer Schema) existence.
- Updated the ENSApi dependency injection container to wait for ENSDb instance to be ready before initializing caches.

---

## Why

- Fixes #2272 

---

## Testing

- Ran all static code checks and testing suites
- Ran an ENSApi instance locally and confirmed that it waits for ENSDb instance to be ready before proceeding to ENSApi caches initialization.

---

## Notes for Reviewer (Optional)

- [The idea implemented in this PR was discussed on Slack](https://namehash.slack.com/archives/C086Z6FNBHN/p1782725305079179)
- Related PR #2335

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)
