### PR TITLE
Fix indexing invariants logic

### DIFF
--- a/.changeset/modern-groups-occur.md
+++ b/.changeset/modern-groups-occur.md
@@ -1,0 +1,5 @@
+---
+"@ensnode/ensnode-sdk": patch
+---
+
+Aligned `isRegistrationFullyExpired` and `isRegistrationInGracePeriod` helpers with onchain logic.

--- a/.changeset/two-corners-tease.md
+++ b/.changeset/two-corners-tease.md
@@ -1,0 +1,5 @@
+---
+"ensindexer": patch
+---
+
+Updated ENSv2Registry handling for non-expiring reverse-name registrations.

--- a/apps/ensindexer/src/plugins/unigraph/handlers/ensv2/ENSv2Registry.ts
+++ b/apps/ensindexer/src/plugins/unigraph/handlers/ensv2/ENSv2Registry.ts
@@ -110,7 +110,7 @@ export default function () {
       // reverse name registrations and allow a new Registration record to be
       // created for the same label.
       // For a reverse name registration, the registrant ID value is
-      // guaranteed to end with the label value.
+      // guaranteed to match the label value.
       const isReverseNameRegistration = registration.registrantId === `0x${label}`;
 
       // Invariant: if this is a Registration, unless it is a Reservation or a reverse name Registration, it should be fully expired

--- a/apps/ensindexer/src/plugins/unigraph/handlers/ensv2/ENSv2Registry.ts
+++ b/apps/ensindexer/src/plugins/unigraph/handlers/ensv2/ENSv2Registry.ts
@@ -110,7 +110,7 @@ export default function () {
       // never expire. Therefore, we need to skip the expiration check for
       // reverse name registrations and allow a new Registration record to be
       // created for the same label.
-      // For a reverse name registration, the label matches the registrant ID.
+      // For a reverse name registration, the registrant ID is the label with `0x` prefix.
       const maybeReverseNameLabel = `0x${label}`;
       const isReverseNameRegistration =
         isNormalizedAddress(maybeReverseNameLabel) &&

--- a/apps/ensindexer/src/plugins/unigraph/handlers/ensv2/ENSv2Registry.ts
+++ b/apps/ensindexer/src/plugins/unigraph/handlers/ensv2/ENSv2Registry.ts
@@ -1,6 +1,7 @@
 import {
   type AccountId,
   asLiteralLabel,
+  isNormalizedAddress,
   type LabelHash,
   labelhashLiteralLabel,
   makeENSv2DomainId,
@@ -109,9 +110,11 @@ export default function () {
       // never expire. Therefore, we need to skip the expiration check for
       // reverse name registrations and allow a new Registration record to be
       // created for the same label.
-      // For a reverse name registration, the registrant ID value is
-      // guaranteed to match the label value.
-      const isReverseNameRegistration = registration.registrantId === `0x${label}`;
+      // For a reverse name registration, the label matches the registrant ID.
+      const maybeReverseNameLabel = `0x${label}`;
+      const isReverseNameRegistration =
+        isNormalizedAddress(maybeReverseNameLabel) &&
+        registration.registrantId === maybeReverseNameLabel;
 
       // Invariant: if this is a Registration, unless it is a Reservation or a reverse name Registration, it should be fully expired
       if (

--- a/apps/ensindexer/src/plugins/unigraph/handlers/ensv2/ENSv2Registry.ts
+++ b/apps/ensindexer/src/plugins/unigraph/handlers/ensv2/ENSv2Registry.ts
@@ -103,10 +103,19 @@ export default function () {
           `Invariant(ENSv2Registry:Label[Registered|Reserved]): Existing unexpired Registration found, expected none or expired.\n${toJson(registration, { pretty: true })}`,
         );
       }
-    } else {
-      // Invariant: if this is a Registration, unless it is a Reservation, it should be fully expired
+    } else if (registration) {
+      // There's an existing Registration record, so we need to handle it carefully.
+      // Registrations for reverse names are a special case, since they can
+      // never expire. Therefore, we need to skip the expiration check for
+      // reverse name registrations and allow a new Registration record to be
+      // created for the same label.
+      // For a reverse name registration, the registrant ID value is
+      // guaranteed to end with the label value.
+      const isReverseNameRegistration = registration.registrantId === `0x${label}`;
+
+      // Invariant: if this is a Registration, unless it is a Reservation or a reverse name Registration, it should be fully expired
       if (
-        registration &&
+        !isReverseNameRegistration &&
         registration.type !== "ENSv2RegistryReservation" &&
         !isRegistrationFullyExpired(registration, event.block.timestamp)
       ) {

--- a/packages/ensnode-sdk/src/registrars/registration-expiration.test.ts
+++ b/packages/ensnode-sdk/src/registrars/registration-expiration.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isRegistrationExpired,
+  isRegistrationFullyExpired,
+  isRegistrationInGracePeriod,
+} from "./registration-expiration";
+
+describe("registration expiration", () => {
+  const expiry = 1000n;
+  const gracePeriod = 100n;
+
+  describe("isRegistrationExpired", () => {
+    it.each([
+      { now: 999n, expected: false, description: "before expiry" },
+      { now: 1000n, expected: true, description: "at expiry" },
+      { now: 1001n, expected: true, description: "after expiry" },
+    ])("returns $expected when $description", ({ now, expected }) => {
+      expect(isRegistrationExpired({ expiry, gracePeriod }, now)).toBe(expected);
+    });
+
+    it("returns false when expiry is null", () => {
+      expect(isRegistrationExpired({ expiry: null, gracePeriod }, 2000n)).toBe(false);
+    });
+  });
+
+  describe("isRegistrationFullyExpired", () => {
+    it.each([
+      { now: 999n, expected: false, description: "before expiry" },
+      { now: 1000n, expected: false, description: "at expiry" },
+      { now: 1050n, expected: false, description: "during grace period" },
+      { now: 1100n, expected: false, description: "at expiry + grace period" },
+      { now: 1101n, expected: true, description: "after expiry + grace period" },
+    ])("returns $expected when $description", ({ now, expected }) => {
+      expect(isRegistrationFullyExpired({ expiry, gracePeriod }, now)).toBe(expected);
+    });
+
+    it("returns false when expiry is null", () => {
+      expect(isRegistrationFullyExpired({ expiry: null, gracePeriod }, 2000n)).toBe(false);
+    });
+
+    it("treats null grace period as zero", () => {
+      expect(isRegistrationFullyExpired({ expiry, gracePeriod: null }, 1000n)).toBe(false);
+      expect(isRegistrationFullyExpired({ expiry, gracePeriod: null }, 1001n)).toBe(true);
+    });
+  });
+
+  describe("isRegistrationInGracePeriod", () => {
+    it.each([
+      { now: 999n, expected: false, description: "before expiry" },
+      { now: 1000n, expected: true, description: "at expiry" },
+      { now: 1050n, expected: true, description: "during grace period" },
+      { now: 1100n, expected: true, description: "at expiry + grace period" },
+      { now: 1101n, expected: false, description: "after expiry + grace period" },
+    ])("returns $expected when $description", ({ now, expected }) => {
+      expect(isRegistrationInGracePeriod({ expiry, gracePeriod }, now)).toBe(expected);
+    });
+
+    it("returns false when expiry is null", () => {
+      expect(isRegistrationInGracePeriod({ expiry: null, gracePeriod }, 1050n)).toBe(false);
+    });
+
+    it("returns false when grace period is null", () => {
+      expect(isRegistrationInGracePeriod({ expiry, gracePeriod: null }, 1050n)).toBe(false);
+    });
+  });
+});

--- a/packages/ensnode-sdk/src/registrars/registration-expiration.ts
+++ b/packages/ensnode-sdk/src/registrars/registration-expiration.ts
@@ -23,8 +23,8 @@ export function isRegistrationFullyExpired(info: RegistrationExpiryInfo, now: bi
   // no expiry, never expired
   if (info.expiry == null) return false;
 
-  // otherwise it is expired if now >= expiry + grace
-  return now >= info.expiry + (info.gracePeriod ?? 0n);
+  // otherwise it is expired if now > expiry + grace
+  return now > info.expiry + (info.gracePeriod ?? 0n);
 }
 
 /**
@@ -34,5 +34,5 @@ export function isRegistrationInGracePeriod(info: RegistrationExpiryInfo, now: b
   if (info.expiry == null) return false;
   if (info.gracePeriod == null) return false;
 
-  return info.expiry <= now && info.expiry + info.gracePeriod > now;
+  return info.expiry <= now && info.expiry + info.gracePeriod >= now;
 }


### PR DESCRIPTION
# Lite PR

[Tip: Review docs on the ENSNode PR process](https://ensnode.io/docs/contributing/prs)

## Summary

- Updated `isRegistrationFullyExpired` and `isRegistrationInGracePeriod` helpers to accurately represent the logic implemented on chain: _the very last second of grace period is still a valid moment to renew a registration_.
- Updated `handleRegistrationOrReservation` event handler to accurately represent the logic implemented onchain: _the `LabelRegistered` event can be emitted multiple times for an existing registration of a reverse name. Such registrations never expire._

---

## Why

- _ENSIndexer Alpha_ and _ENSIndexer V2 Sepolia_ could not continue indexing due to indexing logic mismatch with onchain logic. 
---

## Testing

- Updated unit tests, and executed them successfully.
- Tested updates in the green env (used docker images from a preview release).

---

## Notes for Reviewer (Optional)

- [Details about invariant logic update for ENSIndexer Alpha](https://namehash.slack.com/archives/C086Z6FNBHN/p1783581255786209?thread_ts=1783575873.152759&cid=C086Z6FNBHN)
- [Details about invariant logic update for ENSIndexer V2 Sepolia](https://namehash.slack.com/archives/C086Z6FNBHN/p1783709755120459?thread_ts=1783669420.863369&cid=C086Z6FNBHN)

---

## Pre-Review Checklist (Blocking)

- [x] This PR does not introduce significant changes and is low-risk to review quickly.
- [x] Relevant changesets are included (or are not required)
