### PR TITLE
Simplify public config data models

### DIFF
--- a/.changeset/ensnode-sdk-public-configs.md
+++ b/.changeset/ensnode-sdk-public-configs.md
@@ -1,0 +1,5 @@
+---
+"@ensnode/ensnode-sdk": minor
+---
+
+BREAKING: Dropped `ensRainbowPublicConfig` field from `EnsIndexerPublicConfig` data model, and `ensIndexerPublicConfig` from `EnsApiPublicConfig` data model.

--- a/.changeset/ensnode-stack-info-data-model.md
+++ b/.changeset/ensnode-stack-info-data-model.md
@@ -1,0 +1,5 @@
+---
+"@ensnode/ensnode-sdk": minor
+---
+
+BREAKING: Dropped both `ensRainbowPublicConfig`, and `ensIndexerPublicConfig` fields nested in the Indexing Status API data model.

--- a/.changeset/ensnode-stack-info-data-model.md
+++ b/.changeset/ensnode-stack-info-data-model.md
@@ -2,4 +2,4 @@
 "@ensnode/ensnode-sdk": minor
 ---
 
-BREAKING: Dropped both `ensRainbowPublicConfig`, and `ensIndexerPublicConfig` fields nested in the Indexing Status API data model.
+BREAKING: Indexing Status API's `stackInfo.ensApi` no longer includes `ensIndexerPublicConfig`, and `stackInfo.ensIndexer` no longer includes `ensRainbowPublicConfig`. Use `stackInfo.ensIndexer` and `stackInfo.ensRainbow`, respectively, instead.

--- a/apps/ensadmin/src/app/mock/indexing-status-api.mock.ts
+++ b/apps/ensadmin/src/app/mock/indexing-status-api.mock.ts
@@ -59,7 +59,6 @@ const serializedEnsIndexerPublicConfig = {
 } satisfies SerializedEnsIndexerPublicConfig;
 
 export const serializedEnsApiPublicConfig = {
-  ensIndexerPublicConfig: serializedEnsIndexerPublicConfig,
   theGraphFallback: {
     canFallback: true,
     url: "https://api.thegraph.com/subgraphs/name/ensdomains/ens",

--- a/apps/ensadmin/src/app/mock/indexing-status-api.mock.ts
+++ b/apps/ensadmin/src/app/mock/indexing-status-api.mock.ts
@@ -30,15 +30,6 @@ const serializedEnsIndexerPublicConfig = {
   },
   indexedChainIds: [1, 8453, 59144, 10, 42161, 534352, 567],
   ensIndexerSchemaName: "alphaSchema1.9.0",
-  ensRainbowPublicConfig: {
-    serverLabelSet: {
-      labelSetId: "subgraph",
-      highestLabelSetVersion: 0,
-    },
-    versionInfo: {
-      ensRainbow: "1.9.0",
-    },
-  },
   isSubgraphCompatible: false,
   namespace: "mainnet",
   plugins: [
@@ -75,8 +66,13 @@ const serializedEnsDbPublicConfig = {
   },
 } satisfies SerializedEnsDbPublicConfig;
 
-const serializedEnsRainbowPublicConfig =
-  serializedEnsIndexerPublicConfig.ensRainbowPublicConfig satisfies SerializedEnsRainbowPublicConfig;
+const serializedEnsRainbowPublicConfig = {
+  serverLabelSet: { labelSetId: "subgraph", highestLabelSetVersion: 0 },
+  versionInfo: {
+    commit: "a26a979f06f52ef0e40e69da1052e190240db29b",
+    ensRainbow: "1.0.0",
+  },
+} satisfies SerializedEnsRainbowPublicConfig;
 
 const serializedStackInfo = {
   ensApi: serializedEnsApiPublicConfig,

--- a/apps/ensadmin/src/app/mock/stack-info/stack-info.mock.ts
+++ b/apps/ensadmin/src/app/mock/stack-info/stack-info.mock.ts
@@ -108,7 +108,6 @@ function createEnsIndexerConfig(
     namespace,
     plugins,
     versionInfo: { ...COMMON_ENSINDEXER_VERSION_INFO },
-    ensRainbowPublicConfig: createEnsRainbowConfig(),
   };
 }
 
@@ -207,15 +206,6 @@ function createDeserializationErrorVariant(): SerializedEnsNodeStackInfo {
       plugins: ["subgraph"],
       ensIndexerSchemaName: "DeserializationSchema1.9.0",
       isSubgraphCompatible: true,
-      ensRainbowPublicConfig: {
-        versionInfo: {
-          ensRainbow: "",
-        },
-        serverLabelSet: {
-          labelSetId: "",
-          highestLabelSetVersion: -1,
-        },
-      },
     },
     ensRainbow: {
       versionInfo: {

--- a/apps/ensadmin/src/app/mock/stack-info/stack-info.mock.ts
+++ b/apps/ensadmin/src/app/mock/stack-info/stack-info.mock.ts
@@ -123,15 +123,6 @@ function createEnsApiConfig(
   return {
     versionInfo: { ...COMMON_ENSAPI_VERSION_INFO },
     theGraphFallback,
-    ensIndexerPublicConfig: {
-      ...createEnsIndexerConfig(
-        namespace,
-        indexedChainIds,
-        plugins,
-        ensIndexerSchemaName,
-        isSubgraphCompatible,
-      ),
-    },
   };
 }
 function createAlphaEnsIndexerConfig(
@@ -198,32 +189,6 @@ function createDeserializationErrorVariant(): SerializedEnsNodeStackInfo {
     ensApi: {
       versionInfo: { ...COMMON_ENSAPI_VERSION_INFO },
       theGraphFallback: { ...THE_GRAPH_FALLBACK_DISABLED },
-      ensIndexerPublicConfig: {
-        clientLabelSet: {
-          labelSetId: "",
-          labelSetVersion: 0,
-        },
-        versionInfo: {
-          ponder: "",
-          ensDb: "",
-          ensIndexer: "",
-          ensNormalize: "",
-        },
-        indexedChainIds: [11155111],
-        namespace: "sepolia",
-        plugins: ["subgraph"],
-        ensIndexerSchemaName: "DeserializationSchema1.9.0",
-        isSubgraphCompatible: true,
-        ensRainbowPublicConfig: {
-          serverLabelSet: {
-            labelSetId: "",
-            highestLabelSetVersion: -1,
-          },
-          versionInfo: {
-            ensRainbow: "",
-          },
-        },
-      },
     },
     ensDb: createEnsDbConfig(),
     ensIndexer: {

--- a/apps/ensapi/src/config/config.schema.mock.ts
+++ b/apps/ensapi/src/config/config.schema.mock.ts
@@ -30,12 +30,6 @@ export const ENSDB_PUBLIC_CONFIG = {
 export const ENSINDEXER_PUBLIC_CONFIG = {
   namespace: "mainnet",
   ensIndexerSchemaName: "ensindexer_0",
-  ensRainbowPublicConfig: {
-    serverLabelSet: { labelSetId: "subgraph", highestLabelSetVersion: 0 },
-    versionInfo: {
-      ensRainbow: packageJson.version,
-    },
-  },
   indexedChainIds: [1],
   isSubgraphCompatible: false,
   clientLabelSet: { labelSetId: "subgraph", labelSetVersion: 0 },

--- a/apps/ensapi/src/config/config.schema.test.ts
+++ b/apps/ensapi/src/config/config.schema.test.ts
@@ -159,21 +159,7 @@ describe("buildEnsApiPublicConfig", () => {
         canFallback: false,
         reason: "not-subgraph-compatible",
       },
-      ensIndexerPublicConfig,
     });
-  });
-
-  it("preserves the complete ENSIndexer public config structure", () => {
-    const { ensIndexer: ensIndexerPublicConfig } = indexingMetadataContextInitialized.stackInfo;
-    const ensApiConfig = {
-      port: ENSApi_DEFAULT_PORT,
-      theGraphApiKey: "my-api-key",
-      referralProgramEditionConfigSetUrl: undefined,
-    };
-
-    const result = buildEnsApiPublicConfig(ensApiConfig, ensIndexerPublicConfig);
-
-    expect(result.ensIndexerPublicConfig).toStrictEqual(ensIndexerPublicConfig);
   });
 
   it("includes the theGraphFallback and redacts api key", () => {

--- a/apps/ensapi/src/config/config.schema.ts
+++ b/apps/ensapi/src/config/config.schema.ts
@@ -133,6 +133,5 @@ export function buildEnsApiPublicConfig(
       theGraphApiKey: ensApiConfig.theGraphApiKey ? "<API_KEY>" : undefined,
       isSubgraphCompatible: ensIndexerPublicConfig.isSubgraphCompatible,
     }),
-    ensIndexerPublicConfig,
   };
 }

--- a/apps/ensindexer/ponder/src/api/handlers/ensnode-api.ts
+++ b/apps/ensindexer/ponder/src/api/handlers/ensnode-api.ts
@@ -18,7 +18,7 @@ import { publicConfigBuilder } from "@/lib/public-config-builder/singleton";
 const app = new Hono();
 
 app.get("/config", async (c) => {
-  const ensIndexerPublicConfig = await publicConfigBuilder.getPublicConfig();
+  const ensIndexerPublicConfig = publicConfigBuilder.getPublicConfig();
 
   // respond with the serialized public config object
   return c.json(serializeEnsIndexerPublicConfig(ensIndexerPublicConfig));

--- a/apps/ensindexer/src/lib/public-config-builder/public-config-builder.test.ts
+++ b/apps/ensindexer/src/lib/public-config-builder/public-config-builder.test.ts
@@ -4,10 +4,8 @@ import {
   ENSNamespaceIds,
   type EnsIndexerPublicConfig,
   type EnsIndexerVersionInfo,
-  type EnsRainbowPublicConfig,
   PluginName,
 } from "@ensnode/ensnode-sdk";
-import type { EnsRainbow } from "@ensnode/ensrainbow-sdk";
 
 import { PublicConfigBuilder } from "./public-config-builder";
 
@@ -55,14 +53,6 @@ import {
 } from "@/lib/version-info";
 
 // Test fixtures
-const mockEnsRainbowConfig: EnsRainbowPublicConfig = {
-  serverLabelSet: { labelSetId: "subgraph", highestLabelSetVersion: 0 },
-  versionInfo: {
-    commit: "a26a979f06f52ef0e40e69da1052e190240db29b",
-    ensRainbow: "1.0.0",
-  },
-};
-
 const mockVersionInfo: EnsIndexerVersionInfo = {
   ponder: "0.9.0",
   commit: "a26a979f06f52ef0e40e69da1052e190240db29b",
@@ -76,7 +66,6 @@ function createMockPublicConfig(overrides: Partial<EnsIndexerPublicConfig> = {})
   return {
     ensIndexerSchemaName: "ensindexer_0",
     clientLabelSet: { labelSetId: "subgraph", labelSetVersion: 0 },
-    ensRainbowPublicConfig: mockEnsRainbowConfig,
     indexedChainIds: new Set([1, 8453]),
     isSubgraphCompatible: true,
     namespace: ENSNamespaceIds.Mainnet,
@@ -102,21 +91,17 @@ describe("PublicConfigBuilder", () => {
   describe("getPublicConfig() - successful builds", () => {
     it("builds and returns public config on first call", async () => {
       // Arrange
-      const ensRainbowClientMock = {
-        config: vi.fn().mockResolvedValue(mockEnsRainbowConfig),
-      } as unknown as EnsRainbow.ApiClient;
 
       setupStandardMocks();
       const mockPublicConfig = createMockPublicConfig();
       vi.mocked(validateEnsIndexerPublicConfig).mockReturnValue(mockPublicConfig);
 
-      const builder = new PublicConfigBuilder(ensRainbowClientMock);
+      const builder = new PublicConfigBuilder();
 
       // Act
       const result = await builder.getPublicConfig();
 
       // Assert
-      expect(ensRainbowClientMock.config).toHaveBeenCalledTimes(1);
       expect(getEnsIndexerVersion).toHaveBeenCalledTimes(1);
       expect(getPackageVersion).toHaveBeenCalledWith("ponder");
       expect(getPackageVersion).toHaveBeenCalledWith("@adraffy/ens-normalize");
@@ -131,7 +116,6 @@ describe("PublicConfigBuilder", () => {
 
       expect(validateEnsIndexerPublicConfig).toHaveBeenCalledWith({
         ensIndexerSchemaName: config.ensIndexerSchemaName,
-        ensRainbowPublicConfig: mockEnsRainbowConfig,
         clientLabelSet: config.clientLabelSet,
         indexedChainIds: config.indexedChainIds,
         isSubgraphCompatible: config.isSubgraphCompatible,
@@ -145,23 +129,18 @@ describe("PublicConfigBuilder", () => {
 
     it("caches public config and returns cached version on subsequent calls", async () => {
       // Arrange
-      const ensRainbowClientMock = {
-        config: vi.fn().mockResolvedValue(mockEnsRainbowConfig),
-      } as unknown as EnsRainbow.ApiClient;
-
       setupStandardMocks();
       const mockPublicConfig = createMockPublicConfig();
       vi.mocked(validateEnsIndexerPublicConfig).mockReturnValue(mockPublicConfig);
 
-      const builder = new PublicConfigBuilder(ensRainbowClientMock);
+      const builder = new PublicConfigBuilder();
 
       // Act
-      const result1 = await builder.getPublicConfig();
-      const result2 = await builder.getPublicConfig();
-      const result3 = await builder.getPublicConfig();
+      const result1 = builder.getPublicConfig();
+      const result2 = builder.getPublicConfig();
+      const result3 = builder.getPublicConfig();
 
       // Assert
-      expect(ensRainbowClientMock.config).toHaveBeenCalledTimes(1);
       expect(getEnsIndexerVersion).toHaveBeenCalledTimes(1);
       expect(getPackageVersion).toHaveBeenCalledTimes(2);
       expect(validateEnsIndexerVersionInfo).toHaveBeenCalledTimes(1);
@@ -182,10 +161,6 @@ describe("PublicConfigBuilder", () => {
         indexedChainIds: new Set([1, 8453, 59144]),
       });
 
-      const ensRainbowClientMock = {
-        config: vi.fn().mockResolvedValue(mockEnsRainbowConfig),
-      } as unknown as EnsRainbow.ApiClient;
-
       vi.mocked(getEnsIndexerVersion).mockReturnValue("2.0.0");
       vi.mocked(getPackageVersion).mockReturnValue("1.0.0");
 
@@ -200,10 +175,10 @@ describe("PublicConfigBuilder", () => {
       vi.mocked(validateEnsIndexerVersionInfo).mockReturnValue(customVersionInfo);
       vi.mocked(validateEnsIndexerPublicConfig).mockReturnValue(customConfig);
 
-      const builder = new PublicConfigBuilder(ensRainbowClientMock);
+      const builder = new PublicConfigBuilder();
 
       // Act
-      const result = await builder.getPublicConfig();
+      const result = builder.getPublicConfig();
 
       // Assert
       expect(result).toBe(customConfig);
@@ -217,25 +192,13 @@ describe("PublicConfigBuilder", () => {
         clientLabelSet: { labelSetId: "custom", labelSetVersion: 1 },
       });
 
-      const customEnsRainbowConfig: EnsRainbowPublicConfig = {
-        serverLabelSet: { labelSetId: "custom", highestLabelSetVersion: 1 },
-        versionInfo: {
-          commit: "a26a979f06f52ef0e40e69da1052e190240db29b",
-          ensRainbow: "1.0.0",
-        },
-      };
-
-      const ensRainbowClientMock = {
-        config: vi.fn().mockResolvedValue(customEnsRainbowConfig),
-      } as unknown as EnsRainbow.ApiClient;
-
       setupStandardMocks();
       vi.mocked(validateEnsIndexerPublicConfig).mockReturnValue(customConfig);
 
-      const builder = new PublicConfigBuilder(ensRainbowClientMock);
+      const builder = new PublicConfigBuilder();
 
       // Act
-      const result = await builder.getPublicConfig();
+      const result = builder.getPublicConfig();
 
       // Assert
       expect(result).toBe(customConfig);
@@ -244,29 +207,8 @@ describe("PublicConfigBuilder", () => {
   });
 
   describe("getPublicConfig() - error handling", () => {
-    it("throws when ENSRainbow client config() fails", async () => {
-      // Arrange
-      const ensRainbowError = new Error("ENSRainbow service unavailable");
-      const ensRainbowClientMock = {
-        config: vi.fn().mockRejectedValue(ensRainbowError),
-      } as unknown as EnsRainbow.ApiClient;
-
-      setupStandardMocks();
-
-      const builder = new PublicConfigBuilder(ensRainbowClientMock);
-
-      // Act & Assert
-      await expect(builder.getPublicConfig()).rejects.toThrow(ensRainbowError);
-      expect(ensRainbowClientMock.config).toHaveBeenCalledTimes(1);
-      expect(validateEnsIndexerPublicConfig).not.toHaveBeenCalled();
-    });
-
     it("throws when version info validation fails", async () => {
       // Arrange
-      const ensRainbowClientMock = {
-        config: vi.fn().mockResolvedValue(mockEnsRainbowConfig),
-      } as unknown as EnsRainbow.ApiClient;
-
       setupStandardMocks();
 
       const validationError = new Error("Invalid version info: missing required fields");
@@ -274,19 +216,16 @@ describe("PublicConfigBuilder", () => {
         throw validationError;
       });
 
-      const builder = new PublicConfigBuilder(ensRainbowClientMock);
+      const builder = new PublicConfigBuilder();
 
       // Act & Assert
-      await expect(builder.getPublicConfig()).rejects.toThrow(validationError);
+      expect(() => builder.getPublicConfig()).toThrow(validationError);
       expect(validateEnsIndexerVersionInfo).toHaveBeenCalledTimes(1);
       expect(validateEnsIndexerPublicConfig).not.toHaveBeenCalled();
     });
 
     it("throws when public config validation fails", async () => {
       // Arrange
-      const ensRainbowClientMock = {
-        config: vi.fn().mockResolvedValue(mockEnsRainbowConfig),
-      } as unknown as EnsRainbow.ApiClient;
 
       setupStandardMocks();
 
@@ -295,10 +234,10 @@ describe("PublicConfigBuilder", () => {
         throw validationError;
       });
 
-      const builder = new PublicConfigBuilder(ensRainbowClientMock);
+      const builder = new PublicConfigBuilder();
 
       // Act & Assert
-      await expect(builder.getPublicConfig()).rejects.toThrow(validationError);
+      expect(() => builder.getPublicConfig()).toThrow(validationError);
       expect(validateEnsIndexerPublicConfig).toHaveBeenCalledTimes(1);
     });
   });
@@ -309,60 +248,25 @@ describe("PublicConfigBuilder", () => {
       const config1 = createMockPublicConfig({ ensIndexerSchemaName: "schema1" });
       const config2 = createMockPublicConfig({ ensIndexerSchemaName: "schema2" });
 
-      let callCount = 0;
-      const ensRainbowClientMock = {
-        config: vi.fn().mockImplementation(() => {
-          callCount++;
-          return Promise.resolve(mockEnsRainbowConfig);
-        }),
-      } as unknown as EnsRainbow.ApiClient;
-
       setupStandardMocks();
 
       // Return different configs for each builder instance
-      vi.mocked(validateEnsIndexerPublicConfig).mockImplementation(() => {
-        return callCount === 1 ? config1 : config2;
-      });
-
+      vi.mocked(validateEnsIndexerPublicConfig)
+        .mockImplementationOnce(() => config1)
+        .mockImplementationOnce(() => config2);
       // Act
-      const builder1 = new PublicConfigBuilder(ensRainbowClientMock);
-      const result1 = await builder1.getPublicConfig();
+      const builder1 = new PublicConfigBuilder();
+      const result1 = builder1.getPublicConfig();
 
-      const builder2 = new PublicConfigBuilder(ensRainbowClientMock);
-      const result2 = await builder2.getPublicConfig();
+      const builder2 = new PublicConfigBuilder();
+      const result2 = builder2.getPublicConfig();
 
       // Assert - each builder should have fetched and cached its own config independently
-      expect(ensRainbowClientMock.config).toHaveBeenCalledTimes(2);
       expect(result1).toBe(config1);
       expect(result2).toBe(config2);
       expect(result1).not.toBe(result2);
       expect(result1.ensIndexerSchemaName).toBe("schema1");
       expect(result2.ensIndexerSchemaName).toBe("schema2");
-    });
-
-    it("retries building config on subsequent calls after failure", async () => {
-      // Arrange
-      const ensRainbowClientMock = {
-        config: vi.fn().mockRejectedValueOnce(new Error("ENSRainbow down")),
-      } as unknown as EnsRainbow.ApiClient;
-
-      const builder = new PublicConfigBuilder(ensRainbowClientMock);
-
-      // Act & Assert - first call fails
-      await expect(builder.getPublicConfig()).rejects.toThrow("ENSRainbow down");
-
-      // Simulate recovery
-      vi.mocked(ensRainbowClientMock.config).mockResolvedValue(mockEnsRainbowConfig);
-      setupStandardMocks();
-      const mockPublicConfig = createMockPublicConfig();
-      vi.mocked(validateEnsIndexerPublicConfig).mockReturnValue(mockPublicConfig);
-
-      // Second call should succeed
-      const result = await builder.getPublicConfig();
-
-      // Assert
-      expect(ensRainbowClientMock.config).toHaveBeenCalledTimes(2);
-      expect(result).toBe(mockPublicConfig);
     });
   });
 });

--- a/apps/ensindexer/src/lib/public-config-builder/public-config-builder.test.ts
+++ b/apps/ensindexer/src/lib/public-config-builder/public-config-builder.test.ts
@@ -99,7 +99,7 @@ describe("PublicConfigBuilder", () => {
       const builder = new PublicConfigBuilder();
 
       // Act
-      const result = await builder.getPublicConfig();
+      const result = builder.getPublicConfig();
 
       // Assert
       expect(getEnsIndexerVersion).toHaveBeenCalledTimes(1);

--- a/apps/ensindexer/src/lib/public-config-builder/public-config-builder.ts
+++ b/apps/ensindexer/src/lib/public-config-builder/public-config-builder.ts
@@ -6,7 +6,6 @@ import {
   validateEnsIndexerPublicConfig,
   validateEnsIndexerVersionInfo,
 } from "@ensnode/ensnode-sdk";
-import type { EnsRainbow } from "@ensnode/ensrainbow-sdk";
 
 import {
   getEnsIndexerCommitRef,
@@ -16,27 +15,12 @@ import {
 
 export class PublicConfigBuilder {
   /**
-   * ENSRainbow Client
-   *
-   * Used to fetch ENSRainbow Public Config, which is part of
-   * the ENSIndexer Public Config.
-   */
-  private ensRainbowClient: EnsRainbow.ApiClient;
-
-  /**
    * Immutable ENSIndexer Public Config
    *
    * The cached ENSIndexer Public Config object, which is built and validated
    * on the first call to `getPublicConfig()`, and returned as-is on subsequent calls.
    */
   private immutablePublicConfig: EnsIndexerPublicConfig | undefined;
-
-  /**
-   * @param ensRainbowClient ENSRainbow Client instance used to fetch ENSRainbow Public Config
-   */
-  constructor(ensRainbowClient: EnsRainbow.ApiClient) {
-    this.ensRainbowClient = ensRainbowClient;
-  }
 
   /**
    * Get ENSIndexer Public Config
@@ -49,17 +33,12 @@ export class PublicConfigBuilder {
    * @throws if the built {@link EnsIndexerPublicConfig} does not conform to
    *         the expected schema
    */
-  async getPublicConfig(): Promise<EnsIndexerPublicConfig> {
+  getPublicConfig(): EnsIndexerPublicConfig {
     if (typeof this.immutablePublicConfig === "undefined") {
-      const [versionInfo, ensRainbowPublicConfig] = await Promise.all([
-        this.getEnsIndexerVersionInfo(),
-        // TODO: remove dependency on ENSRainbow by dropping `ensRainbowPublicConfig` from `EnsIndexerPublicConfig`.
-        this.ensRainbowClient.config(),
-      ]);
+      const versionInfo = this.getEnsIndexerVersionInfo();
 
       this.immutablePublicConfig = validateEnsIndexerPublicConfig({
         ensIndexerSchemaName: config.ensIndexerSchemaName,
-        ensRainbowPublicConfig,
         clientLabelSet: config.clientLabelSet,
         indexedChainIds: config.indexedChainIds,
         isSubgraphCompatible: config.isSubgraphCompatible,

--- a/apps/ensindexer/src/lib/public-config-builder/singleton.ts
+++ b/apps/ensindexer/src/lib/public-config-builder/singleton.ts
@@ -1,4 +1,3 @@
-import { ensRainbowClient } from "@/lib/ensrainbow/singleton";
 import { PublicConfigBuilder } from "@/lib/public-config-builder/public-config-builder";
 
-export const publicConfigBuilder = new PublicConfigBuilder(ensRainbowClient);
+export const publicConfigBuilder = new PublicConfigBuilder();

--- a/apps/ensindexer/src/lib/stack-info-builder/stack-info-builder.test.ts
+++ b/apps/ensindexer/src/lib/stack-info-builder/stack-info-builder.test.ts
@@ -73,7 +73,7 @@ function createMockPublicConfigBuilder(
   overrides: Partial<Pick<PublicConfigBuilder, "getPublicConfig">> = {},
 ): PublicConfigBuilder {
   return {
-    getPublicConfig: vi.fn().mockResolvedValue(mockEnsIndexerPublicConfig),
+    getPublicConfig: vi.fn().mockReturnValue(mockEnsIndexerPublicConfig),
     ...overrides,
   } as unknown as PublicConfigBuilder;
 }
@@ -169,7 +169,9 @@ describe("StackInfoBuilder", () => {
 
     it("propagates errors from public config builder", async () => {
       const publicConfigBuilder = createMockPublicConfigBuilder({
-        getPublicConfig: vi.fn().mockRejectedValue(new Error("Config retrieval failed")),
+        getPublicConfig: vi.fn().mockImplementation(() => {
+          throw new Error("Config retrieval failed");
+        }),
       });
 
       const builder = new StackInfoBuilder(

--- a/apps/ensindexer/src/lib/stack-info-builder/stack-info-builder.test.ts
+++ b/apps/ensindexer/src/lib/stack-info-builder/stack-info-builder.test.ts
@@ -27,10 +27,6 @@ const mockEnsDbPublicConfig = {
 
 const mockEnsIndexerPublicConfig = {
   ensIndexerSchemaName: "ensindexer_0",
-  ensRainbowPublicConfig: {
-    serverLabelSet: { labelSetId: "subgraph", highestLabelSetVersion: 0 },
-    versionInfo: { ensRainbow: "1.9.0" },
-  },
   clientLabelSet: { labelSetId: "subgraph", labelSetVersion: 0 },
   indexedChainIds: new Set([1]),
   isSubgraphCompatible: true,

--- a/apps/ensindexer/src/lib/stack-info-builder/stack-info-builder.ts
+++ b/apps/ensindexer/src/lib/stack-info-builder/stack-info-builder.ts
@@ -30,13 +30,12 @@ export class StackInfoBuilder {
    */
   async getStackInfo(): Promise<EnsIndexerStackInfo> {
     if (typeof this.immutableStackInfo === "undefined") {
-      const [ensDbPublicConfig, ensIndexerPublicConfig, ensRainbowPublicConfig] = await Promise.all(
-        [
-          this.ensDbClient.buildEnsDbPublicConfig(),
-          this.publicConfigBuilder.getPublicConfig(),
-          this.ensRainbowClient.config(),
-        ],
-      );
+      const [ensDbPublicConfig, ensRainbowPublicConfig] = await Promise.all([
+        this.ensDbClient.buildEnsDbPublicConfig(),
+        this.ensRainbowClient.config(),
+      ]);
+
+      const ensIndexerPublicConfig = this.publicConfigBuilder.getPublicConfig();
 
       this.immutableStackInfo = buildEnsIndexerStackInfo(
         ensDbPublicConfig,

--- a/docs/ensnode.io/ensapi-openapi.json
+++ b/docs/ensnode.io/ensapi-openapi.json
@@ -802,33 +802,6 @@
                           "type": "object",
                           "properties": {
                             "ensIndexerSchemaName": { "type": "string", "minLength": 1 },
-                            "ensRainbowPublicConfig": {
-                              "type": "object",
-                              "properties": {
-                                "serverLabelSet": {
-                                  "type": "object",
-                                  "properties": {
-                                    "labelSetId": {
-                                      "type": "string",
-                                      "minLength": 1,
-                                      "maxLength": 50,
-                                      "pattern": "^[a-z-]+$"
-                                    },
-                                    "highestLabelSetVersion": { "type": "integer", "minimum": 0 }
-                                  },
-                                  "required": ["labelSetId", "highestLabelSetVersion"]
-                                },
-                                "versionInfo": {
-                                  "type": "object",
-                                  "properties": {
-                                    "commit": { "type": "string", "minLength": 1 },
-                                    "ensRainbow": { "type": "string", "minLength": 1 }
-                                  },
-                                  "required": ["ensRainbow"]
-                                }
-                              },
-                              "required": ["serverLabelSet", "versionInfo"]
-                            },
                             "indexedChainIds": {
                               "type": "array",
                               "items": { "type": "integer", "exclusiveMinimum": 0 },
@@ -871,7 +844,6 @@
                           },
                           "required": [
                             "ensIndexerSchemaName",
-                            "ensRainbowPublicConfig",
                             "indexedChainIds",
                             "isSubgraphCompatible",
                             "clientLabelSet",
@@ -910,91 +882,6 @@
                         "ensApi": {
                           "type": "object",
                           "properties": {
-                            "ensIndexerPublicConfig": {
-                              "type": "object",
-                              "properties": {
-                                "ensIndexerSchemaName": { "type": "string", "minLength": 1 },
-                                "ensRainbowPublicConfig": {
-                                  "type": "object",
-                                  "properties": {
-                                    "serverLabelSet": {
-                                      "type": "object",
-                                      "properties": {
-                                        "labelSetId": {
-                                          "type": "string",
-                                          "minLength": 1,
-                                          "maxLength": 50,
-                                          "pattern": "^[a-z-]+$"
-                                        },
-                                        "highestLabelSetVersion": {
-                                          "type": "integer",
-                                          "minimum": 0
-                                        }
-                                      },
-                                      "required": ["labelSetId", "highestLabelSetVersion"]
-                                    },
-                                    "versionInfo": {
-                                      "type": "object",
-                                      "properties": {
-                                        "commit": { "type": "string", "minLength": 1 },
-                                        "ensRainbow": { "type": "string", "minLength": 1 }
-                                      },
-                                      "required": ["ensRainbow"]
-                                    }
-                                  },
-                                  "required": ["serverLabelSet", "versionInfo"]
-                                },
-                                "indexedChainIds": {
-                                  "type": "array",
-                                  "items": { "type": "integer", "exclusiveMinimum": 0 },
-                                  "minItems": 1
-                                },
-                                "isSubgraphCompatible": { "type": "boolean" },
-                                "clientLabelSet": {
-                                  "type": "object",
-                                  "properties": {
-                                    "labelSetId": {
-                                      "type": "string",
-                                      "minLength": 1,
-                                      "maxLength": 50,
-                                      "pattern": "^[a-z-]+$"
-                                    },
-                                    "labelSetVersion": { "type": ["number", "null"] }
-                                  },
-                                  "required": ["labelSetId", "labelSetVersion"]
-                                },
-                                "namespace": {
-                                  "type": "string",
-                                  "enum": ["mainnet", "sepolia", "sepolia-v2", "ens-test-env"]
-                                },
-                                "plugins": {
-                                  "type": "array",
-                                  "items": { "type": "string" },
-                                  "minItems": 1
-                                },
-                                "versionInfo": {
-                                  "type": "object",
-                                  "properties": {
-                                    "ponder": { "type": "string", "minLength": 1 },
-                                    "commit": { "type": "string", "minLength": 1 },
-                                    "ensDb": { "type": "string", "minLength": 1 },
-                                    "ensIndexer": { "type": "string", "minLength": 1 },
-                                    "ensNormalize": { "type": "string", "minLength": 1 }
-                                  },
-                                  "required": ["ponder", "ensDb", "ensIndexer", "ensNormalize"]
-                                }
-                              },
-                              "required": [
-                                "ensIndexerSchemaName",
-                                "ensRainbowPublicConfig",
-                                "indexedChainIds",
-                                "isSubgraphCompatible",
-                                "clientLabelSet",
-                                "namespace",
-                                "plugins",
-                                "versionInfo"
-                              ]
-                            },
                             "theGraphFallback": {
                               "oneOf": [
                                 {
@@ -1034,7 +921,7 @@
                               "required": ["ensApi", "ensNormalize"]
                             }
                           },
-                          "required": ["ensIndexerPublicConfig", "theGraphFallback", "versionInfo"]
+                          "required": ["theGraphFallback", "versionInfo"]
                         }
                       },
                       "required": ["ensDb", "ensIndexer", "ensRainbow", "ensApi"]

--- a/packages/ensdb-sdk/src/client/ensdb-client.mock.ts
+++ b/packages/ensdb-sdk/src/client/ensdb-client.mock.ts
@@ -25,15 +25,6 @@ export const ensIndexerSchemaName = "ensindexer_0";
 
 export const publicConfig = {
   ensIndexerSchemaName,
-  ensRainbowPublicConfig: {
-    serverLabelSet: {
-      labelSetId: "subgraph",
-      highestLabelSetVersion: 0,
-    },
-    versionInfo: {
-      ensRainbow: "0.32.0",
-    },
-  },
   clientLabelSet: {
     labelSetId: "subgraph",
     labelSetVersion: 0,

--- a/packages/ensnode-sdk/src/ensapi/config/conversions.test.ts
+++ b/packages/ensnode-sdk/src/ensapi/config/conversions.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vitest";
 
-import { ENSNamespaceIds } from "@ensnode/datasources";
-
-import { PluginName } from "../../ensindexer/config/types";
 import { deserializeEnsApiPublicConfig } from "./deserialize";
 import { serializeEnsApiPublicConfig } from "./serialize";
 import type { SerializedEnsApiPublicConfig } from "./serialized-types";
@@ -16,26 +13,6 @@ const MOCK_ENSAPI_PUBLIC_CONFIG = {
   theGraphFallback: {
     canFallback: false,
     reason: "no-api-key",
-  },
-  ensIndexerPublicConfig: {
-    namespace: ENSNamespaceIds.Mainnet,
-    ensIndexerSchemaName: "ensindexer_0",
-    ensRainbowPublicConfig: {
-      serverLabelSet: { labelSetId: "subgraph", highestLabelSetVersion: 0 },
-      versionInfo: {
-        ensRainbow: "0.36.0",
-      },
-    },
-    indexedChainIds: new Set([1]),
-    isSubgraphCompatible: false,
-    clientLabelSet: { labelSetId: "subgraph", labelSetVersion: 0 },
-    plugins: [PluginName.Subgraph],
-    versionInfo: {
-      ensDb: "0.36.0",
-      ensIndexer: "0.36.0",
-      ensNormalize: "1.1.1",
-      ponder: "0.5.0",
-    },
   },
 } satisfies EnsApiPublicConfig;
 
@@ -54,26 +31,6 @@ describe("ENSApi Config Serialization/Deserialization", () => {
         theGraphFallback: {
           canFallback: false,
           reason: "no-api-key",
-        },
-        ensIndexerPublicConfig: {
-          namespace: ENSNamespaceIds.Mainnet,
-          ensIndexerSchemaName: "ensindexer_0",
-          ensRainbowPublicConfig: {
-            serverLabelSet: { labelSetId: "subgraph", highestLabelSetVersion: 0 },
-            versionInfo: {
-              ensRainbow: "0.36.0",
-            },
-          },
-          indexedChainIds: [1],
-          isSubgraphCompatible: false,
-          clientLabelSet: { labelSetId: "subgraph", labelSetVersion: 0 },
-          plugins: [PluginName.Subgraph],
-          versionInfo: {
-            ensDb: "0.36.0",
-            ensIndexer: "0.36.0",
-            ensNormalize: "1.1.1",
-            ponder: "0.5.0",
-          },
         },
       } satisfies SerializedEnsApiPublicConfig);
     });

--- a/packages/ensnode-sdk/src/ensapi/config/deserialize.ts
+++ b/packages/ensnode-sdk/src/ensapi/config/deserialize.ts
@@ -1,6 +1,5 @@
 import { prettifyError } from "zod/v4";
 
-import { buildUnvalidatedEnsIndexerPublicConfig } from "../../ensindexer/config/deserialize";
 import type { Unvalidated } from "../../shared/types";
 import type { SerializedEnsApiPublicConfig } from "./serialized-types";
 import type { EnsApiPublicConfig } from "./types";
@@ -19,12 +18,7 @@ import {
 export function buildUnvalidatedEnsApiPublicConfig(
   serializedPublicConfig: SerializedEnsApiPublicConfig,
 ): Unvalidated<EnsApiPublicConfig> {
-  return {
-    ...serializedPublicConfig,
-    ensIndexerPublicConfig: buildUnvalidatedEnsIndexerPublicConfig(
-      serializedPublicConfig.ensIndexerPublicConfig,
-    ),
-  };
+  return serializedPublicConfig;
 }
 
 /**

--- a/packages/ensnode-sdk/src/ensapi/config/serialize.ts
+++ b/packages/ensnode-sdk/src/ensapi/config/serialize.ts
@@ -7,9 +7,7 @@ import type { EnsApiPublicConfig } from "./types";
 export function serializeEnsApiPublicConfig(
   config: EnsApiPublicConfig,
 ): SerializedEnsApiPublicConfig {
-  return {
-    ...config,
-  };
+  return config;
 }
 
 /**

--- a/packages/ensnode-sdk/src/ensapi/config/serialize.ts
+++ b/packages/ensnode-sdk/src/ensapi/config/serialize.ts
@@ -1,4 +1,3 @@
-import { serializeEnsIndexerPublicConfig } from "../../ensindexer/config/serialize";
 import type { SerializedEnsApiPublicConfig } from "./serialized-types";
 import type { EnsApiPublicConfig } from "./types";
 
@@ -8,13 +7,9 @@ import type { EnsApiPublicConfig } from "./types";
 export function serializeEnsApiPublicConfig(
   config: EnsApiPublicConfig,
 ): SerializedEnsApiPublicConfig {
-  const { ensIndexerPublicConfig, theGraphFallback, versionInfo } = config;
-
   return {
-    ensIndexerPublicConfig: serializeEnsIndexerPublicConfig(ensIndexerPublicConfig),
-    theGraphFallback,
-    versionInfo,
-  } satisfies SerializedEnsApiPublicConfig;
+    ...config,
+  };
 }
 
 /**

--- a/packages/ensnode-sdk/src/ensapi/config/serialized-types.ts
+++ b/packages/ensnode-sdk/src/ensapi/config/serialized-types.ts
@@ -1,16 +1,9 @@
-import type { SerializedEnsIndexerPublicConfig } from "../../ensindexer/config/serialized-types";
 import type { EnsApiPublicConfig } from "./types";
 
 /**
  * Serialized representation of {@link EnsApiPublicConfig}
  */
-export interface SerializedEnsApiPublicConfig
-  extends Omit<EnsApiPublicConfig, "ensIndexerPublicConfig"> {
-  /**
-   * Serialized representation of {@link EnsApiPublicConfig.ensIndexerPublicConfig}.
-   */
-  ensIndexerPublicConfig: SerializedEnsIndexerPublicConfig;
-}
+export type SerializedEnsApiPublicConfig = EnsApiPublicConfig;
 
 /**
  * Serialized representation of {@link EnsApiPublicConfig}

--- a/packages/ensnode-sdk/src/ensapi/config/types.ts
+++ b/packages/ensnode-sdk/src/ensapi/config/types.ts
@@ -1,4 +1,3 @@
-import type { EnsIndexerPublicConfig } from "../../ensindexer/config/types";
 import type { TheGraphCannotFallbackReason, TheGraphFallback } from "../../shared/config/thegraph";
 
 export type { TheGraphCannotFallbackReason, TheGraphFallback };
@@ -42,14 +41,6 @@ export interface EnsApiPublicConfig {
    * The Graph Fallback-related info.
    */
   theGraphFallback: TheGraphFallback;
-
-  /**
-   * Complete ENSIndexer public configuration
-   *
-   * Contains all ENSIndexer public configuration including
-   * namespace, plugins, version info, etc.
-   */
-  ensIndexerPublicConfig: EnsIndexerPublicConfig;
 
   /**
    * Version info about ENSApi.

--- a/packages/ensnode-sdk/src/ensapi/config/zod-schemas.ts
+++ b/packages/ensnode-sdk/src/ensapi/config/zod-schemas.ts
@@ -1,10 +1,6 @@
 import { z } from "zod/v4";
 
 import {
-  makeEnsIndexerPublicConfigSchema,
-  makeSerializedEnsIndexerPublicConfigSchema,
-} from "../../ensindexer/config/zod-schemas";
-import {
   TheGraphCannotFallbackReasonSchema,
   TheGraphFallbackSchema,
 } from "../../shared/config/thegraph";
@@ -28,7 +24,6 @@ export function makeEnsApiPublicConfigSchema(valueLabel?: string) {
 
   return z.object({
     theGraphFallback: TheGraphFallbackSchema,
-    ensIndexerPublicConfig: makeEnsIndexerPublicConfigSchema(`${label}.ensIndexerPublicConfig`),
     versionInfo: makeEnsApiVersionInfoSchema(`${label}.versionInfo`),
   });
 }
@@ -44,9 +39,6 @@ export function makeSerializedEnsApiPublicConfigSchema(valueLabel?: string) {
   const label = valueLabel ?? "ENSApiPublicConfig";
 
   return z.object({
-    ensIndexerPublicConfig: makeSerializedEnsIndexerPublicConfigSchema(
-      `${label}.ensIndexerPublicConfig`,
-    ),
     theGraphFallback: TheGraphFallbackSchema,
     versionInfo: makeEnsApiVersionInfoSchema(`${label}.versionInfo`),
   });

--- a/packages/ensnode-sdk/src/ensindexer/client.mock.ts
+++ b/packages/ensnode-sdk/src/ensindexer/client.mock.ts
@@ -14,15 +14,6 @@ export const configResponseMock = {
   },
   indexedChainIds: [1, 8453, 59144, 10, 42161, 534352],
   ensIndexerSchemaName: "alphaSchema0.31.0",
-  ensRainbowPublicConfig: {
-    serverLabelSet: {
-      labelSetId: "subgraph",
-      highestLabelSetVersion: 0,
-    },
-    versionInfo: {
-      ensRainbow: "0.31.0",
-    },
-  },
   isSubgraphCompatible: false,
   namespace: "mainnet",
   plugins: [

--- a/packages/ensnode-sdk/src/ensindexer/config/conversions.test.ts
+++ b/packages/ensnode-sdk/src/ensindexer/config/conversions.test.ts
@@ -11,12 +11,6 @@ describe("ENSIndexer: Config", () => {
       // arrange
       const config = {
         ensIndexerSchemaName: "ensindexer_0",
-        ensRainbowPublicConfig: {
-          serverLabelSet: { labelSetId: "subgraph", highestLabelSetVersion: 0 },
-          versionInfo: {
-            ensRainbow: "0.32.0",
-          },
-        },
         clientLabelSet: {
           labelSetId: "subgraph",
           labelSetVersion: 0,
@@ -54,12 +48,6 @@ describe("ENSIndexer: Config", () => {
   describe("deserialization", () => {
     const correctSerializedConfig = {
       ensIndexerSchemaName: "ensindexer_0",
-      ensRainbowPublicConfig: {
-        serverLabelSet: { labelSetId: "subgraph", highestLabelSetVersion: 0 },
-        versionInfo: {
-          ensRainbow: "0.32.0",
-        },
-      },
       clientLabelSet: {
         labelSetId: "subgraph",
         labelSetVersion: 0,

--- a/packages/ensnode-sdk/src/ensindexer/config/serialize.ts
+++ b/packages/ensnode-sdk/src/ensindexer/config/serialize.ts
@@ -21,7 +21,6 @@ export function serializeEnsIndexerPublicConfig(
 ): SerializedEnsIndexerPublicConfig {
   const {
     ensIndexerSchemaName,
-    ensRainbowPublicConfig,
     indexedChainIds,
     isSubgraphCompatible,
     clientLabelSet,
@@ -32,7 +31,6 @@ export function serializeEnsIndexerPublicConfig(
 
   return {
     ensIndexerSchemaName,
-    ensRainbowPublicConfig,
     indexedChainIds: serializeIndexedChainIds(indexedChainIds),
     isSubgraphCompatible,
     clientLabelSet,

--- a/packages/ensnode-sdk/src/ensindexer/config/types.ts
+++ b/packages/ensnode-sdk/src/ensindexer/config/types.ts
@@ -2,7 +2,7 @@ import type { ChainId } from "enssdk";
 
 import type { ENSNamespaceId } from "@ensnode/datasources";
 
-import type { EnsRainbowClientLabelSet, EnsRainbowPublicConfig } from "../../ensrainbow";
+import type { EnsRainbowClientLabelSet } from "../../ensrainbow";
 
 /**
  * A PluginName is a unique id for a 'plugin': we use the notion of
@@ -97,13 +97,6 @@ export interface EnsIndexerPublicConfig {
    *   identifier.
    */
   ensIndexerSchemaName: string;
-
-  /**
-   * ENSRainbow public config
-   *
-   * Represents the public config of the connected ENSRainbow instance.
-   */
-  ensRainbowPublicConfig: EnsRainbowPublicConfig;
 
   /**
    * A set of strings referring to the names of plugins that are active.

--- a/packages/ensnode-sdk/src/ensindexer/config/zod-schemas.test.ts
+++ b/packages/ensnode-sdk/src/ensindexer/config/zod-schemas.test.ts
@@ -138,68 +138,8 @@ describe("ENSIndexer: Config", () => {
         ).toContain("`ensDb` version must be same as `ensIndexer` version");
       });
 
-      it("validates ENSRainbow label set and version compatibility", () => {
-        const baseConfig = {
-          ensRainbowPublicConfig: {
-            serverLabelSet: {
-              labelSetId: "subgraph",
-              highestLabelSetVersion: 0,
-            },
-            versionInfo: {
-              ensRainbow: "0.32.0",
-            },
-          },
-          indexedChainIds: [1], // Use array for serialized config
-          isSubgraphCompatible: false, // Set to false to bypass isSubgraphCompatible invariant
-          namespace: "mainnet" as const,
-          plugins: [PluginName.Subgraph, PluginName.Registrars], // Multiple plugins allowed when not subgraph compatible
-          ensIndexerSchemaName: "ensindexer_0",
-          versionInfo: {
-            ponder: "0.11.25",
-            ensDb: "0.32.0",
-            ensIndexer: "0.32.0",
-            ensNormalize: "1.11.1",
-          },
-        };
-
-        // Test mismatched label set IDs
-        expect(
-          formatParseError(
-            makeEnsIndexerPublicConfigSchema().safeParse(
-              buildUnvalidatedEnsIndexerPublicConfig({
-                ...baseConfig,
-                clientLabelSet: { labelSetId: "custom-labels", labelSetVersion: 0 },
-              }),
-            ),
-          ),
-        ).toContain(
-          'Server label set ID "subgraph" does not match client\'s requested label set ID "custom-labels"',
-        );
-
-        // Test server version too low
-        expect(
-          formatParseError(
-            makeEnsIndexerPublicConfigSchema().safeParse(
-              buildUnvalidatedEnsIndexerPublicConfig({
-                ...baseConfig,
-                clientLabelSet: { labelSetId: "subgraph", labelSetVersion: 5 },
-              }),
-            ),
-          ),
-        ).toContain("Server highest label set version 0 is less than client's requested version 5");
-      });
-
       it("can parse full ENSIndexerPublicConfig with label set", () => {
         const validConfig = {
-          ensRainbowPublicConfig: {
-            serverLabelSet: {
-              labelSetId: "subgraph",
-              highestLabelSetVersion: 0,
-            },
-            versionInfo: {
-              ensRainbow: "0.32.0",
-            },
-          },
           clientLabelSet: {
             labelSetId: "subgraph",
             labelSetVersion: 0,

--- a/packages/ensnode-sdk/src/ensindexer/config/zod-schemas.ts
+++ b/packages/ensnode-sdk/src/ensindexer/config/zod-schemas.ts
@@ -9,7 +9,6 @@
 import { z } from "zod/v4";
 
 import {
-  makeEnsRainbowPublicConfigSchema,
   makeLabelSetIdSchema,
   makeLabelSetVersionStringSchema,
 } from "../../ensrainbow/zod-schemas/config";
@@ -17,7 +16,6 @@ import { uniq } from "../../shared/collections";
 import { makeChainIdSchema, makeENSNamespaceIdSchema } from "../../shared/zod-schemas";
 import type { ZodCheckFnInput } from "../../shared/zod-types";
 import { isSubgraphCompatible } from "./is-subgraph-compatible";
-import { validateSupportedLabelSetAndVersion } from "./labelset-utils";
 import type { EnsIndexerPublicConfig } from "./types";
 import { PluginName } from "./types";
 import { invariant_ensDbVersionIsSameAsEnsIndexerVersion } from "./validations";
@@ -135,25 +133,6 @@ export function invariant_isSubgraphCompatibleRequirements(
   }
 }
 
-export function invariant_ensRainbowSupportedLabelSetAndVersion(
-  ctx: ZodCheckFnInput<Pick<EnsIndexerPublicConfig, "clientLabelSet" | "ensRainbowPublicConfig">>,
-) {
-  const { clientLabelSet } = ctx.value;
-  const { serverLabelSet } = ctx.value.ensRainbowPublicConfig;
-
-  try {
-    validateSupportedLabelSetAndVersion(serverLabelSet, clientLabelSet);
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : "Unknown error";
-
-    ctx.issues.push({
-      code: "custom",
-      input: ctx.value,
-      message: `The ENSRainbow label set and version specified in the config are not supported by the ENSRainbow version specified in ensRainbowPublicConfig. Cause: ${errorMessage}`,
-    });
-  }
-}
-
 /**
  * ENSIndexer Public Config Schema
  *
@@ -164,9 +143,6 @@ export const makeEnsIndexerPublicConfigSchema = (valueLabel: string = "ENSIndexe
   z
     .object({
       ensIndexerSchemaName: makeEnsIndexerSchemaNameSchema(`${valueLabel}.ensIndexerSchemaName`),
-      ensRainbowPublicConfig: makeEnsRainbowPublicConfigSchema(
-        `${valueLabel}.ensRainbowPublicConfig`,
-      ),
       indexedChainIds: makeIndexedChainIdsSchema(`${valueLabel}.indexedChainIds`),
       isSubgraphCompatible: z.boolean({
         error: `${valueLabel}.isSubgraphCompatible must be a boolean value.`,
@@ -181,8 +157,7 @@ export const makeEnsIndexerPublicConfigSchema = (valueLabel: string = "ENSIndexe
      *
      * All required data validations must be performed below.
      */
-    .check(invariant_isSubgraphCompatibleRequirements)
-    .check(invariant_ensRainbowSupportedLabelSetAndVersion);
+    .check(invariant_isSubgraphCompatibleRequirements);
 
 /**
  * ENSIndexer Public Config Schema
@@ -196,9 +171,6 @@ export const makeSerializedEnsIndexerPublicConfigSchema = (
 ) =>
   z.object({
     ensIndexerSchemaName: makeEnsIndexerSchemaNameSchema(`${valueLabel}.ensIndexerSchemaName`),
-    ensRainbowPublicConfig: makeEnsRainbowPublicConfigSchema(
-      `${valueLabel}.ensRainbowPublicConfig`,
-    ),
     indexedChainIds: makeSerializedIndexedChainIdsSchema(`${valueLabel}.indexedChainIds`),
     isSubgraphCompatible: z.boolean({
       error: `${valueLabel}.isSubgraphCompatible must be a boolean value.`,

--- a/packages/ensnode-sdk/src/ensnode/client.test.ts
+++ b/packages/ensnode-sdk/src/ensnode/client.test.ts
@@ -69,36 +69,6 @@ const EXAMPLE_ENSAPI_CONFIG_RESPONSE = {
     canFallback: false,
     reason: "no-api-key",
   },
-  ensIndexerPublicConfig: {
-    ensRainbowPublicConfig: {
-      serverLabelSet: { labelSetId: "subgraph", highestLabelSetVersion: 0 },
-      versionInfo: {
-        ensRainbow: "1.9.0",
-      },
-    },
-    clientLabelSet: {
-      labelSetId: "subgraph",
-      labelSetVersion: 0,
-    },
-    indexedChainIds: [1, 8453, 59144, 10, 42161, 534352],
-    ensIndexerSchemaName: "alphaSchema1.9.0",
-    isSubgraphCompatible: false,
-    namespace: "mainnet",
-    plugins: [
-      PluginName.Subgraph,
-      PluginName.Basenames,
-      PluginName.Lineanames,
-      PluginName.ThreeDNS,
-      PluginName.ProtocolAcceleration,
-      PluginName.Registrars,
-    ],
-    versionInfo: {
-      ponder: "0.11.43",
-      ensDb: "1.9.0",
-      ensIndexer: "1.9.0",
-      ensNormalize: "1.11.1",
-    },
-  },
 } satisfies SerializedEnsApiPublicConfig;
 
 const EXAMPLE_ENSDB_PUBLIC_RESPONSE = {

--- a/packages/ensnode-sdk/src/ensnode/client.test.ts
+++ b/packages/ensnode-sdk/src/ensnode/client.test.ts
@@ -78,12 +78,6 @@ const EXAMPLE_ENSDB_PUBLIC_RESPONSE = {
 } satisfies SerializedEnsDbPublicConfig;
 
 const EXAMPLE_ENSINDEXER_PUBLIC_CONFIG = {
-  ensRainbowPublicConfig: {
-    serverLabelSet: { labelSetId: "subgraph", highestLabelSetVersion: 0 },
-    versionInfo: {
-      ensRainbow: "1.9.0",
-    },
-  },
   clientLabelSet: {
     labelSetId: "subgraph",
     labelSetVersion: 0,

--- a/packages/ensnode-sdk/src/ensnode/metadata/indexing-metadata-context.test.ts
+++ b/packages/ensnode-sdk/src/ensnode/metadata/indexing-metadata-context.test.ts
@@ -46,10 +46,6 @@ function makeMinimalStackInfo() {
       namespace: "mainnet",
       clientLabelSet: { labelSetId: "subgraph", labelSetVersion: 0 },
       ensIndexerSchemaName: "test_schema",
-      ensRainbowPublicConfig: {
-        serverLabelSet: { labelSetId: "subgraph", highestLabelSetVersion: 0 },
-        versionInfo: { ensRainbow: "1.0.0" },
-      },
       indexedChainIds: new Set([1]),
       isSubgraphCompatible: true,
       plugins: ["subgraph"],


### PR DESCRIPTION
# Lite PR

[Tip: Review docs on the ENSNode PR process](https://ensnode.io/docs/contributing/prs)

## Summary

- ENSNode SDK
  - Dropped `ensIndexerPublicConfig` field from `EnsApiPublicConfig` data model.
  - Dropped `ensRainbowPublicConfig` field from `EnsIndexerPublicConfig` data model.
- Updated the Indexing Status API response (now, the `EnsNodeStackInfo` data model does not include fields that were dropped from ENSNode SDK).

---

## Why

- Resolves #1970

---

## Testing

- Ran static code checks, and testing suite.
- Ran ENSNode locally to confirm all apps work well despite breaking changes in the data model.

---

## Notes for Reviewer (Optional)

- This is a breaking change so older clients won't be able to parse the Indexing Status API response due to missing fields. Please make sure to update all clients as otherwise they will not be able to parse the stack info object properly.

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)
